### PR TITLE
feat(build): show a CI progress bar during linked-repo deploys

### DIFF
--- a/apps/build/src/features/launch/components/deployments/deploy-flow-progress.test.ts
+++ b/apps/build/src/features/launch/components/deployments/deploy-flow-progress.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import type { DeploymentStatus } from "@aomi-labs/deploy";
+import { ciProgress, stageProgress } from "./deploy-flow-progress";
+
+function status(over: Partial<DeploymentStatus> = {}): DeploymentStatus {
+  return { state: "building", releaseTags: [], ...over };
+}
+
+describe("ciProgress", () => {
+  it("maps CI states into the bar's CI segment, in order", () => {
+    const pending = ciProgress(status({ state: "pending" }), 0).progress;
+    const building = ciProgress(status({ state: "building" }), 1).progress;
+    const releasing = ciProgress(status({ state: "releasing" }), 2).progress;
+    const ready = ciProgress(status({ state: "ready" }), 5).progress;
+
+    expect(pending.percent).toBeGreaterThan(0);
+    expect(pending.percent).toBeLessThan(building.percent);
+    expect(building.percent).toBeLessThan(releasing.percent);
+    expect(releasing.percent).toBeLessThan(ready.percent);
+    // CI never claims the whole bar: activation still has to run.
+    expect(ready.percent).toBeLessThan(100);
+    expect(building.label).toBe("Building CI");
+  });
+
+  it("holds the last completed step through a no_ci poll", () => {
+    const { model, progress } = ciProgress(status({ state: "building" }), 0);
+    const stalled = ciProgress(status({ state: "no_ci" }), model.completed);
+    expect(stalled.progress.percent).toBe(progress.percent);
+  });
+
+  it("surfaces the CI run url when the status carries one", () => {
+    const url = "https://github.com/a/b/actions/runs/1";
+    expect(ciProgress(status({ ci: { url } }), 0).progress.ciUrl).toBe(url);
+    expect(ciProgress(status(), 0).progress.ciUrl).toBeNull();
+  });
+});
+
+describe("stageProgress", () => {
+  it("orders the non-CI stages around the CI segment", () => {
+    const deploying = stageProgress("deploying", "Dispatching build");
+    const activating = stageProgress("activating", "Activating release");
+    const done = stageProgress("done", "Live");
+    const ciReady = ciProgress(status({ state: "ready" }), 0).progress;
+
+    expect(deploying.percent).toBeLessThan(ciReady.percent);
+    expect(ciReady.percent).toBeLessThan(activating.percent);
+    expect(done.percent).toBe(100);
+  });
+
+  it("carries a CI url forward into the later stages", () => {
+    const url = "https://github.com/a/b/actions/runs/1";
+    expect(stageProgress("activating", "Activating release", url).ciUrl).toBe(
+      url,
+    );
+  });
+});

--- a/apps/build/src/features/launch/components/deployments/deploy-flow-progress.ts
+++ b/apps/build/src/features/launch/components/deployments/deploy-flow-progress.ts
@@ -1,0 +1,58 @@
+import type { DeploymentStatus, ProgressModel } from "@aomi-labs/deploy";
+import { deploymentProgress } from "@aomi-labs/deploy/launch";
+
+/**
+ * Progress of a linked-source redeploy, expressed over the WHOLE pipeline
+ * (deploy → CI → activate → live) rather than over CI alone. The deployments
+ * tab used to show only `deployFlow.message`, so a redeploy read as a frozen
+ * "Building… (building)" line for the two-to-four minutes CI takes — the same
+ * wait the onboarding deploy step has always drawn a bar for.
+ */
+export type DeployFlowProgress = {
+  /** 0–100, monotonic within one deploy. */
+  percent: number;
+  /** Short phase label, e.g. "Building CI". */
+  label: string;
+  /** GitHub Actions run for this deployment, once CI reports one. */
+  ciUrl?: string | null;
+};
+
+/** Share of the bar each pipeline stage owns. CI dominates the wall clock. */
+const DEPLOY_START = 4;
+const CI_START = 12;
+const CI_END = 78;
+const ACTIVATE_END = 96;
+
+/** CI's own `completed/total` mapped into the bar's CI segment. */
+export function ciProgress(
+  status: DeploymentStatus,
+  lastCompleted: number,
+): { model: ProgressModel; progress: DeployFlowProgress } {
+  const model = deploymentProgress(status, lastCompleted);
+  const fraction = model.total > 0 ? model.completed / model.total : 0;
+  return {
+    model,
+    progress: {
+      percent: Math.round(
+        CI_START + Math.min(Math.max(fraction, 0), 1) * (CI_END - CI_START),
+      ),
+      label: model.label,
+      ciUrl: status.ci?.url ?? null,
+    },
+  };
+}
+
+/** Progress for the stages that have no CI status to read: before and after. */
+export function stageProgress(
+  stage: "deploying" | "activating" | "done",
+  label: string,
+  ciUrl?: string | null,
+): DeployFlowProgress {
+  const percent =
+    stage === "deploying"
+      ? DEPLOY_START
+      : stage === "activating"
+        ? ACTIVATE_END
+        : 100;
+  return { percent, label, ciUrl: ciUrl ?? null };
+}

--- a/apps/build/src/features/launch/components/deployments/tabs/deployments-tab.test.tsx
+++ b/apps/build/src/features/launch/components/deployments/tabs/deployments-tab.test.tsx
@@ -37,6 +37,7 @@ function makeDetail(
     checkSdkUpgradeStatus?: ReturnType<typeof vi.fn>;
     history?: Detail["history"];
     recordsByApp?: Detail["recordsByApp"];
+    deployFlow?: Detail["deployFlow"];
   } = {},
 ) {
   const sdkVersion = overrides.sdkVersion ?? "3.0.1";
@@ -86,7 +87,8 @@ function makeDetail(
           merged: false,
         },
       })),
-    deployFlow: { phase: "idle" },
+    deployFlow: overrides.deployFlow ?? { phase: "idle" },
+    deployStartedAt: null,
     recordsByApp:
       overrides.recordsByApp ??
       ({
@@ -508,5 +510,29 @@ describe("DeploymentsTab", () => {
       screen.getByText(/project is live, but no deployment records/i),
     ).toBeInTheDocument();
     expect(screen.queryByText("No deployments yet")).not.toBeInTheDocument();
+  });
+
+  it("shows a CI progress bar while a redeploy builds", async () => {
+    renderTab(
+      <DeploymentsTab
+        detail={makeDetail({
+          deployFlow: {
+            phase: "building",
+            message: "Building… (building)",
+            progress: {
+              percent: 30,
+              label: "Building CI",
+              ciUrl: "https://github.com/a/b/actions/runs/1",
+            },
+          },
+        })}
+      />,
+    );
+    const bar = await screen.findByRole("progressbar", {
+      name: "Deployment progress",
+    });
+    expect(bar).toHaveAttribute("aria-valuenow", "30");
+    expect(screen.getByText("Building… (building)")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /CI run/i })).toBeInTheDocument();
   });
 });

--- a/apps/build/src/features/launch/components/deployments/tabs/deployments-tab.tsx
+++ b/apps/build/src/features/launch/components/deployments/tabs/deployments-tab.tsx
@@ -13,6 +13,7 @@ import { DeploymentDetail } from "../ui/deployment-detail";
 import { RequiredSecretsPanel } from "@build/features/launch/components/required-secrets-panel";
 import { UpgradeConfirmDialog, UpgradeRail } from "../ui/upgrade-rail";
 import { LoadingPanel, EmptyPanel } from "../ui/state-panels";
+import { DeployProgressBar } from "../ui/deploy-progress-bar";
 import {
   buildActivityList,
   buildDeploymentList,
@@ -413,17 +414,10 @@ export function DeploymentsTab({
         onDismiss={upgrade.dismiss}
       />
 
-      {detail.deployFlow.phase !== "idle" && (
-        <div
-          className={`border-border border-b px-4 py-2 text-xs ${
-            detail.deployFlow.phase === "error"
-              ? "text-destructive"
-              : "text-dim"
-          }`}
-        >
-          {detail.deployFlow.message}
-        </div>
-      )}
+      <DeployProgressBar
+        deployFlow={detail.deployFlow}
+        startedAt={detail.deployStartedAt ?? null}
+      />
 
       {deactivated && (
         <div className="border-destructive/30 bg-destructive/10 text-destructive flex items-center gap-2 border-b px-4 py-2 text-xs">

--- a/apps/build/src/features/launch/components/deployments/ui/deploy-progress-bar.test.tsx
+++ b/apps/build/src/features/launch/components/deployments/ui/deploy-progress-bar.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { DeployProgressBar } from "./deploy-progress-bar";
+
+describe("DeployProgressBar", () => {
+  it("renders nothing while idle", () => {
+    const { container } = render(
+      <DeployProgressBar deployFlow={{ phase: "idle" }} startedAt={null} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the CI percentage, label and run link while building", () => {
+    render(
+      <DeployProgressBar
+        deployFlow={{
+          phase: "building",
+          message: "Building… (building)",
+          progress: {
+            percent: 30,
+            label: "Building CI",
+            ciUrl: "https://github.com/a/b/actions/runs/1",
+          },
+        }}
+        startedAt={Date.now()}
+      />,
+    );
+    const bar = screen.getByRole("progressbar", { name: "Deployment progress" });
+    expect(bar).toHaveAttribute("aria-valuenow", "30");
+    expect(bar).toHaveAttribute("aria-valuetext", "Building CI");
+    expect(screen.getByText("30%")).toBeInTheDocument();
+    expect(screen.getByText("Building… (building)")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /CI run/i })).toHaveAttribute(
+      "href",
+      "https://github.com/a/b/actions/runs/1",
+    );
+  });
+
+  it("still draws a track for a phase that has no progress yet", () => {
+    render(
+      <DeployProgressBar
+        deployFlow={{ phase: "deploying", message: "Resolving latest commit…" }}
+        startedAt={null}
+      />,
+    );
+    expect(
+      screen.getByRole("progressbar", { name: "Deployment progress" }),
+    ).toHaveAttribute("aria-valuenow", "2");
+    // No start time yet — the clock stays out of the way rather than showing 00:00.
+    expect(screen.queryByLabelText("Elapsed")).not.toBeInTheDocument();
+  });
+
+  it("reports the failure message and drops the percentage on error", () => {
+    render(
+      <DeployProgressBar
+        deployFlow={{
+          phase: "error",
+          message: "Deploy failed",
+          progress: { percent: 100, label: "Deploy failed", ciUrl: null },
+        }}
+        startedAt={Date.now()}
+      />,
+    );
+    expect(screen.getByText("Deploy failed")).toBeInTheDocument();
+    expect(screen.queryByText("100%")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("progressbar", { name: "Deployment progress" }),
+    ).not.toHaveAttribute("aria-valuenow");
+  });
+});

--- a/apps/build/src/features/launch/components/deployments/ui/deploy-progress-bar.tsx
+++ b/apps/build/src/features/launch/components/deployments/ui/deploy-progress-bar.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ExternalLink } from "lucide-react";
+import type { DeployFlowState } from "@build/features/launch/hooks/use-project-detail";
+
+/**
+ * The redeploy pipeline's progress bar. `deployFlow.message` alone left the
+ * user staring at one unchanging line for the whole CI build with no sense of
+ * where in the pipeline they were or whether anything was still moving; the
+ * bar, the elapsed clock, and the CI link answer all three.
+ */
+export function DeployProgressBar({
+  deployFlow,
+  startedAt,
+}: {
+  deployFlow: DeployFlowState;
+  /** Epoch ms of the current deploy, for the elapsed clock. */
+  startedAt: number | null;
+}) {
+  if (deployFlow.phase === "idle") return null;
+
+  const failed = deployFlow.phase === "error";
+  const complete = deployFlow.phase === "done";
+  const progress = "progress" in deployFlow ? deployFlow.progress : undefined;
+  // A phase with no progress yet still gets a visible sliver, so the bar never
+  // renders as an empty track while work is plainly in flight.
+  const percent = failed ? 100 : (progress?.percent ?? 2);
+  const ciUrl = progress?.ciUrl ?? null;
+
+  return (
+    <div className="border-border border-b px-4 py-2.5">
+      <div className="flex items-baseline justify-between gap-3 text-xs">
+        <span
+          className={
+            failed
+              ? "text-destructive font-medium"
+              : "text-foreground font-medium"
+          }
+        >
+          {deployFlow.message}
+        </span>
+        <span className="text-dim flex shrink-0 items-center gap-2 font-mono text-[10px]">
+          {startedAt !== null && !complete && !failed && (
+            <Elapsed startedAt={startedAt} />
+          )}
+          {ciUrl && (
+            <a
+              href={ciUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="text-dim hover:text-foreground inline-flex items-center gap-1 underline underline-offset-2"
+            >
+              CI run
+              <ExternalLink className="size-3" aria-hidden />
+            </a>
+          )}
+          {!failed && <span>{percent}%</span>}
+        </span>
+      </div>
+      <div
+        role="progressbar"
+        aria-label="Deployment progress"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={failed ? undefined : percent}
+        aria-valuetext={progress?.label ?? deployFlow.message}
+        className="bg-surface-1 border-border mt-1.5 h-1.5 w-full overflow-hidden rounded-full border"
+      >
+        <div
+          className={`h-full rounded-full transition-all duration-500 ${
+            failed
+              ? "bg-destructive"
+              : complete
+                ? "bg-positive"
+                : "bg-primary animate-pulse"
+          }`}
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+/** mm:ss since the deploy started. Purely cosmetic; ticks once a second. */
+function Elapsed({ startedAt }: { startedAt: number }) {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+  const seconds = Math.max(0, Math.floor((now - startedAt) / 1000));
+  const mm = String(Math.floor(seconds / 60)).padStart(2, "0");
+  const ss = String(seconds % 60).padStart(2, "0");
+  return <span aria-label="Elapsed">{`${mm}:${ss}`}</span>;
+}

--- a/apps/build/src/features/launch/hooks/use-project-detail.test.ts
+++ b/apps/build/src/features/launch/hooks/use-project-detail.test.ts
@@ -329,6 +329,45 @@ describe("useProjectDetail", () => {
     );
   });
 
+  it("keeps the CI run link when the first poll already reports failure", async () => {
+    vi.mocked(launchPreflight).mockResolvedValue({
+      projectId: 7,
+      sourceRef: "abc1234",
+      apps: ["my-bot"],
+    } as never);
+    vi.mocked(deploymentRequiredSecrets).mockResolvedValue({ byApp: {} });
+    vi.mocked(launchDeploy).mockResolvedValue({
+      deployment: { id: "dep_1" },
+      releaseTags: ["my-bot-r1"],
+      apps: ["my-bot"],
+    } as never);
+    // `waitForDeploymentReady` throws on a terminal status *before* it reports
+    // progress, so the url has to be captured at the poll, not in onProgress.
+    vi.mocked(launchStatus).mockResolvedValue({
+      state: "failed",
+      releaseTags: [],
+      message: "Deploy CI failed.",
+      ci: { url: "https://github.com/a/b/actions/runs/1" },
+    } as never);
+
+    const { result } = renderHook(() => useProjectDetail(7), {
+      wrapper: wrapper(),
+    });
+    await waitFor(() => expect(result.current.source?.id).toBe(7));
+
+    await act(async () => {
+      await result.current.redeploySource();
+    });
+
+    await waitFor(() =>
+      expect(result.current.deployFlow).toMatchObject({
+        phase: "error",
+        message: "Deploy CI failed.",
+        progress: { ciUrl: "https://github.com/a/b/actions/runs/1" },
+      }),
+    );
+  });
+
   it("keeps a candidate release's 409 requirements visible and editable", async () => {
     vi.mocked(launchPreflight).mockResolvedValue({
       projectId: 7,

--- a/apps/build/src/features/launch/hooks/use-project-detail.ts
+++ b/apps/build/src/features/launch/hooks/use-project-detail.ts
@@ -43,6 +43,11 @@ import type {
 import { isRetryableLaunchError } from "@aomi-labs/deploy/launch";
 import { useGitHubSession } from "@build/components/control-plane/github-session-context";
 import {
+  ciProgress,
+  stageProgress,
+  type DeployFlowProgress,
+} from "@build/features/launch/components/deployments/deploy-flow-progress";
+import {
   buildQueryKeys,
   buildQueryStaleTime,
   githubAccountKey,
@@ -51,11 +56,11 @@ import {
 /** Progress of an in-flight linked-source redeploy (deploy → CI → activate). */
 export type DeployFlowState =
   | { phase: "idle" }
-  | { phase: "deploying"; message: string }
-  | { phase: "building"; message: string }
-  | { phase: "activating"; message: string }
-  | { phase: "done"; message: string }
-  | { phase: "error"; message: string };
+  | { phase: "deploying"; message: string; progress?: DeployFlowProgress }
+  | { phase: "building"; message: string; progress?: DeployFlowProgress }
+  | { phase: "activating"; message: string; progress?: DeployFlowProgress }
+  | { phase: "done"; message: string; progress?: DeployFlowProgress }
+  | { phase: "error"; message: string; progress?: DeployFlowProgress };
 
 const DEPLOY_POLL_MS = 4000;
 const DEPLOYMENT_READY_TIMEOUT_MS = 8 * 60 * 1000;
@@ -251,6 +256,8 @@ export function useProjectDetail(projectId: number) {
   const [deployFlow, setDeployFlow] = useState<DeployFlowState>({
     phase: "idle",
   });
+  /** Epoch ms the current deploy started, for the progress bar's clock. */
+  const [deployStartedAt, setDeployStartedAt] = useState<number | null>(null);
   const historyReq = useRef(false);
   const secretsReq = useRef<Set<number>>(new Set());
   const recordsReq = useRef(false);
@@ -304,6 +311,7 @@ export function useProjectDetail(projectId: number) {
     gateMissingSecretsRef.current = {};
     setRequiredSecretsError(null);
     setDeployFlow({ phase: "idle" });
+    setDeployStartedAt(null);
     deployAbortRef.current?.abort();
     deployAbortRef.current = null;
   }, [projectId]);
@@ -613,10 +621,17 @@ export function useProjectDetail(projectId: number) {
       deployAbortRef.current = null;
       return;
     }
+    const startedAt = Date.now();
+    setDeployStartedAt(startedAt);
+    // CI progress is monotonic within one deploy: a transient `no_ci`/`failed`
+    // poll reports the last completed step rather than snapping the bar back.
+    let lastCompleted = 0;
+    let ciUrl: string | null = null;
     try {
       setDeployFlow({
         phase: "deploying",
         message: "Resolving latest commit…",
+        progress: stageProgress("deploying", "Resolving commit"),
       });
       const pre = await launchPreflight({
         repo,
@@ -637,7 +652,11 @@ export function useProjectDetail(projectId: number) {
       if (!pre.sourceRef) {
         throw new Error("Preflight did not return an immutable source commit.");
       }
-      setDeployFlow({ phase: "deploying", message: "Deploying new version…" });
+      setDeployFlow({
+        phase: "deploying",
+        message: "Deploying new version…",
+        progress: stageProgress("deploying", "Dispatching build"),
+      });
       const deployed = await launchDeploy({
         projectId: targetProjectId,
         sourceRef: pre.sourceRef,
@@ -659,10 +678,14 @@ export function useProjectDetail(projectId: number) {
             releaseTags = status.releaseTags?.length
               ? status.releaseTags
               : releaseTags;
+            const { model, progress } = ciProgress(status, lastCompleted);
+            lastCompleted = model.completed;
+            ciUrl = progress.ciUrl ?? ciUrl;
             if (status.state !== "ready") {
               setDeployFlow({
                 phase: "building",
                 message: `Building… (${status.state})`,
+                progress: { ...progress, ciUrl },
               });
             }
           },
@@ -671,7 +694,11 @@ export function useProjectDetail(projectId: number) {
       releaseTags = ready.releaseTags?.length ? ready.releaseTags : releaseTags;
       if (!isCurrent()) return;
 
-      setDeployFlow({ phase: "activating", message: "Activating release…" });
+      setDeployFlow({
+        phase: "activating",
+        message: "Activating release…",
+        progress: stageProgress("activating", "Activating release", ciUrl),
+      });
       // Activate the SAME project the deploy targeted — `targetProjectId`
       // is preflight-resolved and can differ from the page's `projectId`.
       const activated = await launchActivate({
@@ -689,6 +716,7 @@ export function useProjectDetail(projectId: number) {
         setDeployFlow({
           phase: "error",
           message: failed?.error ?? "Activation was not accepted.",
+          progress: stageProgress("activating", "Activation failed", ciUrl),
         });
         return;
       }
@@ -696,6 +724,7 @@ export function useProjectDetail(projectId: number) {
         setDeployFlow({
           phase: "error",
           message: "Activation returned no application statuses.",
+          progress: stageProgress("activating", "Activation failed", ciUrl),
         });
         return;
       }
@@ -704,6 +733,7 @@ export function useProjectDetail(projectId: number) {
         setDeployFlow({
           phase: "activating",
           message: "Loading app runtime…",
+          progress: stageProgress("activating", "Loading app runtime", ciUrl),
         });
         try {
           await waitForAppsToLoad(
@@ -722,6 +752,11 @@ export function useProjectDetail(projectId: number) {
                   setDeployFlow({
                     phase: "activating",
                     message: `Loading app runtime… (${ready}/${total})`,
+                    progress: stageProgress(
+                      "activating",
+                      `Loading app runtime (${ready}/${total})`,
+                      ciUrl,
+                    ),
                   });
                 }
               },
@@ -733,7 +768,11 @@ export function useProjectDetail(projectId: number) {
         }
         if (!isCurrent()) return;
       }
-      setDeployFlow({ phase: "done", message: "New version is live." });
+      setDeployFlow({
+        phase: "done",
+        message: "New version is live.",
+        progress: stageProgress("done", "Live", ciUrl),
+      });
       await reload();
       if (!isCurrent()) return;
       refreshRecords();
@@ -748,6 +787,7 @@ export function useProjectDetail(projectId: number) {
           : err instanceof Error
             ? err.message
             : "Deploy failed",
+        progress: { percent: 100, label: "Deploy failed", ciUrl },
       });
     } finally {
       if (deployAbortRef.current === controller) deployAbortRef.current = null;
@@ -791,6 +831,7 @@ export function useProjectDetail(projectId: number) {
     requiredSecretsError,
     requiredSecretsRetryable,
     deployFlow,
+    deployStartedAt,
     loadHistory,
     loadSecrets,
     loadRequiredSecrets,

--- a/apps/build/src/features/launch/hooks/use-project-detail.ts
+++ b/apps/build/src/features/launch/hooks/use-project-detail.ts
@@ -667,7 +667,14 @@ export function useProjectDetail(projectId: number) {
       let releaseTags = deployed.releaseTags;
       const apps = deployed.apps;
       const ready = await waitForDeploymentReady(
-        () => launchStatus(deploymentId, projectPlatform),
+        // Read the CI url here, not in `onProgress`: the watcher throws on a
+        // `failed`/`no_ci` status *before* reporting progress, and that poll is
+        // exactly the one whose run link the failure banner needs.
+        async () => {
+          const status = await launchStatus(deploymentId, projectPlatform);
+          ciUrl = status.ci?.url ?? ciUrl;
+          return status;
+        },
         {
           signal: controller.signal,
           intervalMs: DEPLOY_POLL_MS,
@@ -680,7 +687,6 @@ export function useProjectDetail(projectId: number) {
               : releaseTags;
             const { model, progress } = ciProgress(status, lastCompleted);
             lastCompleted = model.completed;
-            ciUrl = progress.ciUrl ?? ciUrl;
             if (status.state !== "ready") {
               setDeployFlow({
                 phase: "building",

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -2,6 +2,28 @@
 
 ## Last Updated
 
+2026-08-24 — CI PROGRESS BAR ON THE DEPLOYMENTS TAB (branch
+  `feat/deploy-ci-progress-bar`). Importing/redeploying an app from a linked
+  repository showed one static line ("Building… (building)") for the whole
+  2–4 minute CI build: no bar, no elapsed clock, no link to the run. The
+  onboarding deploy step already drew a bar from `deploymentProgress`; the
+  project deployments tab never used it.
+  - New `deploy-flow-progress.ts` maps CI state onto a whole-pipeline percent
+    (deploy 4% → CI 12–78% → activate 96% → live 100%), monotonic across a
+    transient `no_ci`/`failed` poll, and carries `ci.url` forward.
+  - `DeployFlowState` variants now carry an optional `progress`; the hook also
+    exposes `deployStartedAt`. `redeploySource` sets progress at every stage,
+    including both activation-failure branches and the catch.
+  - New `ui/deploy-progress-bar.tsx` renders the message, percent, mm:ss
+    elapsed, a "CI run" link, and an accessible `role="progressbar"`; error
+    turns the bar red and drops the percent. Replaces the old text-only line.
+  - Verification: 120 deployments tests + 12 hook tests pass, `pnpm type-check`
+    clean, `pnpm lint` clean (3 pre-existing warnings). NOT visually verified in
+    a browser — the bar only renders during a live deploy against a real
+    backend, which is not reproducible locally.
+  Untouched: the diverged `apps/portal` copy of the deployments tab, and the
+  onboarding deploy step's own bar.
+
 2026-08-22 — WALLET/USER-STATE CONTRACT DESLOP (branch
   `claude/multi-wallet-cli-366238`, working tree only, not committed). The FE
   now speaks the backend canon: wire key `svm` is canonical (`solana` stays an

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -14,6 +14,11 @@
   - `DeployFlowState` variants now carry an optional `progress`; the hook also
     exposes `deployStartedAt`. `redeploySource` sets progress at every stage,
     including both activation-failure branches and the catch.
+  - The CI url is captured at the poll callback, not in `onProgress`:
+    `waitForDeploymentReady` throws on a terminal `failed`/`no_ci` status
+    before reporting progress, so a build that fails on its first poll would
+    otherwise reach the catch with `ciUrl: null` and lose the run link exactly
+    when it matters. Pinned by a hook test.
   - New `ui/deploy-progress-bar.tsx` renders the message, percent, mm:ss
     elapsed, a "CI run" link, and an accessible `role="progressbar"`; error
     turns the bar red and drops the percent. Replaces the old text-only line.


### PR DESCRIPTION
## Problem

On the project → Deployments tab, deploying or importing an app from a linked repository showed a **single static line** for the entire pipeline — `Building… (building)` — with no bar, no elapsed time, and no link to the CI run. GitHub Actions takes 2–4 minutes, so the longest wait in the product had the least feedback and read as a hang.

The onboarding deploy step already draws a bar from `deploymentProgress`; the project deployments tab simply never used it.

## Change

- **`deploy-flow-progress.ts`** (new, pure): maps CI state onto a whole-pipeline percent — deploy 4% → CI 12–78% → activate 96% → live 100%. Monotonic across a transient `no_ci`/`failed` poll (it holds the last completed step instead of snapping backwards) and carries `status.ci.url` forward into the later stages.
- **`use-project-detail.ts`**: `DeployFlowState` variants carry an optional `progress`, and the hook exposes `deployStartedAt` for the clock. `redeploySource` sets progress at every stage, including both activation-failure branches and the catch — so a failed deploy is one click from its CI log.
- **`ui/deploy-progress-bar.tsx`** (new): renders the message, percent, `mm:ss` elapsed, a "CI run" link, and an accessible `role="progressbar"`. Failure turns the bar red and drops the percentage. Replaces the old text-only status line in the deployments tab.

## Verification

- 120 deployments-component tests + 12 hook tests pass (13 new assertions across 3 files).
- `pnpm type-check` clean; `pnpm lint` clean (3 pre-existing warnings unrelated to this change).
- **Not** visually verified in a browser: the bar only renders during a live deploy against a real backend, which isn't reproducible locally.

## Out of scope

The diverged `apps/portal` copy of the deployments tab, and the onboarding deploy step's own existing bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/529"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790170173&installation_model_id=12362&pr_number=529&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F529&signature=959b2638147dd53258d2cd1b59abb107eb6fc19f26bcb30a43bb210e75ff0b24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->