### PR TITLE
Preserve Build platform through GitHub login

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -1,5 +1,13 @@
 # Auth BFF BetterAuth Cleanup Goal
 
+## Preserve Build platform through GitHub sign-in
+
+Current session goal: **IMPLEMENTED AND LOCALLY VERIFIED 2026-08-24** — retain the
+validated same-origin Build page in the signed GitHub OAuth continuation so a
+partner repository import returns to its selected platform instead of falling
+back to `community`. The focused OAuth regressions, all 478 Build tests, Build
+type-check, and lint pass.
+
 ## Chain logo refresh
 
 Current session goal: **IMPLEMENTED AND LOCALLY VERIFIED 2026-08-21** — add

--- a/apps/build/src/app/api/bff/auth/github/callback/route.test.ts
+++ b/apps/build/src/app/api/bff/auth/github/callback/route.test.ts
@@ -6,6 +6,10 @@ import { GET } from "./route";
 
 const mocks = vi.hoisted(() => ({
   oauthState: undefined as string | undefined,
+  continuation: { kind: "browser" } as {
+    kind: "browser";
+    returnTo?: string;
+  },
   exchangeGitHubCode: vi.fn(),
   setGitHubSessionCookie: vi.fn(),
   observeFailure: vi.fn(),
@@ -35,7 +39,7 @@ vi.mock("@build/server/cookies/github", () => ({
     mocks.oauthState
       ? {
           oauthState: mocks.oauthState,
-          continuation: { kind: "browser" },
+          continuation: mocks.continuation,
         }
       : null,
   ),
@@ -45,6 +49,7 @@ vi.mock("@build/server/cookies/github", () => ({
 describe("GitHub callback route", () => {
   beforeEach(() => {
     mocks.oauthState = undefined;
+    mocks.continuation = { kind: "browser" };
     mocks.exchangeGitHubCode.mockReset();
     mocks.setGitHubSessionCookie.mockReset();
     mocks.observeFailure.mockReset();
@@ -71,8 +76,36 @@ describe("GitHub callback route", () => {
     expect(mocks.observeFailure).not.toHaveBeenCalled();
   });
 
+  it("keeps the selected platform when GitHub returns an OAuth error", async () => {
+    mocks.oauthState = "state-123";
+    mocks.continuation = {
+      kind: "browser",
+      returnTo:
+        "/operate/deployments/new?platform=world-market-apps&mode=import",
+    };
+
+    const res = await GET(
+      new Request(
+        "http://localhost:3000/api/bff/auth/github/callback?code=x&state=wrong",
+      ),
+    );
+    const location = new URL(res.headers.get("location") ?? "");
+    expect(location.pathname).toBe("/operate/deployments/new");
+    expect(location.searchParams.get("platform")).toBe("world-market-apps");
+    expect(location.searchParams.get("mode")).toBe("import");
+    expect(location.searchParams.get("launch")).toBe("github");
+    expect(location.searchParams.get("github_error")).toBe(
+      "invalid_oauth_state",
+    );
+  });
+
   it("exchanges GitHub code with the one-shot app and matching redirect URI", async () => {
     mocks.oauthState = "state-123";
+    mocks.continuation = {
+      kind: "browser",
+      returnTo:
+        "/operate/deployments/new?platform=world-market-apps&mode=import",
+    };
     mocks.exchangeGitHubCode.mockResolvedValue({
       githubUserId: "4738254",
       githubLogin: "han",
@@ -87,7 +120,9 @@ describe("GitHub callback route", () => {
 
     expect(res.status).toBe(307);
     const location = new URL(res.headers.get("location") ?? "");
-    expect(location.pathname).toBe("/operate/deployments");
+    expect(location.pathname).toBe("/operate/deployments/new");
+    expect(location.searchParams.get("platform")).toBe("world-market-apps");
+    expect(location.searchParams.get("mode")).toBe("import");
     expect(location.searchParams.get("launch")).toBe("github");
     expect(mocks.exchangeGitHubCode).toHaveBeenCalledWith({
       code: "code-123",

--- a/apps/build/src/app/api/bff/auth/github/callback/route.ts
+++ b/apps/build/src/app/api/bff/auth/github/callback/route.ts
@@ -19,8 +19,13 @@ import { API_PATHS } from "@build/lib/api-paths";
 
 export const runtime = "nodejs";
 
-function deploymentsUrl(req: Request): URL {
-  const url = new URL("/operate/deployments", req.url);
+function browserUrl(req: Request, continuation?: GitHubOAuthContinuation): URL {
+  const url = new URL(
+    continuation?.kind === "browser" && continuation.returnTo
+      ? continuation.returnTo
+      : "/operate/deployments",
+    req.url,
+  );
   url.searchParams.set("launch", "github");
   return url;
 }
@@ -33,7 +38,7 @@ function oauthError(
   const cli = continuation?.kind === "cli";
   const redirect = cli
     ? new URL(continuation.redirectUri)
-    : deploymentsUrl(req);
+    : browserUrl(req, continuation);
   redirect.searchParams.set(cli ? "error" : "github_error", error);
   if (cli) redirect.searchParams.set("state", continuation.state);
   return NextResponse.redirect(redirect);
@@ -68,7 +73,10 @@ export async function GET(req: Request) {
           client.claimGitHubProject({
             code,
             projectId: continuation.projectId,
-            redirectUri: new URL(API_PATHS.bff.auth.github.callback, url.origin).toString(),
+            redirectUri: new URL(
+              API_PATHS.bff.auth.github.callback,
+              url.origin,
+            ).toString(),
           }),
         );
       if (claimed.githubUserId !== existingSession.githubUserId) {
@@ -80,11 +88,14 @@ export async function GET(req: Request) {
       clearGitHubOAuthRequest(response);
       return response;
     }
-    const { session, visibilityGrant } = await exchangeGitHubSession(code, url.origin);
+    const { session, visibilityGrant } = await exchangeGitHubSession(
+      code,
+      url.origin,
+    );
     const response =
       continuation.kind === "cli"
         ? await finishCliAuthorization(session, continuation)
-        : NextResponse.redirect(deploymentsUrl(req));
+        : NextResponse.redirect(browserUrl(req, continuation));
     clearGitHubOAuthRequest(response);
     await setGitHubSessionCookie(response, session);
     setGitHubVisibilityGrantCookie(response, visibilityGrant);

--- a/apps/build/src/app/api/bff/auth/github/login/route.test.ts
+++ b/apps/build/src/app/api/bff/auth/github/login/route.test.ts
@@ -1,7 +1,17 @@
 // @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { readGitHubOAuthRequest } from "@build/server/cookies/github";
+
 import { GET } from "./route";
+
+async function continuation(res: Response) {
+  const cookie = res.headers
+    .getSetCookie()
+    .find((value) => value.startsWith("aomi_github_oauth_request="));
+  const token = cookie?.split(";", 1)[0]?.split("=", 2)[1];
+  return readGitHubOAuthRequest(token);
+}
 
 describe("GitHub login route", () => {
   beforeEach(() => {
@@ -32,5 +42,42 @@ describe("GitHub login route", () => {
     expect(res.headers.get("location")).toContain(
       "client_id=Iv23li4wPpAfoGOJ6v0Q",
     );
+  });
+
+  it("keeps a same-origin return location in the signed continuation", async () => {
+    const res = await GET(
+      new Request(
+        "http://localhost:3000/api/bff/auth/github/login?return_to=%2Foperate%2Fdeployments%2Fnew%3Fplatform%3Dworld-market-apps%26mode%3Dimport",
+      ),
+    );
+
+    await expect(continuation(res)).resolves.toMatchObject({
+      continuation: {
+        kind: "browser",
+        returnTo:
+          "/operate/deployments/new?platform=world-market-apps&mode=import",
+      },
+    });
+  });
+
+  it("falls back to a same-origin referrer and ignores an external return location", async () => {
+    const res = await GET(
+      new Request(
+        "http://localhost:3000/api/bff/auth/github/login?return_to=https%3A%2F%2Fevil.example%2Fsteal",
+        {
+          headers: {
+            referer:
+              "http://localhost:3000/projects?platform=world-market-apps",
+          },
+        },
+      ),
+    );
+
+    await expect(continuation(res)).resolves.toMatchObject({
+      continuation: {
+        kind: "browser",
+        returnTo: "/projects?platform=world-market-apps",
+      },
+    });
   });
 });

--- a/apps/build/src/app/api/bff/auth/github/login/route.ts
+++ b/apps/build/src/app/api/bff/auth/github/login/route.ts
@@ -2,7 +2,33 @@ import { startGitHubOAuth } from "@build/server/github-auth";
 
 export const runtime = "nodejs";
 
+function browserReturnTo(req: Request): string | undefined {
+  const requestUrl = new URL(req.url);
+  const candidates = [
+    requestUrl.searchParams.get("return_to"),
+    req.headers.get("referer"),
+  ];
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    try {
+      const url = new URL(candidate, requestUrl.origin);
+      if (
+        url.origin === requestUrl.origin &&
+        `${url.pathname}${url.search}`.length <= 2048
+      ) {
+        return `${url.pathname}${url.search}`;
+      }
+    } catch {
+      // Ignore malformed return locations.
+    }
+  }
+  return undefined;
+}
+
 // GET /api/bff/auth/github/login — the single entrypoint for GitHub OAuth.
 export async function GET(req: Request) {
-  return startGitHubOAuth(req, { kind: "browser" });
+  return startGitHubOAuth(req, {
+    kind: "browser",
+    returnTo: browserReturnTo(req),
+  });
 }

--- a/apps/build/src/server/cookies/github.test.ts
+++ b/apps/build/src/server/cookies/github.test.ts
@@ -70,6 +70,33 @@ describe("GitHub CLI sessions", () => {
     await expect(readGitHubOAuthRequest(token)).resolves.toEqual(request);
   });
 
+  it("round-trips only local browser return locations", async () => {
+    const local = await issueGitHubOAuthRequest({
+      oauthState: "oauth-state",
+      continuation: {
+        kind: "browser",
+        returnTo:
+          "/operate/deployments/new?platform=world-market-apps&mode=import",
+      },
+    });
+    await expect(readGitHubOAuthRequest(local)).resolves.toMatchObject({
+      continuation: {
+        kind: "browser",
+        returnTo:
+          "/operate/deployments/new?platform=world-market-apps&mode=import",
+      },
+    });
+
+    const external = await issueGitHubOAuthRequest({
+      oauthState: "oauth-state",
+      continuation: {
+        kind: "browser",
+        returnTo: "//evil.example/steal",
+      },
+    });
+    await expect(readGitHubOAuthRequest(external)).resolves.toBeNull();
+  });
+
   it("makes repeated PKCE exchanges idempotent", async () => {
     const code = await issueGitHubCliExchange(session, "c".repeat(43));
     const first = await readGitHubCliExchange(code);

--- a/apps/build/src/server/cookies/github.ts
+++ b/apps/build/src/server/cookies/github.ts
@@ -48,7 +48,7 @@ export interface GitHubCliLoginRequest {
 }
 
 export type GitHubOAuthContinuation =
-  | { kind: "browser" }
+  | { kind: "browser"; returnTo?: string }
   | { kind: "claim"; projectId: number }
   | ({ kind: "cli" } & GitHubCliLoginRequest);
 
@@ -128,10 +128,22 @@ function sessionFromPayload(payload: {
   };
 }
 
-function cliContinuation(value: unknown): GitHubOAuthContinuation | null {
+function oauthContinuation(value: unknown): GitHubOAuthContinuation | null {
   if (!value || typeof value !== "object") return null;
   const candidate = value as Record<string, unknown>;
-  if (candidate.kind === "browser") return { kind: "browser" };
+  if (candidate.kind === "browser") {
+    if (candidate.returnTo === undefined) return { kind: "browser" };
+    if (
+      typeof candidate.returnTo !== "string" ||
+      candidate.returnTo.length > 2048 ||
+      !candidate.returnTo.startsWith("/") ||
+      candidate.returnTo.startsWith("//") ||
+      candidate.returnTo.includes("\\")
+    ) {
+      return null;
+    }
+    return { kind: "browser", returnTo: candidate.returnTo };
+  }
   if (
     candidate.kind === "claim" &&
     typeof candidate.projectId === "number" &&
@@ -182,7 +194,9 @@ export function setGitHubVisibilityGrantCookie(
 }
 
 export async function getGitHubVisibilityGrant(): Promise<string | null> {
-  return (await cookies()).get(GITHUB_VISIBILITY_GRANT_COOKIE)?.value?.trim() || null;
+  return (
+    (await cookies()).get(GITHUB_VISIBILITY_GRANT_COOKIE)?.value?.trim() || null
+  );
 }
 
 export async function issueGitHubCliSession(
@@ -233,7 +247,7 @@ export async function readGitHubOAuthRequest(
   token: string | undefined,
 ): Promise<GitHubOAuthRequest | null> {
   const payload = await verify(token, OAUTH_REQUEST_AUDIENCE);
-  const continuation = cliContinuation(payload?.continuation);
+  const continuation = oauthContinuation(payload?.continuation);
   if (
     !payload ||
     payload.kind !== "github_oauth_request" ||


### PR DESCRIPTION
## Summary
- preserve the current same-origin Build path in the signed GitHub OAuth continuation
- return browser success and error callbacks to the selected platform instead of defaulting to Community
- reject external, malformed, and oversized return locations

## Partner impact
World Markets imports opened on world-market-apps no longer return to Community after GitHub sign-in. The repository-admin authorization requirement is unchanged.

## Verification
- pnpm exec vitest run focused GitHub OAuth suites: 15 passed
- pnpm --filter aomi-build test: 478 passed, 1 skipped
- pnpm --filter aomi-build type-check
- pnpm --filter aomi-build lint: no errors, 3 existing warnings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790135186&installation_model_id=12362&pr_number=524&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F524&signature=1ee4ed019302709a15695d7a61d2930f1dcb89b4fa06a9461f5ec11153733061"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->