### PR TITLE
Add EIP-5792 wallet exports for MOSS and MetaMask

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -10,16 +10,21 @@ availability status for partner UIs. The client is patch-bumped to
 
 ## EIP-5792 transaction export
 
-Current session goal: **IMPLEMENTED AND LOCALLY VERIFIED 2026-08-23** — add a
-wallet-neutral, read-only `aomi tx export <id>...` command to
-`@aomi-labs/client@0.6.1`. The command refreshes authoritative staged EVM calls,
-validates one sender and chain, and emits only an EIP-5792 `wallet_sendCalls`
-version `2.0.0` parameter object without signing, broadcasting, fee injection,
-or backend completion. The full 1,563-test repository suite, repository lint,
-root typecheck, client build, CLI help, and npm package dry run pass. MegaETH
-MOSS CLI v0.1.6 accepts the exported `.calls` shape through normalization and
-reaches wallet-profile loading; a live relay submission requires user wallet
-login and delegated-key approval.
+Current session goal: **EXPANDED AND LOCALLY VERIFIED 2026-08-24** — ship the
+wallet-neutral, read-only `aomi tx export <id>...` command in
+`@aomi-labs/client@0.6.2` with explicit `eip5792`, `moss`, and `metamask`
+formats. EIP-5792 `wallet_sendCalls` version `2.0.0` remains the canonical and
+default representation; MOSS emits the ordered call array, while MetaMask emits
+the decimal chain argument and one raw transaction payload expected by Agent
+Wallet. The MetaMask adapter rejects multiple calls instead of silently losing
+batch or atomic semantics. The command still refreshes authoritative staged EVM
+calls, validates one sender and chain, and never signs, broadcasts, injects the
+execution-time service fee, or reports backend completion. The full 1,574-test
+repository suite, repository lint, root typecheck, client build, CLI help, and
+npm package dry run pass. MegaETH MOSS CLI v0.1.6 accepts the exported call
+shape through normalization and reaches wallet-profile loading; live MOSS or
+MetaMask submission still requires the user's external wallet authentication
+and approvals.
 
 ## Chain logo refresh
 

--- a/GOAL.md
+++ b/GOAL.md
@@ -8,6 +8,19 @@ configured `application_id`, and normalize the backend's explicit artifact
 availability status for partner UIs. The client is patch-bumped to
 `@aomi-labs/client@0.6.1`; publishing is intentionally outside this PR.
 
+## EIP-5792 transaction export
+
+Current session goal: **IMPLEMENTED AND LOCALLY VERIFIED 2026-08-23** — add a
+wallet-neutral, read-only `aomi tx export <id>...` command to
+`@aomi-labs/client@0.6.1`. The command refreshes authoritative staged EVM calls,
+validates one sender and chain, and emits only an EIP-5792 `wallet_sendCalls`
+version `2.0.0` parameter object without signing, broadcasting, fee injection,
+or backend completion. The full 1,563-test repository suite, repository lint,
+root typecheck, client build, CLI help, and npm package dry run pass. MegaETH
+MOSS CLI v0.1.6 accepts the exported `.calls` shape through normalization and
+reaches wallet-profile loading; a live relay submission requires user wallet
+login and delegated-key approval.
+
 ## Chain logo refresh
 
 Current session goal: **IMPLEMENTED AND LOCALLY VERIFIED 2026-08-21** — add

--- a/docs/topics/client-runtime/facts/cli.md
+++ b/docs/topics/client-runtime/facts/cli.md
@@ -25,6 +25,8 @@ The `aomi` terminal client is published from `@aomi-labs/client` and shares its 
 ## Command Surface
 
 - The CLI supports chat, transaction, session, model, app, chain, wallet, config, and secret commands.
+- Transaction commands include `tx list`, `tx simulate <id>...`, `tx export <id>...`, and `tx sign <id>...`.
+- `tx export` refreshes authoritative pending state and emits only an EIP-5792 `wallet_sendCalls` version `2.0.0` parameter object to stdout. It accepts EVM transaction calls on one sender and chain; it never signs, broadcasts, injects the execution-time service-fee call, or reports completion to the backend.
 - Interactive mode exposes slash-style helpers such as `/app`, `/model`, and `/key`.
 - The root help path is intentionally explicit about backend URL, API key, app, model, chain, and wallet options.
 

--- a/docs/topics/client-runtime/facts/cli.md
+++ b/docs/topics/client-runtime/facts/cli.md
@@ -26,7 +26,7 @@ The `aomi` terminal client is published from `@aomi-labs/client` and shares its 
 
 - The CLI supports chat, transaction, session, model, app, chain, wallet, config, and secret commands.
 - Transaction commands include `tx list`, `tx simulate <id>...`, `tx export <id>...`, and `tx sign <id>...`.
-- `tx export` refreshes authoritative pending state and emits only an EIP-5792 `wallet_sendCalls` version `2.0.0` parameter object to stdout. It accepts EVM transaction calls on one sender and chain; it never signs, broadcasts, injects the execution-time service-fee call, or reports completion to the backend.
+- `tx export` refreshes authoritative pending state and emits a wallet handoff artifact to stdout. The default `eip5792` format is the full EIP-5792 `wallet_sendCalls` version `2.0.0` parameter object; `moss` emits its ordered call array, and `metamask` emits a decimal chain ID plus exactly one raw transaction payload. It accepts EVM transaction calls on one sender and chain; it never signs, broadcasts, injects the execution-time service-fee call, or reports completion to the backend.
 - Interactive mode exposes slash-style helpers such as `/app`, `/model`, and `/key`.
 - The root help path is intentionally explicit about backend URL, API key, app, model, chain, and wallet options.
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -138,6 +138,8 @@ npx @aomi-labs/client secret list                        # list configured secre
 npx @aomi-labs/client secret add ALCHEMY_API_KEY=...     # ingest a secret for the active session
 npx @aomi-labs/client session log                        # show full conversation history
 npx @aomi-labs/client tx list                            # list pending + signed txs
+npx @aomi-labs/client tx simulate tx-1                   # simulate pending calls
+npx @aomi-labs/client tx export tx-1 > execution.json    # export EIP-5792 calls
 npx @aomi-labs/client tx sign tx-1                       # sign a specific pending tx
 npx @aomi-labs/client session status                     # session info
 npx @aomi-labs/client session events                     # system events
@@ -284,6 +286,11 @@ $ npx @aomi-labs/client tx list
 Pending (1):
   ⏳ tx-1  to: 0x3fC9...7FAD  value: 1000000000000000000  chain: 1
 
+$ npx @aomi-labs/client tx simulate tx-1
+All steps passed.
+
+$ npx @aomi-labs/client tx export tx-1 > execution.json
+
 $ npx @aomi-labs/client tx sign tx-1 --private-key 0xac0974...
 Signer:  0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 IDs:     tx-1
@@ -299,6 +306,32 @@ $ npx @aomi-labs/client tx list
 Signed (1):
   ✅ tx-1  hash: 0xabc123...  to: 0x3fC9...7FAD  value: 1000000000000000000
 ```
+
+`aomi tx export <id>...` refreshes the backend's authoritative pending state
+and writes an EIP-5792 `wallet_sendCalls` version `2.0.0` parameter object to
+stdout. It requires no private key, preserves the selected call order, and
+fails if the calls do not share one sender and chain. Redirect stdout to keep
+the wallet handoff artifact separate from diagnostics:
+
+```bash
+aomi tx export evm:tx-1 evm:tx-2 > execution.json
+```
+
+The exported object contains canonical hexadecimal `chainId` and `value`
+quantities, `atomicRequired: false`, and `to`/`data`/`value` call tuples. The
+command does not sign, broadcast, append the local signer's execution-time Aomi
+service-fee call, notify the backend, or remove pending requests. Simulate the
+same ordered selection before handing it to an external wallet.
+
+MegaETH MOSS consumes the call array inside the standard parameter object:
+
+```bash
+jq '.calls' execution.json > moss-calls.json
+mega moss execute --calls moss-calls.json --network mainnet --json
+```
+
+MOSS still requires its own wallet login and an approved delegated key whose
+call and spend permissions cover every exported call.
 
 **EIP-712 signing** is also supported. When the backend requests a typed data
 signature (e.g. for CoW Protocol orders or permit approvals), it shows up as a

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -139,7 +139,9 @@ npx @aomi-labs/client secret add ALCHEMY_API_KEY=...     # ingest a secret for t
 npx @aomi-labs/client session log                        # show full conversation history
 npx @aomi-labs/client tx list                            # list pending + signed txs
 npx @aomi-labs/client tx simulate tx-1                   # simulate pending calls
-npx @aomi-labs/client tx export tx-1 > execution.json    # export EIP-5792 calls
+npx @aomi-labs/client tx export tx-1 > execution.json    # canonical EIP-5792
+npx @aomi-labs/client tx export tx-1 --format moss       # MOSS call array
+npx @aomi-labs/client tx export tx-1 --format metamask   # MetaMask handoff
 npx @aomi-labs/client tx sign tx-1                       # sign a specific pending tx
 npx @aomi-labs/client session status                     # session info
 npx @aomi-labs/client session events                     # system events
@@ -308,30 +310,68 @@ Signed (1):
 ```
 
 `aomi tx export <id>...` refreshes the backend's authoritative pending state
-and writes an EIP-5792 `wallet_sendCalls` version `2.0.0` parameter object to
-stdout. It requires no private key, preserves the selected call order, and
-fails if the calls do not share one sender and chain. Redirect stdout to keep
-the wallet handoff artifact separate from diagnostics:
+and writes a wallet handoff artifact to stdout. It requires no private key,
+preserves the selected call order, and fails if the calls do not share one
+sender and chain. Redirect stdout to keep the artifact separate from
+diagnostics:
 
 ```bash
 aomi tx export evm:tx-1 evm:tx-2 > execution.json
 ```
 
-The exported object contains canonical hexadecimal `chainId` and `value`
-quantities, `atomicRequired: false`, and `to`/`data`/`value` call tuples. The
-command does not sign, broadcast, append the local signer's execution-time Aomi
-service-fee call, notify the backend, or remove pending requests. Simulate the
-same ordered selection before handing it to an external wallet.
+The default `eip5792` format is the canonical export. It contains an EIP-5792
+`wallet_sendCalls` version `2.0.0` parameter object with hexadecimal `chainId`
+and `value` quantities, `atomicRequired: false`, and `to`/`data`/`value` call
+tuples. `moss` and `metamask` are small adapters over that representation:
 
-MegaETH MOSS consumes the call array inside the standard parameter object:
+| Format     | Output                                               | Batch behavior            |
+| ---------- | ---------------------------------------------------- | ------------------------- |
+| `eip5792`  | Full `wallet_sendCalls` parameter object             | Preserves all calls       |
+| `moss`     | Ordered call array                                   | Preserves all calls       |
+| `metamask` | Numeric `chainId` plus one raw transaction `payload` | Requires exactly one call |
+
+The command does not sign, broadcast, append the local signer's execution-time
+Aomi service-fee call, notify the backend, or remove pending requests. Simulate
+the same ordered selection before handing it to an external wallet.
+
+MegaETH MOSS consumes the call array directly:
 
 ```bash
-jq '.calls' execution.json > moss-calls.json
+aomi tx export evm:tx-1 evm:tx-2 --format moss > moss-calls.json
 mega moss execute --calls moss-calls.json --network mainnet --json
 ```
 
 MOSS still requires its own wallet login and an approved delegated key whose
 call and spend permissions cover every exported call.
+
+MetaMask browser and mobile wallets consume the default EIP-5792 object through
+an EIP-1193 provider. Check `wallet_getCapabilities` for the selected account
+and chain before requesting execution:
+
+```ts
+const execution = JSON.parse(await readFile("execution.json", "utf8"));
+await provider.request({
+  method: "wallet_sendCalls",
+  params: [execution],
+});
+```
+
+MetaMask Agent Wallet currently exposes one raw EVM transaction at a time. The
+`metamask` format keeps its required decimal chain argument beside the
+hexadecimal transaction payload:
+
+```bash
+aomi tx export evm:tx-1 --format metamask > metamask.json
+mm wallet send-transaction \
+  --chain-id "$(jq -r '.chainId' metamask.json)" \
+  --payload "$(jq -c '.payload' metamask.json)" \
+  --wait
+```
+
+The `metamask` format rejects multiple calls instead of turning a batch into
+unrelated sequential transactions. Use the default `eip5792` format for native
+MetaMask batch execution when the connected account advertises that
+capability.
 
 **EIP-712 signing** is also supported. When the backend requests a typed data
 signature (e.g. for CoW Protocol orders or permit approvals), it shows up as a

--- a/packages/client/dist/cli.js
+++ b/packages/client/dist/cli.js
@@ -4146,10 +4146,12 @@ function pendingTxsFromBackendUserState(userState, existingPendingTxs = []) {
       continue;
     }
     const data = normalizePendingTxData(tx);
+    const from = normalizeMaybeAddress(tx.from);
     nextPendingTxs.push({
       id,
       kind: "transaction",
       txId: pendingId,
+      from,
       to,
       value: parseOptionalString(tx.value),
       data,
@@ -4159,6 +4161,7 @@ function pendingTxsFromBackendUserState(userState, existingPendingTxs = []) {
       payload: {
         pending_tx_id: pendingId,
         txId: pendingId,
+        from,
         to,
         value: parseOptionalString(tx.value),
         data,
@@ -7963,6 +7966,198 @@ var init_simulate = __esm({
   }
 });
 
+// src/cli/eip5792.ts
+import { getAddress as getAddress4, toHex } from "viem";
+function normalizeAddress3(value, field) {
+  try {
+    return getAddress4(value);
+  } catch (e) {
+    throw new Error(`${field} must be a valid EVM address.`);
+  }
+}
+function normalizeChainId(value) {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error("chainId must be a positive safe integer.");
+  }
+  return value;
+}
+function normalizeData(value, index) {
+  const data = value != null ? value : "0x";
+  if (!/^0x(?:[0-9a-fA-F]{2})*$/.test(data)) {
+    throw new Error(`Call ${index + 1} data must be a hex byte string.`);
+  }
+  return data.toLowerCase();
+}
+function toEip5792SendCallsParams(input2) {
+  const chainId3 = normalizeChainId(input2.chainId);
+  if (input2.calls.length === 0) {
+    throw new Error("At least one EVM call is required.");
+  }
+  return {
+    version: "2.0.0",
+    from: normalizeAddress3(input2.from, "from"),
+    chainId: toHex(chainId3),
+    atomicRequired: false,
+    calls: input2.calls.map((call, index) => {
+      if (call.chainId !== chainId3) {
+        throw new Error("All calls must use the exported chainId.");
+      }
+      if (call.value < BigInt(0)) {
+        throw new Error(`Call ${index + 1} value cannot be negative.`);
+      }
+      return {
+        to: normalizeAddress3(call.to, `Call ${index + 1} to`),
+        data: normalizeData(call.data, index),
+        value: toHex(call.value)
+      };
+    })
+  };
+}
+var init_eip5792 = __esm({
+  "src/cli/eip5792.ts"() {
+    "use strict";
+  }
+});
+
+// src/cli/commands/export.ts
+var export_exports = {};
+__export(export_exports, {
+  exportCommand: () => exportCommand
+});
+import { getAddress as getAddress5 } from "viem";
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+function normalizeSender(value, label) {
+  try {
+    return getAddress5(value);
+  } catch (e) {
+    throw new Error(`${label} is not a valid EVM address.`);
+  }
+}
+function resolvePendingEvmTransactions(cli, selectors) {
+  const pending = selectors.map((selector) => {
+    const evm = cli.findPendingTx(selector);
+    const svm = cli.findPendingSolTx(selector);
+    if (!selector.includes(":") && evm && svm) {
+      throw new Error(
+        `Transaction "${selector}" is ambiguous. Use the chain-qualified selector shown by \`aomi tx list\`.`
+      );
+    }
+    if (!evm && svm) {
+      throw new Error(
+        `Transaction "${selector}" is a Solana request; EIP-5792 export supports pending EVM transactions only.`
+      );
+    }
+    if (!evm) {
+      const available = cli.pendingSelectors().join(", ") || "(none)";
+      throw new Error(
+        `Transaction "${selector}" not found.
+Available: ${available}`
+      );
+    }
+    if (evm.kind !== "transaction") {
+      throw new Error(
+        `Transaction "${selector}" is an EVM signing request; EIP-5792 export supports transaction calls only.`
+      );
+    }
+    return evm;
+  });
+  if (new Set(pending.map((tx) => tx.id)).size !== pending.length) {
+    throw new Error(
+      "Duplicate transaction IDs are not allowed in a single `aomi tx export` call."
+    );
+  }
+  return pending;
+}
+function resolveSender(pending, sessionSender) {
+  const normalizedSessionSender = sessionSender ? normalizeSender(sessionSender, "The active session sender") : void 0;
+  const senders = pending.map((tx) => {
+    const stagedSender = tx.from ? normalizeSender(tx.from, `Transaction "${tx.id}" sender`) : void 0;
+    if (stagedSender && normalizedSessionSender && stagedSender.toLowerCase() !== normalizedSessionSender.toLowerCase()) {
+      throw new Error(
+        `Transaction "${tx.id}" sender ${stagedSender} does not match the active session sender ${normalizedSessionSender}.`
+      );
+    }
+    const sender = stagedSender != null ? stagedSender : normalizedSessionSender;
+    if (!sender) {
+      throw new Error(
+        `Transaction "${tx.id}" has no sender and the active session has no EVM address.`
+      );
+    }
+    return sender;
+  });
+  if (new Set(senders.map((sender) => sender.toLowerCase())).size !== 1) {
+    throw new Error("Selected transactions must use one sender.");
+  }
+  return senders[0];
+}
+function resolveChainIds(pending, sessionChainId) {
+  const chainIds = pending.map((tx) => {
+    var _a3;
+    const chainId3 = (_a3 = tx.chainId) != null ? _a3 : sessionChainId;
+    if (!Number.isSafeInteger(chainId3) || (chainId3 != null ? chainId3 : 0) <= 0) {
+      throw new Error(
+        `Transaction "${tx.id}" has no valid chain ID; export will not default to Ethereum.`
+      );
+    }
+    return chainId3;
+  });
+  if (new Set(chainIds).size !== 1) {
+    throw new Error("Selected transactions must use one chain.");
+  }
+  return chainIds;
+}
+async function exportCommand(config, txIds) {
+  if (txIds.length === 0) {
+    fatal(
+      "Usage: aomi tx export <tx-id> [<tx-id> ...]\nRun `aomi tx list` to see pending transaction IDs."
+    );
+  }
+  const cli = CliSession.load();
+  if (!cli) {
+    fatal("No active session. Run `aomi chat` first.");
+  }
+  cli.mergeConfig(config);
+  const session = cli.createClientSession(config);
+  try {
+    const state = await session.client.fetchState(
+      cli.sessionId,
+      void 0,
+      cli.clientId
+    );
+    cli.syncPendingFromUserState(state.user_state);
+  } finally {
+    session.close();
+  }
+  try {
+    const pending = resolvePendingEvmTransactions(cli, txIds);
+    const sender = resolveSender(pending, cli.publicKey);
+    const chainIds = resolveChainIds(pending, cli.chainId);
+    const calls = pending.flatMap(
+      (tx, index) => pendingTxToCallList(__spreadProps(__spreadValues({}, tx), { chainId: chainIds[index] }))
+    );
+    const payload = toEip5792SendCallsParams({
+      from: sender,
+      chainId: chainIds[0],
+      calls
+    });
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}
+`);
+  } catch (error) {
+    fatal(errorMessage(error));
+  }
+}
+var init_export = __esm({
+  "src/cli/commands/export.ts"() {
+    "use strict";
+    init_cli_session();
+    init_eip5792();
+    init_errors();
+    init_transactions();
+  }
+});
+
 // src/cli/commands/sessions.ts
 var sessions_exports = {};
 __export(sessions_exports, {
@@ -10608,6 +10803,23 @@ var txSimulateDef = defineCommand2({
     await simulateCommand2(buildCliConfig(args), txIds);
   }
 });
+var txExportDef = defineCommand2({
+  meta: {
+    name: "export",
+    description: "Export pending EVM calls as an EIP-5792 wallet_sendCalls payload"
+  },
+  args: __spreadProps(__spreadValues({}, globalArgs), {
+    txIds: {
+      type: "positional",
+      description: "Pending EVM transaction IDs to export",
+      required: false
+    }
+  }),
+  async run({ args }) {
+    const { exportCommand: exportCommand2 } = await Promise.resolve().then(() => (init_export(), export_exports));
+    await exportCommand2(buildCliConfig(args), getPositionals(args));
+  }
+});
 var txSignDef = defineCommand2({
   meta: { name: "sign", description: "Sign and submit pending transactions" },
   args: __spreadProps(__spreadValues({}, globalArgs), {
@@ -10644,6 +10856,7 @@ var txDef = defineCommand2({
   subCommands: {
     list: txListDef,
     simulate: txSimulateDef,
+    export: txExportDef,
     sign: txSignDef
   }
 });

--- a/packages/client/dist/cli.js
+++ b/packages/client/dist/cli.js
@@ -8019,6 +8019,41 @@ var init_eip5792 = __esm({
   }
 });
 
+// src/cli/wallet-export.ts
+function parseWalletExportFormat(value) {
+  const format = (value == null ? void 0 : value.trim().toLowerCase()) || "eip5792";
+  if (WALLET_EXPORT_FORMATS.includes(format)) {
+    return format;
+  }
+  throw new Error(
+    `Unknown export format "${value}". Use "eip5792", "moss", or "metamask".`
+  );
+}
+function formatWalletExport(params, format) {
+  if (format === "eip5792") {
+    return params;
+  }
+  if (format === "moss") {
+    return params.calls;
+  }
+  if (params.calls.length !== 1) {
+    throw new Error(
+      "The metamask format supports exactly one call. Export one transaction at a time, or use the eip5792 or moss format for multiple calls."
+    );
+  }
+  return {
+    chainId: Number(BigInt(params.chainId)),
+    payload: params.calls[0]
+  };
+}
+var WALLET_EXPORT_FORMATS;
+var init_wallet_export = __esm({
+  "src/cli/wallet-export.ts"() {
+    "use strict";
+    WALLET_EXPORT_FORMATS = ["eip5792", "moss", "metamask"];
+  }
+});
+
 // src/cli/commands/export.ts
 var export_exports = {};
 __export(export_exports, {
@@ -8108,11 +8143,17 @@ function resolveChainIds(pending, sessionChainId) {
   }
   return chainIds;
 }
-async function exportCommand(config, txIds) {
+async function exportCommand(config, txIds, rawFormat) {
   if (txIds.length === 0) {
     fatal(
       "Usage: aomi tx export <tx-id> [<tx-id> ...]\nRun `aomi tx list` to see pending transaction IDs."
     );
+  }
+  let format;
+  try {
+    format = parseWalletExportFormat(rawFormat);
+  } catch (error) {
+    fatal(errorMessage(error));
   }
   const cli = CliSession.load();
   if (!cli) {
@@ -8142,8 +8183,10 @@ async function exportCommand(config, txIds) {
       chainId: chainIds[0],
       calls
     });
-    process.stdout.write(`${JSON.stringify(payload, null, 2)}
-`);
+    process.stdout.write(
+      `${JSON.stringify(formatWalletExport(payload, format), null, 2)}
+`
+    );
   } catch (error) {
     fatal(errorMessage(error));
   }
@@ -8155,6 +8198,7 @@ var init_export = __esm({
     init_eip5792();
     init_errors();
     init_transactions();
+    init_wallet_export();
   }
 });
 
@@ -10806,9 +10850,13 @@ var txSimulateDef = defineCommand2({
 var txExportDef = defineCommand2({
   meta: {
     name: "export",
-    description: "Export pending EVM calls as an EIP-5792 wallet_sendCalls payload"
+    description: "Export pending EVM calls for an external wallet"
   },
   args: __spreadProps(__spreadValues({}, globalArgs), {
+    format: {
+      type: "string",
+      description: "Output format: eip5792 (default), moss, or metamask"
+    },
     txIds: {
       type: "positional",
       description: "Pending EVM transaction IDs to export",
@@ -10817,7 +10865,11 @@ var txExportDef = defineCommand2({
   }),
   async run({ args }) {
     const { exportCommand: exportCommand2 } = await Promise.resolve().then(() => (init_export(), export_exports));
-    await exportCommand2(buildCliConfig(args), getPositionals(args));
+    await exportCommand2(
+      buildCliConfig(args),
+      getPositionals(args),
+      typeof args.format === "string" ? args.format : void 0
+    );
   }
 });
 var txSignDef = defineCommand2({
@@ -11602,7 +11654,7 @@ init_shared();
 // package.json
 var package_default = {
   name: "@aomi-labs/client",
-  version: "0.6.1",
+  version: "0.6.2",
   description: "Platform-agnostic TypeScript client for the Aomi backend API",
   type: "module",
   main: "./dist/index.cjs",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aomi-labs/client",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Platform-agnostic TypeScript client for the Aomi backend API",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/client/src/cli/commands/defs/tx.ts
+++ b/packages/client/src/cli/commands/defs/tx.ts
@@ -30,6 +30,26 @@ const txSimulateDef = defineCommand({
   },
 });
 
+const txExportDef = defineCommand({
+  meta: {
+    name: "export",
+    description:
+      "Export pending EVM calls as an EIP-5792 wallet_sendCalls payload",
+  },
+  args: {
+    ...globalArgs,
+    txIds: {
+      type: "positional",
+      description: "Pending EVM transaction IDs to export",
+      required: false,
+    },
+  },
+  async run({ args }) {
+    const { exportCommand } = await import("../export");
+    await exportCommand(buildCliConfig(args), getPositionals(args));
+  },
+});
+
 const txSignDef = defineCommand({
   meta: { name: "sign", description: "Sign and submit pending transactions" },
   args: {
@@ -71,6 +91,7 @@ export const txDef = defineCommand({
   subCommands: {
     list: txListDef,
     simulate: txSimulateDef,
+    export: txExportDef,
     sign: txSignDef,
   },
 });

--- a/packages/client/src/cli/commands/defs/tx.ts
+++ b/packages/client/src/cli/commands/defs/tx.ts
@@ -33,11 +33,14 @@ const txSimulateDef = defineCommand({
 const txExportDef = defineCommand({
   meta: {
     name: "export",
-    description:
-      "Export pending EVM calls as an EIP-5792 wallet_sendCalls payload",
+    description: "Export pending EVM calls for an external wallet",
   },
   args: {
     ...globalArgs,
+    format: {
+      type: "string",
+      description: "Output format: eip5792 (default), moss, or metamask",
+    },
     txIds: {
       type: "positional",
       description: "Pending EVM transaction IDs to export",
@@ -46,7 +49,11 @@ const txExportDef = defineCommand({
   },
   async run({ args }) {
     const { exportCommand } = await import("../export");
-    await exportCommand(buildCliConfig(args), getPositionals(args));
+    await exportCommand(
+      buildCliConfig(args),
+      getPositionals(args),
+      typeof args.format === "string" ? args.format : undefined,
+    );
   },
 });
 

--- a/packages/client/src/cli/commands/export.ts
+++ b/packages/client/src/cli/commands/export.ts
@@ -5,6 +5,11 @@ import { fatal } from "../errors";
 import type { PendingTx } from "../state";
 import { pendingTxToCallList } from "../transactions";
 import type { CliConfig } from "../types";
+import {
+  formatWalletExport,
+  parseWalletExportFormat,
+  type WalletExportFormat,
+} from "../wallet-export";
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -115,11 +120,19 @@ function resolveChainIds(
 export async function exportCommand(
   config: CliConfig,
   txIds: string[],
+  rawFormat?: string,
 ): Promise<void> {
   if (txIds.length === 0) {
     fatal(
       "Usage: aomi tx export <tx-id> [<tx-id> ...]\nRun `aomi tx list` to see pending transaction IDs.",
     );
+  }
+
+  let format: WalletExportFormat;
+  try {
+    format = parseWalletExportFormat(rawFormat);
+  } catch (error) {
+    fatal(errorMessage(error));
   }
 
   const cli = CliSession.load();
@@ -152,7 +165,9 @@ export async function exportCommand(
       chainId: chainIds[0],
       calls,
     });
-    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+    process.stdout.write(
+      `${JSON.stringify(formatWalletExport(payload, format), null, 2)}\n`,
+    );
   } catch (error) {
     fatal(errorMessage(error));
   }

--- a/packages/client/src/cli/commands/export.ts
+++ b/packages/client/src/cli/commands/export.ts
@@ -1,0 +1,159 @@
+import { getAddress, type Address } from "viem";
+import { CliSession } from "../cli-session";
+import { toEip5792SendCallsParams } from "../eip5792";
+import { fatal } from "../errors";
+import type { PendingTx } from "../state";
+import { pendingTxToCallList } from "../transactions";
+import type { CliConfig } from "../types";
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function normalizeSender(value: string, label: string): Address {
+  try {
+    return getAddress(value);
+  } catch {
+    throw new Error(`${label} is not a valid EVM address.`);
+  }
+}
+
+function resolvePendingEvmTransactions(
+  cli: CliSession,
+  selectors: readonly string[],
+): PendingTx[] {
+  const pending = selectors.map((selector) => {
+    const evm = cli.findPendingTx(selector);
+    const svm = cli.findPendingSolTx(selector);
+
+    if (!selector.includes(":") && evm && svm) {
+      throw new Error(
+        `Transaction "${selector}" is ambiguous. Use the chain-qualified selector shown by \`aomi tx list\`.`,
+      );
+    }
+    if (!evm && svm) {
+      throw new Error(
+        `Transaction "${selector}" is a Solana request; EIP-5792 export supports pending EVM transactions only.`,
+      );
+    }
+    if (!evm) {
+      const available = cli.pendingSelectors().join(", ") || "(none)";
+      throw new Error(
+        `Transaction "${selector}" not found.\nAvailable: ${available}`,
+      );
+    }
+    if (evm.kind !== "transaction") {
+      throw new Error(
+        `Transaction "${selector}" is an EVM signing request; EIP-5792 export supports transaction calls only.`,
+      );
+    }
+    return evm;
+  });
+
+  if (new Set(pending.map((tx) => tx.id)).size !== pending.length) {
+    throw new Error(
+      "Duplicate transaction IDs are not allowed in a single `aomi tx export` call.",
+    );
+  }
+  return pending;
+}
+
+function resolveSender(
+  pending: readonly PendingTx[],
+  sessionSender: string | undefined,
+): Address {
+  const normalizedSessionSender = sessionSender
+    ? normalizeSender(sessionSender, "The active session sender")
+    : undefined;
+  const senders = pending.map((tx) => {
+    const stagedSender = tx.from
+      ? normalizeSender(tx.from, `Transaction "${tx.id}" sender`)
+      : undefined;
+    if (
+      stagedSender &&
+      normalizedSessionSender &&
+      stagedSender.toLowerCase() !== normalizedSessionSender.toLowerCase()
+    ) {
+      throw new Error(
+        `Transaction "${tx.id}" sender ${stagedSender} does not match the active session sender ${normalizedSessionSender}.`,
+      );
+    }
+    const sender = stagedSender ?? normalizedSessionSender;
+    if (!sender) {
+      throw new Error(
+        `Transaction "${tx.id}" has no sender and the active session has no EVM address.`,
+      );
+    }
+    return sender;
+  });
+
+  if (new Set(senders.map((sender) => sender.toLowerCase())).size !== 1) {
+    throw new Error("Selected transactions must use one sender.");
+  }
+  return senders[0];
+}
+
+function resolveChainIds(
+  pending: readonly PendingTx[],
+  sessionChainId: number | undefined,
+): number[] {
+  const chainIds = pending.map((tx) => {
+    const chainId = tx.chainId ?? sessionChainId;
+    if (!Number.isSafeInteger(chainId) || (chainId ?? 0) <= 0) {
+      throw new Error(
+        `Transaction "${tx.id}" has no valid chain ID; export will not default to Ethereum.`,
+      );
+    }
+    return chainId as number;
+  });
+  if (new Set(chainIds).size !== 1) {
+    throw new Error("Selected transactions must use one chain.");
+  }
+  return chainIds;
+}
+
+export async function exportCommand(
+  config: CliConfig,
+  txIds: string[],
+): Promise<void> {
+  if (txIds.length === 0) {
+    fatal(
+      "Usage: aomi tx export <tx-id> [<tx-id> ...]\nRun `aomi tx list` to see pending transaction IDs.",
+    );
+  }
+
+  const cli = CliSession.load();
+  if (!cli) {
+    fatal("No active session. Run `aomi chat` first.");
+  }
+
+  cli.mergeConfig(config);
+  const session = cli.createClientSession(config);
+  try {
+    const state = await session.client.fetchState(
+      cli.sessionId,
+      undefined,
+      cli.clientId,
+    );
+    cli.syncPendingFromUserState(state.user_state);
+  } finally {
+    session.close();
+  }
+
+  try {
+    const pending = resolvePendingEvmTransactions(cli, txIds);
+    const sender = resolveSender(pending, cli.publicKey);
+    const chainIds = resolveChainIds(pending, cli.chainId);
+    const calls = pending.flatMap((tx, index) =>
+      pendingTxToCallList({ ...tx, chainId: chainIds[index] }),
+    );
+    const payload = toEip5792SendCallsParams({
+      from: sender,
+      chainId: chainIds[0],
+      calls,
+    });
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+  } catch (error) {
+    fatal(errorMessage(error));
+  }
+}

--- a/packages/client/src/cli/eip5792.ts
+++ b/packages/client/src/cli/eip5792.ts
@@ -1,0 +1,70 @@
+import { getAddress, toHex, type Address, type Hex } from "viem";
+import type { AAWalletCall } from "../aa";
+
+export type Eip5792Call = {
+  to: Address;
+  data: Hex;
+  value: Hex;
+};
+
+export type Eip5792SendCallsParams = {
+  version: "2.0.0";
+  from: Address;
+  chainId: Hex;
+  atomicRequired: false;
+  calls: Eip5792Call[];
+};
+
+function normalizeAddress(value: string, field: string): Address {
+  try {
+    return getAddress(value);
+  } catch {
+    throw new Error(`${field} must be a valid EVM address.`);
+  }
+}
+
+function normalizeChainId(value: number): number {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error("chainId must be a positive safe integer.");
+  }
+  return value;
+}
+
+function normalizeData(value: Hex | undefined, index: number): Hex {
+  const data = value ?? "0x";
+  if (!/^0x(?:[0-9a-fA-F]{2})*$/.test(data)) {
+    throw new Error(`Call ${index + 1} data must be a hex byte string.`);
+  }
+  return data.toLowerCase() as Hex;
+}
+
+export function toEip5792SendCallsParams(input: {
+  from: string;
+  chainId: number;
+  calls: readonly AAWalletCall[];
+}): Eip5792SendCallsParams {
+  const chainId = normalizeChainId(input.chainId);
+  if (input.calls.length === 0) {
+    throw new Error("At least one EVM call is required.");
+  }
+
+  return {
+    version: "2.0.0",
+    from: normalizeAddress(input.from, "from"),
+    chainId: toHex(chainId),
+    atomicRequired: false,
+    calls: input.calls.map((call, index) => {
+      if (call.chainId !== chainId) {
+        throw new Error("All calls must use the exported chainId.");
+      }
+      if (call.value < BigInt(0)) {
+        throw new Error(`Call ${index + 1} value cannot be negative.`);
+      }
+      return {
+        to: normalizeAddress(call.to, `Call ${index + 1} to`),
+        data: normalizeData(call.data, index),
+        value: toHex(call.value),
+      };
+    }),
+  };
+}

--- a/packages/client/src/cli/state.ts
+++ b/packages/client/src/cli/state.ts
@@ -26,6 +26,7 @@ export type PendingTx = {
   kind: "transaction" | "eip712_sign";
   txId?: number;
   eip712Id?: number;
+  from?: string;
   to?: string;
   value?: string;
   data?: string;

--- a/packages/client/src/cli/user-state.ts
+++ b/packages/client/src/cli/user-state.ts
@@ -136,10 +136,12 @@ export function pendingTxsFromBackendUserState(
     }
 
     const data = normalizePendingTxData(tx);
+    const from = normalizeMaybeAddress(tx.from);
     nextPendingTxs.push({
       id,
       kind: "transaction",
       txId: pendingId,
+      from,
       to,
       value: parseOptionalString(tx.value),
       data,
@@ -149,6 +151,7 @@ export function pendingTxsFromBackendUserState(
       payload: {
         pending_tx_id: pendingId,
         txId: pendingId,
+        from,
         to,
         value: parseOptionalString(tx.value),
         data,

--- a/packages/client/src/cli/wallet-export.ts
+++ b/packages/client/src/cli/wallet-export.ts
@@ -1,0 +1,48 @@
+import type { Eip5792Call, Eip5792SendCallsParams } from "./eip5792";
+
+export const WALLET_EXPORT_FORMATS = ["eip5792", "moss", "metamask"] as const;
+
+export type WalletExportFormat = (typeof WALLET_EXPORT_FORMATS)[number];
+
+export type MetaMaskTransactionExport = {
+  chainId: number;
+  payload: Eip5792Call;
+};
+
+export type WalletExport =
+  | Eip5792SendCallsParams
+  | Eip5792Call[]
+  | MetaMaskTransactionExport;
+
+export function parseWalletExportFormat(
+  value: string | undefined,
+): WalletExportFormat {
+  const format = value?.trim().toLowerCase() || "eip5792";
+  if ((WALLET_EXPORT_FORMATS as readonly string[]).includes(format)) {
+    return format as WalletExportFormat;
+  }
+  throw new Error(
+    `Unknown export format "${value}". Use "eip5792", "moss", or "metamask".`,
+  );
+}
+
+export function formatWalletExport(
+  params: Eip5792SendCallsParams,
+  format: WalletExportFormat,
+): WalletExport {
+  if (format === "eip5792") {
+    return params;
+  }
+  if (format === "moss") {
+    return params.calls;
+  }
+  if (params.calls.length !== 1) {
+    throw new Error(
+      "The metamask format supports exactly one call. Export one transaction at a time, or use the eip5792 or moss format for multiple calls.",
+    );
+  }
+  return {
+    chainId: Number(BigInt(params.chainId)),
+    payload: params.calls[0],
+  };
+}

--- a/packages/client/test/cli/cli-eip5792.unit.test.ts
+++ b/packages/client/test/cli/cli-eip5792.unit.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { toEip5792SendCallsParams } from "../../src/cli/eip5792";
+
+const FROM = "0x1111111111111111111111111111111111111111";
+const FIRST_TO = "0x2222222222222222222222222222222222222222";
+const SECOND_TO = "0x3333333333333333333333333333333333333333";
+
+describe("toEip5792SendCallsParams", () => {
+  it("serializes canonical quantities and preserves call order", () => {
+    expect(
+      toEip5792SendCallsParams({
+        from: FROM,
+        chainId: 4326,
+        calls: [
+          {
+            to: FIRST_TO,
+            value: 0n,
+            data: undefined,
+            chainId: 4326,
+          },
+          {
+            to: SECOND_TO,
+            value: 1_000_000_000_000_000n,
+            data: "0xAABB",
+            chainId: 4326,
+          },
+        ],
+      }),
+    ).toEqual({
+      version: "2.0.0",
+      from: FROM,
+      chainId: "0x10e6",
+      atomicRequired: false,
+      calls: [
+        { to: FIRST_TO, data: "0x", value: "0x0" },
+        {
+          to: SECOND_TO,
+          data: "0xaabb",
+          value: "0x38d7ea4c68000",
+        },
+      ],
+    });
+  });
+
+  it("serializes Ethereum as 0x1 without a leading zero", () => {
+    const result = toEip5792SendCallsParams({
+      from: FROM,
+      chainId: 1,
+      calls: [{ to: FIRST_TO, value: 0n, data: "0x", chainId: 1 }],
+    });
+
+    expect(result.chainId).toBe("0x1");
+  });
+
+  it.each([
+    {
+      name: "an invalid sender",
+      input: {
+        from: "not-an-address",
+        chainId: 1,
+        calls: [{ to: FIRST_TO, value: 0n, chainId: 1 }],
+      },
+      error: "from must be a valid EVM address",
+    },
+    {
+      name: "an invalid call target",
+      input: {
+        from: FROM,
+        chainId: 1,
+        calls: [{ to: "0x1234", value: 0n, chainId: 1 }],
+      },
+      error: "Call 1 to must be a valid EVM address",
+    },
+    {
+      name: "odd-length calldata",
+      input: {
+        from: FROM,
+        chainId: 1,
+        calls: [{ to: FIRST_TO, value: 0n, data: "0x123", chainId: 1 }],
+      },
+      error: "Call 1 data must be a hex byte string",
+    },
+    {
+      name: "a negative value",
+      input: {
+        from: FROM,
+        chainId: 1,
+        calls: [{ to: FIRST_TO, value: -1n, chainId: 1 }],
+      },
+      error: "Call 1 value cannot be negative",
+    },
+    {
+      name: "a mixed call chain",
+      input: {
+        from: FROM,
+        chainId: 1,
+        calls: [{ to: FIRST_TO, value: 0n, chainId: 10 }],
+      },
+      error: "All calls must use the exported chainId",
+    },
+  ])("rejects $name", ({ input, error }) => {
+    expect(() =>
+      toEip5792SendCallsParams(
+        input as Parameters<typeof toEip5792SendCallsParams>[0],
+      ),
+    ).toThrow(error);
+  });
+
+  it("requires at least one call and a positive safe chain ID", () => {
+    expect(() =>
+      toEip5792SendCallsParams({ from: FROM, chainId: 1, calls: [] }),
+    ).toThrow("At least one EVM call is required");
+    expect(() =>
+      toEip5792SendCallsParams({
+        from: FROM,
+        chainId: 0,
+        calls: [{ to: FIRST_TO, value: 0n, chainId: 0 }],
+      }),
+    ).toThrow("chainId must be a positive safe integer");
+  });
+});

--- a/packages/client/test/cli/cli-tx-export.unit.test.ts
+++ b/packages/client/test/cli/cli-tx-export.unit.test.ts
@@ -1,0 +1,248 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PendingSolTx, PendingTx } from "../../src/cli/state";
+
+const SENDER = "0x1111111111111111111111111111111111111111";
+const OTHER_SENDER = "0x9999999999999999999999999999999999999999";
+const FIRST_TO = "0x2222222222222222222222222222222222222222";
+const SECOND_TO = "0x3333333333333333333333333333333333333333";
+
+const mocks = vi.hoisted(() => ({
+  fetchState: vi.fn(),
+  sendSystemMessage: vi.fn(),
+  close: vi.fn(),
+  readState: vi.fn(),
+  writeState: vi.fn(),
+  refreshedPendingTxs: [] as PendingTx[],
+  refreshedPendingSolTxs: [] as PendingSolTx[],
+}));
+
+vi.mock("../../src/session", () => ({
+  ClientSession: class MockClientSession {
+    client = {
+      fetchState: mocks.fetchState,
+      sendSystemMessage: mocks.sendSystemMessage,
+    };
+
+    resolveUserState = vi.fn();
+    close = mocks.close;
+  },
+}));
+
+vi.mock("../../src/cli/state", async () => {
+  const actual = await vi.importActual<typeof import("../../src/cli/state")>(
+    "../../src/cli/state",
+  );
+  return {
+    ...actual,
+    readState: mocks.readState,
+    writeState: mocks.writeState,
+    syncPendingTxsFromUserState: (
+      state: import("../../src/cli/state").CliSessionState,
+    ) => {
+      state.pendingTxs = [...mocks.refreshedPendingTxs];
+      state.pendingSolTxs = [...mocks.refreshedPendingSolTxs];
+      mocks.writeState(state);
+      return {
+        pendingTxs: state.pendingTxs,
+        pendingSolTxs: state.pendingSolTxs,
+      };
+    },
+  };
+});
+
+import { exportCommand } from "../../src/cli/commands/export";
+
+function pendingTx(id: number, overrides: Partial<PendingTx> = {}): PendingTx {
+  return {
+    id: `tx-${id}`,
+    kind: "transaction",
+    txId: id,
+    from: SENDER,
+    to: id === 1 ? FIRST_TO : SECOND_TO,
+    value: "0",
+    data: "0x",
+    chainId: 4326,
+    timestamp: id,
+    payload: { txId: id },
+    ...overrides,
+  };
+}
+
+function state(overrides: Record<string, unknown> = {}) {
+  return {
+    sessionId: "session-1",
+    clientId: "client-1",
+    baseUrl: "http://127.0.0.1:8080",
+    app: "default",
+    publicKey: SENDER,
+    chainId: 4326,
+    pendingTxs: [pendingTx(1, { data: "0xdead" })],
+    pendingSolTxs: [],
+    signedTxs: [],
+    ...overrides,
+  };
+}
+
+const config = {
+  baseUrl: "http://127.0.0.1:8080",
+  app: "default",
+  secrets: {},
+};
+
+describe("aomi tx export", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.AOMI_CLI_STRICT_EXIT = "1";
+    mocks.refreshedPendingTxs = [
+      pendingTx(1, { data: "0xaabb", value: "0" }),
+      pendingTx(2, { data: undefined, value: "1000" }),
+    ];
+    mocks.refreshedPendingSolTxs = [];
+    mocks.readState.mockReturnValue(state());
+    mocks.fetchState.mockResolvedValue({ user_state: { pending: {} } });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    delete process.env.AOMI_CLI_STRICT_EXIT;
+    vi.restoreAllMocks();
+  });
+
+  it("refreshes state and prints only ordered EIP-5792 JSON", async () => {
+    const stdout = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await exportCommand(config, ["tx-2", "tx-1"]);
+
+    expect(mocks.fetchState).toHaveBeenCalledWith(
+      "session-1",
+      undefined,
+      "client-1",
+    );
+    expect(mocks.close).toHaveBeenCalledOnce();
+    expect(mocks.sendSystemMessage).not.toHaveBeenCalled();
+    expect(log).not.toHaveBeenCalled();
+    expect(stdout).toHaveBeenCalledOnce();
+    expect(JSON.parse(stdout.mock.calls[0]?.[0] as string)).toEqual({
+      version: "2.0.0",
+      from: SENDER,
+      chainId: "0x10e6",
+      atomicRequired: false,
+      calls: [
+        { to: SECOND_TO, data: "0x", value: "0x3e8" },
+        { to: FIRST_TO, data: "0xaabb", value: "0x0" },
+      ],
+    });
+  });
+
+  it("requires selectors and an active session", async () => {
+    await expect(exportCommand(config, [])).rejects.toMatchObject({ code: 1 });
+
+    mocks.readState.mockReturnValue(null);
+    await expect(exportCommand(config, ["tx-1"])).rejects.toMatchObject({
+      code: 1,
+    });
+  });
+
+  it("rejects duplicate selectors after chain qualification", async () => {
+    await expect(
+      exportCommand(config, ["tx-1", "evm:tx-1"]),
+    ).rejects.toMatchObject({ code: 1 });
+  });
+
+  it("rejects EIP-712 and Solana signing requests", async () => {
+    mocks.refreshedPendingTxs = [
+      pendingTx(1, {
+        kind: "eip712_sign",
+        txId: undefined,
+        eip712Id: 1,
+        to: undefined,
+      }),
+    ];
+    await expect(exportCommand(config, ["tx-1"])).rejects.toMatchObject({
+      code: 1,
+    });
+
+    mocks.refreshedPendingTxs = [];
+    mocks.refreshedPendingSolTxs = [
+      {
+        id: "tx-1",
+        solanaId: 1,
+        unsignedTx: "AA==",
+        timestamp: 1,
+        payload: {},
+      },
+    ];
+    await expect(exportCommand(config, ["svm:tx-1"])).rejects.toMatchObject({
+      code: 1,
+    });
+  });
+
+  it("rejects ambiguous cross-family selectors", async () => {
+    mocks.refreshedPendingSolTxs = [
+      {
+        id: "tx-1",
+        solanaId: 1,
+        unsignedTx: "AA==",
+        timestamp: 1,
+        payload: {},
+      },
+    ];
+
+    await expect(exportCommand(config, ["tx-1"])).rejects.toMatchObject({
+      code: 1,
+    });
+  });
+
+  it("rejects mixed chains and never defaults a missing chain to Ethereum", async () => {
+    mocks.refreshedPendingTxs = [
+      pendingTx(1, { chainId: 1 }),
+      pendingTx(2, { chainId: 10 }),
+    ];
+    await expect(exportCommand(config, ["tx-1", "tx-2"])).rejects.toMatchObject(
+      { code: 1 },
+    );
+
+    mocks.readState.mockReturnValue(state({ chainId: undefined }));
+    mocks.refreshedPendingTxs = [pendingTx(1, { chainId: undefined })];
+    await expect(exportCommand(config, ["tx-1"])).rejects.toMatchObject({
+      code: 1,
+    });
+  });
+
+  it("rejects mixed, missing, and session-mismatched senders", async () => {
+    mocks.readState.mockReturnValue(state({ publicKey: undefined }));
+    mocks.refreshedPendingTxs = [
+      pendingTx(1),
+      pendingTx(2, { from: OTHER_SENDER }),
+    ];
+    await expect(exportCommand(config, ["tx-1", "tx-2"])).rejects.toMatchObject(
+      { code: 1 },
+    );
+
+    mocks.refreshedPendingTxs = [pendingTx(1, { from: undefined })];
+    await expect(exportCommand(config, ["tx-1"])).rejects.toMatchObject({
+      code: 1,
+    });
+
+    mocks.readState.mockReturnValue(state());
+    mocks.refreshedPendingTxs = [pendingTx(1, { from: OTHER_SENDER })];
+    await expect(exportCommand(config, ["tx-1"])).rejects.toMatchObject({
+      code: 1,
+    });
+  });
+
+  it("rejects malformed refreshed calldata before writing stdout", async () => {
+    const stdout = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    mocks.refreshedPendingTxs = [pendingTx(1, { data: "0x123" })];
+
+    await expect(exportCommand(config, ["tx-1"])).rejects.toMatchObject({
+      code: 1,
+    });
+    expect(stdout).not.toHaveBeenCalled();
+  });
+});

--- a/packages/client/test/cli/cli-tx-export.unit.test.ts
+++ b/packages/client/test/cli/cli-tx-export.unit.test.ts
@@ -137,6 +137,46 @@ describe("aomi tx export", () => {
     });
   });
 
+  it("prints the call array in moss format", async () => {
+    const stdout = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    await exportCommand(config, ["tx-2", "tx-1"], "moss");
+
+    expect(JSON.parse(stdout.mock.calls[0]?.[0] as string)).toEqual([
+      { to: SECOND_TO, data: "0x", value: "0x3e8" },
+      { to: FIRST_TO, data: "0xaabb", value: "0x0" },
+    ]);
+  });
+
+  it("prints a single MetaMask transaction handoff", async () => {
+    const stdout = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    await exportCommand(config, ["tx-1"], "metamask");
+
+    expect(JSON.parse(stdout.mock.calls[0]?.[0] as string)).toEqual({
+      chainId: 4326,
+      payload: { to: FIRST_TO, data: "0xaabb", value: "0x0" },
+    });
+  });
+
+  it("rejects multiple calls and unknown format aliases", async () => {
+    const stdout = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    await expect(
+      exportCommand(config, ["tx-1", "tx-2"], "metamask"),
+    ).rejects.toMatchObject({ code: 1 });
+    await expect(exportCommand(config, ["tx-1"], "mm")).rejects.toMatchObject({
+      code: 1,
+    });
+    expect(stdout).not.toHaveBeenCalled();
+  });
+
   it("requires selectors and an active session", async () => {
     await expect(exportCommand(config, [])).rejects.toMatchObject({ code: 1 });
 

--- a/packages/client/test/cli/cli-user-state.unit.test.ts
+++ b/packages/client/test/cli/cli-user-state.unit.test.ts
@@ -126,6 +126,31 @@ describe("pendingTxsFromBackendUserState", () => {
     });
   });
 
+  it("retains the authoritative staged sender", () => {
+    const result = pendingTxsFromBackendUserState({
+      pending: {
+        evm_txs: {
+          4: {
+            from: "0x1234567890abcdef1234567890abcdef12345678",
+            to: "0x742d35Cc6634C0532925a3b844Bc9e7595f33749",
+            value: "0",
+            data: "0x",
+            kind: "contract_call",
+            chain_id: 4326,
+          },
+        },
+      },
+    });
+
+    expect(result[0]).toMatchObject({
+      from: "0x1234567890AbcdEF1234567890aBcdef12345678",
+      chainId: 4326,
+    });
+    expect(result[0].payload).toMatchObject({
+      from: "0x1234567890AbcdEF1234567890aBcdef12345678",
+    });
+  });
+
   it("preserves data when kind is absent", () => {
     const result = pendingTxsFromBackendUserState({
       pending_txs: {

--- a/packages/client/test/cli/cli-wallet-export.unit.test.ts
+++ b/packages/client/test/cli/cli-wallet-export.unit.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import type { Eip5792SendCallsParams } from "../../src/cli/eip5792";
+import {
+  formatWalletExport,
+  parseWalletExportFormat,
+} from "../../src/cli/wallet-export";
+
+const params: Eip5792SendCallsParams = {
+  version: "2.0.0",
+  from: "0x1111111111111111111111111111111111111111",
+  chainId: "0x10e6",
+  atomicRequired: false,
+  calls: [
+    {
+      to: "0x2222222222222222222222222222222222222222",
+      data: "0xaabb",
+      value: "0x3e8",
+    },
+  ],
+};
+
+describe("wallet export formats", () => {
+  it("defaults to eip5792 and accepts the documented format names", () => {
+    expect(parseWalletExportFormat(undefined)).toBe("eip5792");
+    expect(parseWalletExportFormat(" EIP5792 ")).toBe("eip5792");
+    expect(parseWalletExportFormat("moss")).toBe("moss");
+    expect(parseWalletExportFormat("MetaMask")).toBe("metamask");
+  });
+
+  it("rejects undocumented format names", () => {
+    expect(() => parseWalletExportFormat("mm")).toThrow(
+      'Use "eip5792", "moss", or "metamask"',
+    );
+  });
+
+  it("keeps the canonical EIP-5792 object unchanged", () => {
+    expect(formatWalletExport(params, "eip5792")).toBe(params);
+  });
+
+  it("emits only the ordered call array for MOSS", () => {
+    expect(formatWalletExport(params, "moss")).toEqual(params.calls);
+  });
+
+  it("emits MetaMask's numeric chain argument and raw transaction payload", () => {
+    expect(formatWalletExport(params, "metamask")).toEqual({
+      chainId: 4326,
+      payload: params.calls[0],
+    });
+  });
+
+  it("does not flatten multiple calls into sequential MetaMask sends", () => {
+    expect(() =>
+      formatWalletExport(
+        { ...params, calls: [...params.calls, params.calls[0]] },
+        "metamask",
+      ),
+    ).toThrow("metamask format supports exactly one call");
+  });
+});


### PR DESCRIPTION
## Summary

- add `aomi tx export <id>...` for wallet-neutral EVM call handoff
- keep EIP-5792 `wallet_sendCalls` version `2.0.0` as the canonical default with `--format eip5792`
- add `--format moss` to emit the ordered call array consumed by MegaETH MOSS
- add `--format metamask` to emit the decimal `chainId` and raw transaction `payload` consumed by MetaMask Agent Wallet
- reject multiple calls in the MetaMask adapter instead of silently converting a batch into unrelated sequential transactions
- refresh authoritative pending state and validate EVM-only selectors, one sender, one chain, addresses, calldata, quantities, duplicates, and selector order
- document native MetaMask browser/mobile EIP-5792 execution, MetaMask Agent Wallet execution, and MOSS execution
- bump `@aomi-labs/client` to `0.6.2` and refresh the tracked CLI bundle

## Export formats

| Format | Output | Batch behavior |
| --- | --- | --- |
| `eip5792` | Full `wallet_sendCalls` version `2.0.0` parameter object | Preserves all calls |
| `moss` | Ordered `to` / `data` / `value` call array | Preserves all calls |
| `metamask` | Decimal `chainId` plus one raw transaction `payload` | Requires exactly one call |

The canonical export remains wallet-neutral. MOSS and MetaMask are deliberately small CLI adapters over the EIP-5792 representation.

## Lifecycle boundary

This remains an export-only primitive. It does not sign, broadcast, append the local signer execution-time Aomi service-fee call, notify the backend, or clear pending requests. External execution is a handoff, not yet a complete external-wallet lifecycle.

## Wallet compatibility

### MegaETH MOSS

Validated against MegaETH MOSS CLI v0.1.6 in an isolated Node 22 runtime. The exported call array passed MOSS JSON loading and call normalization, including hexadecimal values, and reached wallet-profile loading. A live relay submission was not attempted because it requires user wallet login and an approved delegated key with matching call and spend permissions.

### MetaMask

- Browser and mobile integrations use the canonical EIP-5792 object through `wallet_sendCalls`; callers should check `wallet_getCapabilities` for the selected account and chain first.
- MetaMask Agent Wallet currently exposes `mm wallet send-transaction --chain-id <id> --payload <json>` as its raw EVM primitive. The `metamask` adapter emits those two inputs without renaming the format after the CLI executable.
- A live MetaMask submission was not attempted because it requires the user's external-wallet authentication and approval flow.

## Verification

- [x] `pnpm exec vitest run` — 1,574 passed, 29 skipped
- [x] `pnpm run lint` — passes with 6 existing unrelated warnings
- [x] `pnpm run typecheck`
- [x] `pnpm --filter @aomi-labs/client build`
- [x] generated `tx export --help` smoke, including all three format names
- [x] unknown format and MetaMask multi-call rejection smokes
- [x] `pnpm --filter @aomi-labs/client pack --dry-run`
- [x] confirmed `@aomi-labs/client@0.6.2` is available on npm
- [x] MegaETH MOSS v0.1.6 call-array parser/normalization smoke

No backend or `product-mono` changes are required for this export-only phase.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790080582&installation_model_id=12362&pr_number=521&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F521&signature=310fac3166ffb2d752af41b4588c3abe5b2b8047463d5d007dda65800ca01519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

