### PR TITLE
Fix Agent chat ordering, terminal drain, and tool traces

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -1,5 +1,15 @@
 # Canonical Landing
 
+Current session goal: **CLI AGENT CHAT AUTH, ORDER, AND TOOL TRACES VERIFIED
+2026-08-31** — anonymous Agent and Pipeline calls now receive a guest bearer
+even while additive account auth is configured, the CLI persists that guest
+identity across processes, and resumed chats skip prior-turn output. Current
+wire-format `message` tool results render in both React and verbose CLI output
+without duplicating future typed tool events. Device-only OAuth registration no
+longer declares an unused redirect flow. Client and React builds, typecheck,
+lint, formatting, 259 focused package tests, 44 Rust runtime tests, and repeated
+live staging CLI tool calls pass with message, tool, answer, and terminal order.
+
 Current session goal: **GUEST SELF-CUSTODY API AND SDK FIXES VERIFIED
 2026-08-30** — guest Agent sessions can resolve their own staged actions and
 guest Pipeline sessions can execute self-custodial operations without gaining

--- a/GOAL.md
+++ b/GOAL.md
@@ -11,6 +11,14 @@ and API catalog routes backed by api-server. Client/account/Portal typechecks,
 scoped lint, the client build, 431 tests, and a live staging guest Agent plus
 Pipeline catalog smoke pass.
 
+Current session goal: **LEGACY AGENT TOOL TRACE PROJECTION VERIFIED
+2026-08-30** — React now projects the Agent ledger's current tool-bearing
+`message` events into Assistant UI tool-call parts with the backend tool name,
+arguments, and parsed result. Typed `tool_complete` events take precedence for
+the turn, so the compatibility path does not duplicate traces after the backend
+cutover. Focused React tests, library typecheck, lint, formatting, build, and
+package dry-run inspection pass.
+
 Current session goal: **PRIVY LOGIN POLICY DRIFT FIXED 2026-08-30** — the
 portal no longer hard-codes login methods into Privy's modal. The Privy app
 configuration is now the single authority, so disabled providers such as

--- a/apps/portal/src/components/shell/portal-aomi-frame.tsx
+++ b/apps/portal/src/components/shell/portal-aomi-frame.tsx
@@ -191,6 +191,11 @@ export function PortalAomiFrame() {
         backendUrl={backendUrl}
         applicationId={lockedApplicationId}
         accountSessionAvailable={Boolean(accountUser)}
+        // Scope the remembered thread to the signed-in principal so a
+        // sign-out (or a different account) never restores another
+        // principal's thread id, which the backend rejects with
+        // session_not_found.
+        threadPersistenceScope={accountUserId ?? "guest"}
         showSidebar={!lockedApp}
         walletPosition="footer"
         walletFamilies={["evm", "solana"]}

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aomi-labs/client",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Platform-agnostic TypeScript client for the Aomi backend API",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/client/src/agent/types.ts
+++ b/packages/client/src/agent/types.ts
@@ -2,9 +2,30 @@ import type { components } from "../generated/agent-v1/types";
 
 type Schemas = components["schemas"];
 
-export type Event = Schemas["ConcreteEvent"];
-export type EventPage = Schemas["EventPage"];
-export type MessageEvent = Schemas["MessageEvent"];
+type GeneratedMessageEvent = Schemas["MessageEvent"];
+
+/**
+ * The recorder bridges INLINE (sync-executed) tool steps as agent `message` events
+ * carrying these fields; typed `tool_update`/`tool_complete` events cover
+ * only the async path. The backend's OpenAPI contract does not declare them
+ * yet, so they are added to the consumer shape here — one honest type
+ * instead of every consumer duck-typing the wire.
+ */
+export type MessageEvent = GeneratedMessageEvent & {
+  /** `[topic, payload]`: human topic label plus the tool's JSON (or plain-text) result. */
+  tool_result?: [topic: string, payload: string] | null;
+  /** Canonical tool name; consumers fall back to `topic` when absent. */
+  tool_name?: string | null;
+  /** Tool call arguments, when the recorder attaches them. */
+  tool_arguments?: unknown;
+};
+
+export type Event =
+  | Exclude<Schemas["ConcreteEvent"], GeneratedMessageEvent>
+  | MessageEvent;
+export type EventPage = Omit<Schemas["EventPage"], "events"> & {
+  events: Event[];
+};
 export type TurnStateChangedEvent = Schemas["TurnStateChangedEvent"];
 export type ToolUpdateEvent = Schemas["ToolUpdateEvent"];
 export type ToolCompleteEvent = Schemas["ToolCompleteEvent"];

--- a/packages/client/src/cli/cli-session.ts
+++ b/packages/client/src/cli/cli-session.ts
@@ -25,6 +25,10 @@ import { createCliPaymentFetch, type CliPaymentListener } from "./payment";
 import type { AomiOAuthTokenProvider } from "../authorization";
 import { signInWithOAuthDevice } from "./oauth-device-auth";
 import { wrapFetchWithPublicApiAuthorization } from "../client";
+import {
+  createGuestSessionProvider,
+  type GuestSessionProvider,
+} from "../guest-auth";
 import { cliActionCapabilities } from "./action-capabilities";
 
 export class CliSession {
@@ -92,14 +96,16 @@ export class CliSession {
       }
     }
 
+    const baseUrl = config.baseUrl ?? seed?.baseUrl ?? DEFAULT_CLI_BASE_URL;
     const state: CliSessionState = {
       sessionId,
       clientId: crypto.randomUUID(),
-      baseUrl: config.baseUrl ?? seed?.baseUrl ?? DEFAULT_CLI_BASE_URL,
+      baseUrl,
       app: config.app ?? seed?.app,
       model: config.model ?? seed?.model,
       apiKey: config.apiKey ?? seed?.apiKey,
       accountBearer: config.accountBearer ?? seed?.accountBearer,
+      guestBearer: baseUrl === seed?.baseUrl ? seed.guestBearer : undefined,
       publicKey: config.publicKey ?? seed?.publicKey,
       privateKey: seed?.privateKey,
       svmPublicKey: svmPublicKey ?? seed?.svmPublicKey,
@@ -185,6 +191,7 @@ export class CliSession {
 
     if (config.baseUrl !== undefined && config.baseUrl !== this.state.baseUrl) {
       this.state.baseUrl = config.baseUrl;
+      delete this.state.guestBearer;
       changed = true;
     }
     if (config.app !== undefined && config.app !== this.state.app) {
@@ -266,6 +273,7 @@ export class CliSession {
   }
 
   setBaseUrl(url: string): void {
+    if (url !== this.state.baseUrl) delete this.state.guestBearer;
     this.state.baseUrl = url;
     this.save();
   }
@@ -403,7 +411,9 @@ export class CliSession {
         fetch: paymentFetch,
         getAccountBearer: createCliAuthTokenProvider(() => this.state),
         oauth: paymentFetch ? undefined : oauth,
-        guest: false,
+        // Account auth remains additive for control routes. Public Agent and
+        // Pipeline requests still need a guest bearer until the user logs in.
+        guest: oauth ? false : this.createGuestProvider(fetch),
       },
       {
         sessionId: this.state.sessionId,
@@ -420,6 +430,33 @@ export class CliSession {
       },
     );
     return session;
+  }
+
+  createGuestProvider(fetchImpl: typeof fetch): GuestSessionProvider {
+    const guest = createGuestSessionProvider({
+      baseUrl: this.state.baseUrl,
+      fetch: fetchImpl,
+    });
+    const provider = async (options?: { forceRefresh?: boolean }) => {
+      if (!options?.forceRefresh && this.state.guestBearer) {
+        return this.state.guestBearer;
+      }
+      const credential = await guest(options);
+      if (credential && credential !== this.state.guestBearer) {
+        this.state.guestBearer = credential;
+        this.save();
+      }
+      return credential;
+    };
+    return Object.assign(provider, {
+      clear: () => {
+        guest.clear();
+        if (this.state.guestBearer) {
+          delete this.state.guestBearer;
+          this.save();
+        }
+      },
+    });
   }
 
   createOAuthProvider(

--- a/packages/client/src/cli/cli-session.ts
+++ b/packages/client/src/cli/cli-session.ts
@@ -432,17 +432,30 @@ export class CliSession {
     return session;
   }
 
-  createGuestProvider(fetchImpl: typeof fetch): GuestSessionProvider {
+  createGuestProvider(
+    fetchImpl: typeof fetch,
+    baseUrl?: string,
+  ): GuestSessionProvider {
+    const targetBaseUrl = baseUrl ?? this.state.baseUrl;
+    // The persisted guest bearer was minted for the persisted base URL; only
+    // reuse (or overwrite) it when this provider targets the same origin, so
+    // a --backend-url override never sends or clobbers another origin's
+    // credential.
+    const canUsePersisted = targetBaseUrl === this.state.baseUrl;
     const guest = createGuestSessionProvider({
-      baseUrl: this.state.baseUrl,
+      baseUrl: targetBaseUrl,
       fetch: fetchImpl,
     });
     const provider = async (options?: { forceRefresh?: boolean }) => {
-      if (!options?.forceRefresh && this.state.guestBearer) {
+      if (!options?.forceRefresh && canUsePersisted && this.state.guestBearer) {
         return this.state.guestBearer;
       }
       const credential = await guest(options);
-      if (credential && credential !== this.state.guestBearer) {
+      if (
+        canUsePersisted &&
+        credential &&
+        credential !== this.state.guestBearer
+      ) {
         this.state.guestBearer = credential;
         this.save();
       }
@@ -451,7 +464,7 @@ export class CliSession {
     return Object.assign(provider, {
       clear: () => {
         guest.clear();
-        if (this.state.guestBearer) {
+        if (canUsePersisted && this.state.guestBearer) {
           delete this.state.guestBearer;
           this.save();
         }

--- a/packages/client/src/cli/commands/chat.ts
+++ b/packages/client/src/cli/commands/chat.ts
@@ -6,12 +6,14 @@ import {
   getToolNameFromEvent,
   getToolResultFromEvent,
   isAlwaysVisibleTool,
+  legacyToolResultFromMessage,
   printNewAgentMessages,
   printPaymentEvent,
   printTaskActivity,
   printTaskCompleted,
   printTaskStarted,
   printToolComplete,
+  printToolResultLine,
 } from "../output";
 import {
   applyRequestedModelIfPresent,
@@ -21,6 +23,7 @@ import { fatal } from "../errors";
 import type { CliConfig } from "../types";
 import { parseSolanaKeypairSecret } from "../solana-signer";
 import type { ClientSession } from "../../session";
+import type { Event, MessageEvent } from "../../agent/types";
 
 const STOPPED_TURN_STATES = new Set([
   "awaiting_action",
@@ -64,6 +67,20 @@ export function resolveSvmAddressForChat(
   return deriveSvmAddress(solanaPrivateKey) ?? persistedSvmAddress;
 }
 
+export function printBoundaryForTurn(
+  events: readonly Event[],
+  messages: readonly MessageEvent[],
+  turnId: string | undefined,
+) {
+  const firstTurnEvent = events.find((event) => event.turn_id === turnId);
+  return {
+    handledSequence: firstTurnEvent ? firstTurnEvent.sequence - 1 : 0,
+    printedAgentCount: messages.filter(
+      (message) => message.sender === "agent" && message.turn_id !== turnId,
+    ).length,
+  };
+}
+
 export async function chatCommand(
   config: CliConfig,
   message: string,
@@ -88,6 +105,8 @@ export async function chatCommand(
     let handledSequence = 0;
     let thinkingPrinted = false;
     const agentLabels = new Map<string, string>();
+    const legacyToolTurns = new Set<string>();
+    const typedToolTurns = new Set<string>();
     const render = () => {
       const snapshot = session.getSnapshot();
       if (
@@ -102,8 +121,28 @@ export async function chatCommand(
         if (event.sequence <= handledSequence) continue;
         handledSequence = event.sequence;
         if (event.type === "tool_complete") {
+          const turnId = event.turn_id ?? `event:${event.event_id}`;
+          typedToolTurns.add(turnId);
           const name = getToolNameFromEvent(event);
-          if (verbose || isAlwaysVisibleTool(name)) printToolComplete(event);
+          if (
+            !legacyToolTurns.has(turnId) &&
+            (verbose || isAlwaysVisibleTool(name))
+          ) {
+            printToolComplete(event);
+          }
+        } else if (event.type === "message") {
+          const tool = legacyToolResultFromMessage(event);
+          if (tool) {
+            legacyToolTurns.add(tool.turnId);
+            if (
+              !typedToolTurns.has(tool.turnId) &&
+              (verbose || isAlwaysVisibleTool(tool.name))
+            ) {
+              printToolResultLine(tool.name, tool.result);
+            }
+          } else if (verbose && event.sender === "notice") {
+            console.log(`${YELLOW}📢 ${event.content}${RESET}`);
+          }
         } else if (verbose && event.type === "task_started") {
           agentLabels.set(event.agent_id, event.label || event.agent_id);
           printTaskStarted(event);
@@ -112,8 +151,6 @@ export async function chatCommand(
         } else if (verbose && event.type === "task_completed") {
           printTaskCompleted(event, agentLabels.get(event.agent_id));
           agentLabels.delete(event.agent_id);
-        } else if (verbose && event.type === "message" && event.sender === "notice") {
-          console.log(`${YELLOW}📢 ${event.content}${RESET}`);
         } else if (verbose && event.type === "error") {
           console.log(`\x1b[31m❌ ${event.message}${RESET}`);
         }
@@ -125,23 +162,19 @@ export async function chatCommand(
         );
       }
     };
-    const unsubscribe = session.subscribe(render);
-
-    await session.sendAsync(message);
-    render();
-
-    const allMessages = session.getSnapshot().messages;
-    let seedIdx = allMessages.length;
-    for (let i = allMessages.length - 1; i >= 0; i--) {
-      if (allMessages[i].sender === "user") {
-        seedIdx = i;
-        break;
-      }
+    if (verbose) {
+      thinkingPrinted = true;
+      console.log(`${DIM}⏳ Thinking…${RESET}`);
     }
-
-    printedAgentCount = allMessages
-      .slice(0, seedIdx)
-      .filter((entry) => entry.sender === "agent").length;
+    await session.sendAsync(message);
+    const boundary = printBoundaryForTurn(
+      session.getSnapshot().events,
+      session.getSnapshot().messages,
+      session.getSnapshot().turnId,
+    );
+    handledSequence = boundary.handledSequence;
+    printedAgentCount = boundary.printedAgentCount;
+    const unsubscribe = session.subscribe(render);
     render();
     await waitForTurnStop(session);
     render();
@@ -176,8 +209,7 @@ export async function chatCommand(
     if (!verbose) {
       const agentMessages = session
         .getSnapshot()
-        .messages
-        .filter((entry) => entry.sender === "agent");
+        .messages.filter((entry) => entry.sender === "agent");
       const last = agentMessages[agentMessages.length - 1];
 
       if (last?.content) {

--- a/packages/client/src/cli/commands/chat.ts
+++ b/packages/client/src/cli/commands/chat.ts
@@ -6,7 +6,7 @@ import {
   getToolNameFromEvent,
   getToolResultFromEvent,
   isAlwaysVisibleTool,
-  legacyToolResultFromMessage,
+  inlineToolResultFromMessage,
   printNewAgentMessages,
   printPaymentEvent,
   printTaskActivity,
@@ -105,8 +105,12 @@ export async function chatCommand(
     let handledSequence = 0;
     let thinkingPrinted = false;
     const agentLabels = new Map<string, string>();
-    const legacyToolTurns = new Set<string>();
-    const typedToolTurns = new Set<string>();
+    // One printed line per (turn, tool) pair, whichever wire shape lands
+    // first. Suppressing by turn alone silently drops a distinct tool's only
+    // trace whenever another tool in the turn used the other shape.
+    const seenToolPairs = new Set<string>();
+    const toolPairKey = (turnId: string, name: string) =>
+      `${turnId}::${name}`;
     const render = () => {
       const snapshot = session.getSnapshot();
       if (
@@ -121,23 +125,23 @@ export async function chatCommand(
         if (event.sequence <= handledSequence) continue;
         handledSequence = event.sequence;
         if (event.type === "tool_complete") {
-          const turnId = event.turn_id ?? `event:${event.event_id}`;
-          typedToolTurns.add(turnId);
           const name = getToolNameFromEvent(event);
-          if (
-            !legacyToolTurns.has(turnId) &&
-            (verbose || isAlwaysVisibleTool(name))
-          ) {
+          // Subagent lifecycles print through the task_* lines, not as tools.
+          if (name === "task") continue;
+          const turnId = event.turn_id ?? `event:${event.event_id}`;
+          const pair = toolPairKey(turnId, name);
+          const firstForPair = !seenToolPairs.has(pair);
+          seenToolPairs.add(pair);
+          if (firstForPair && (verbose || isAlwaysVisibleTool(name))) {
             printToolComplete(event);
           }
         } else if (event.type === "message") {
-          const tool = legacyToolResultFromMessage(event);
+          const tool = inlineToolResultFromMessage(event);
           if (tool) {
-            legacyToolTurns.add(tool.turnId);
-            if (
-              !typedToolTurns.has(tool.turnId) &&
-              (verbose || isAlwaysVisibleTool(tool.name))
-            ) {
+            const pair = toolPairKey(tool.turnId, tool.name);
+            const firstForPair = !seenToolPairs.has(pair);
+            seenToolPairs.add(pair);
+            if (firstForPair && (verbose || isAlwaysVisibleTool(tool.name))) {
               printToolResultLine(tool.name, tool.result);
             }
           } else if (verbose && event.sender === "notice") {

--- a/packages/client/src/cli/commands/history.ts
+++ b/packages/client/src/cli/commands/history.ts
@@ -4,6 +4,7 @@ import {
   DIM,
   RESET,
   YELLOW,
+  countToolCalls,
   formatLogContent,
   printDataFileLocation,
 } from "../output";
@@ -26,9 +27,7 @@ export async function logCommand(config: CliConfig): Promise<void> {
     const snapshot = session.getSnapshot();
     const messages = snapshot.messages;
     const actions = snapshot.actions;
-    const toolCalls = snapshot.events.filter(
-      (event) => event.type === "tool_complete",
-    ).length;
+    const toolCalls = countToolCalls(snapshot.events);
     const tokenCountEstimate = estimateTokenCount(messages);
     const topic = snapshot.title ?? "Untitled Session";
 

--- a/packages/client/src/cli/commands/sessions.ts
+++ b/packages/client/src/cli/commands/sessions.ts
@@ -1,7 +1,12 @@
 import { AomiClient } from "../../client";
 import { CliSession } from "../cli-session";
 import { fatal } from "../errors";
-import { RESET, YELLOW, printDataFileLocation } from "../output";
+import {
+  RESET,
+  YELLOW,
+  countToolCalls,
+  printDataFileLocation,
+} from "../output";
 import {
   deleteStoredSession,
   listStoredSessions,
@@ -42,8 +47,7 @@ async function fetchRemoteSessionStats(
           : "Untitled Session",
       messageCount: messages.length,
       tokenCountEstimate: estimateTokenCount(messages),
-      toolCalls: page.events.filter((event) => event.type === "tool_complete")
-        .length,
+      toolCalls: countToolCalls(page.events),
       pendingActions: page.events.filter(
         (event) => event.type === "action" && event.state === "pending",
       ).length,

--- a/packages/client/src/cli/context.ts
+++ b/packages/client/src/cli/context.ts
@@ -41,7 +41,7 @@ export function createControlClient(
     // inside that wrapper so a newly-added Payment-Signature is authorized
     // again with payments:submit instead of reusing the narrower first token.
     oauth: paymentFetch ? undefined : oauth,
-    guest: oauth ? false : (cli?.createGuestProvider(fetch) ?? true),
+    guest: oauth ? false : (cli?.createGuestProvider(fetch, baseUrl) ?? true),
     getAccountBearer:
       createCliGetAccountBearer(config) ??
       createCliAuthTokenProvider(() => readState() ?? {}),

--- a/packages/client/src/cli/context.ts
+++ b/packages/client/src/cli/context.ts
@@ -41,7 +41,7 @@ export function createControlClient(
     // inside that wrapper so a newly-added Payment-Signature is authorized
     // again with payments:submit instead of reusing the narrower first token.
     oauth: paymentFetch ? undefined : oauth,
-    guest: false,
+    guest: oauth ? false : (cli?.createGuestProvider(fetch) ?? true),
     getAccountBearer:
       createCliGetAccountBearer(config) ??
       createCliAuthTokenProvider(() => readState() ?? {}),

--- a/packages/client/src/cli/oauth-device-auth.ts
+++ b/packages/client/src/cli/oauth-device-auth.ts
@@ -34,10 +34,8 @@ export async function signInWithOAuthDevice(input: {
           headers: { "content-type": "application/json" },
           body: JSON.stringify({
             client_name: "Aomi CLI",
-            redirect_uris: ["http://127.0.0.1"],
             token_endpoint_auth_method: "none",
             grant_types: [DEVICE_GRANT, "refresh_token"],
-            response_types: ["code"],
             resources: [input.resource],
             scope: input.scopes.join(" "),
           }),

--- a/packages/client/src/cli/output.ts
+++ b/packages/client/src/cli/output.ts
@@ -1,4 +1,5 @@
 import type {
+  Event,
   MessageEvent,
   TaskActivityEvent,
   TaskCompletedEvent,
@@ -32,6 +33,49 @@ export function printJson(value: unknown): void {
 }
 
 type ToolEvent = ToolUpdateEvent | ToolCompleteEvent;
+
+export type LegacyToolResult = {
+  name: string;
+  result: string;
+  turnId: string;
+};
+
+type ToolBearingMessageEvent = MessageEvent & {
+  tool_name?: unknown;
+  tool_result?: unknown;
+};
+
+export function legacyToolResultFromMessage(
+  event: MessageEvent,
+): LegacyToolResult | null {
+  const message = event as ToolBearingMessageEvent;
+  const raw = message.tool_result;
+  if (!Array.isArray(raw) || raw.length < 2) return null;
+  const [topic, result] = raw;
+  if (typeof topic !== "string" || typeof result !== "string") return null;
+  return {
+    name:
+      typeof message.tool_name === "string" && message.tool_name.length > 0
+        ? message.tool_name
+        : topic,
+    result,
+    turnId: event.turn_id ?? `event:${event.event_id}`,
+  };
+}
+
+export function countToolCalls(events: readonly Event[]): number {
+  const typedToolTurns = new Set(
+    events
+      .filter((event) => event.type === "tool_complete")
+      .map((event) => event.turn_id ?? `event:${event.event_id}`),
+  );
+  return events.filter((event) => {
+    if (event.type === "tool_complete") return true;
+    if (event.type !== "message") return false;
+    const tool = legacyToolResultFromMessage(event);
+    return tool !== null && !typedToolTurns.has(tool.turnId);
+  }).length;
+}
 
 export function printToolComplete(event: ToolEvent): void {
   const name = getToolNameFromEvent(event);
@@ -68,16 +112,13 @@ export function printTaskCompleted(
 
 /** `tool_call` → tool name, `note` → note text. Truncated for one-line output. */
 export function formatTaskActivity(event: TaskActivityEvent): string {
-  const raw =
-    event.kind === "note" ? event.text : event.tool_name;
+  const raw = event.kind === "note" ? event.text : event.tool_name;
   const normalized = raw.replace(/\s+/g, " ").trim();
   if (normalized.length <= TASK_LINE_MAX) return normalized;
   return `${normalized.slice(0, TASK_LINE_MAX)}…`;
 }
 
-export function formatTaskCompletionStats(
-  event: TaskCompletedEvent,
-): string {
+export function formatTaskCompletionStats(event: TaskCompletedEvent): string {
   const steps = event.steps;
   const seconds = (event.duration_ms / 1000).toFixed(1);
   return `${steps} ${steps === 1 ? "step" : "steps"}, ${seconds}s`;
@@ -122,9 +163,7 @@ export function getToolNameFromEvent(event: ToolEvent): string {
   return event.tool_name;
 }
 
-export function getToolResultFromEvent(
-  event: ToolEvent,
-): string | undefined {
+export function getToolResultFromEvent(event: ToolEvent): string | undefined {
   return typeof event.result === "string"
     ? event.result
     : JSON.stringify(event.result);
@@ -154,7 +193,9 @@ export function printNewAgentMessages(
   messages: readonly MessageEvent[],
   lastPrintedCount: number,
 ): number {
-  const agentMessages = messages.filter((message) => message.sender === "agent");
+  const agentMessages = messages.filter(
+    (message) => message.sender === "agent",
+  );
 
   let handled = lastPrintedCount;
   for (let i = lastPrintedCount; i < agentMessages.length; i++) {

--- a/packages/client/src/cli/output.ts
+++ b/packages/client/src/cli/output.ts
@@ -34,29 +34,25 @@ export function printJson(value: unknown): void {
 
 type ToolEvent = ToolUpdateEvent | ToolCompleteEvent;
 
-export type LegacyToolResult = {
+export type InlineToolResult = {
   name: string;
   result: string;
   turnId: string;
 };
 
-type ToolBearingMessageEvent = MessageEvent & {
-  tool_name?: unknown;
-  tool_result?: unknown;
-};
-
-export function legacyToolResultFromMessage(
+export function inlineToolResultFromMessage(
   event: MessageEvent,
-): LegacyToolResult | null {
-  const message = event as ToolBearingMessageEvent;
-  const raw = message.tool_result;
+): InlineToolResult | null {
+  // The fields are declared on MessageEvent, but the wire is still untrusted
+  // input — validate before use.
+  const raw: unknown = event.tool_result;
   if (!Array.isArray(raw) || raw.length < 2) return null;
   const [topic, result] = raw;
   if (typeof topic !== "string" || typeof result !== "string") return null;
   return {
     name:
-      typeof message.tool_name === "string" && message.tool_name.length > 0
-        ? message.tool_name
+      typeof event.tool_name === "string" && event.tool_name.length > 0
+        ? event.tool_name
         : topic,
     result,
     turnId: event.turn_id ?? `event:${event.event_id}`,
@@ -64,16 +60,22 @@ export function legacyToolResultFromMessage(
 }
 
 export function countToolCalls(events: readonly Event[]): number {
-  const typedToolTurns = new Set(
-    events
-      .filter((event) => event.type === "tool_complete")
-      .map((event) => event.turn_id ?? `event:${event.event_id}`),
+  // Subagent lifecycles ("task") are not tool calls, and an inline-tool
+  // message is a duplicate only of a typed completion for the SAME tool in
+  // the same turn — deduping by turn alone undercounts turns mixing inline
+  // and async tools.
+  const typedToolPairs = new Set(
+    events.flatMap((event) =>
+      event.type === "tool_complete" && event.tool_name !== "task"
+        ? [`${event.turn_id ?? `event:${event.event_id}`}::${event.tool_name}`]
+        : [],
+    ),
   );
   return events.filter((event) => {
-    if (event.type === "tool_complete") return true;
+    if (event.type === "tool_complete") return event.tool_name !== "task";
     if (event.type !== "message") return false;
-    const tool = legacyToolResultFromMessage(event);
-    return tool !== null && !typedToolTurns.has(tool.turnId);
+    const tool = inlineToolResultFromMessage(event);
+    return tool !== null && !typedToolPairs.has(`${tool.turnId}::${tool.name}`);
   }).length;
 }
 

--- a/packages/client/src/cli/state.ts
+++ b/packages/client/src/cli/state.ts
@@ -44,6 +44,9 @@ export type CliSessionState = {
   /** Aomi account bearer for authenticated requests. Persisted so a bearer
    * supplied once (via `--account-bearer`) survives across CLI invocations. */
   accountBearer?: string;
+  /** Better Auth anonymous bearer owning guest Agent sessions. Stored in the
+   * same private state file so a later CLI process can resume that identity. */
+  guestBearer?: string;
   publicKey?: string;
   privateKey?: string;
   /** Solana public key (base58), derived from the Solana keypair when provided. */
@@ -122,6 +125,7 @@ function toCliSessionState(stored: StoredSessionState): CliSessionState {
     modelSynced: stored.modelSynced,
     apiKey: stored.apiKey,
     accountBearer: stored.accountBearer,
+    guestBearer: stored.guestBearer,
     publicKey: stored.publicKey,
     privateKey: stored.privateKey,
     svmPublicKey: stored.svmPublicKey,
@@ -159,6 +163,10 @@ function readStoredSession(path: string): StoredSessionState | null {
       modelSynced: parsed.modelSynced,
       apiKey: parsed.apiKey,
       accountBearer: parsed.accountBearer,
+      guestBearer:
+        typeof parsed.guestBearer === "string" && parsed.guestBearer
+          ? parsed.guestBearer
+          : undefined,
       publicKey: parsed.publicKey,
       privateKey: parsed.privateKey,
       svmPublicKey: parsed.svmPublicKey,
@@ -388,7 +396,6 @@ export function deleteStoredSession(
 }
 
 export function readState(): CliSessionState | null {
-
   const sessions = readAllStoredSessions();
   if (sessions.length === 0) return null;
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -314,7 +314,9 @@ export class AomiClient {
         ? globalThis.fetch.bind(globalThis)
         : fetchImpl;
     const guest =
-      options.oauth || options.getAccountBearer || options.guest === false
+      options.oauth ||
+      options.guest === false ||
+      (options.getAccountBearer && options.guest === undefined)
         ? undefined
         : typeof options.guest === "function"
           ? options.guest

--- a/packages/client/src/guest-auth.ts
+++ b/packages/client/src/guest-auth.ts
@@ -72,6 +72,16 @@ async function signInAnonymous(
   ) {
     return null;
   }
+  // Better Auth refuses a second anonymous sign-in while an anonymous
+  // session cookie is live. That cookie IS a working credential — fall back
+  // to it instead of failing the caller's request.
+  if (
+    response.status === 400 &&
+    (await responseCode(response)) ===
+      "ANONYMOUS_USERS_CANNOT_SIGN_IN_AGAIN_ANONYMOUSLY"
+  ) {
+    return null;
+  }
   if (!response.ok) {
     throw new Error(`Aomi guest sign-in failed with HTTP ${response.status}`);
   }

--- a/packages/client/src/session/index.ts
+++ b/packages/client/src/session/index.ts
@@ -57,10 +57,19 @@ export class ClientSession {
   private pollFailureCount = 0;
   private awaitingResume = false;
   private terminalDrainUntil?: number;
+  private terminalTurnId?: string;
   private isSubmitting = false;
+  private pendingUserMessage?: { content: string; sinceSequence: number };
   private events: Event[] = [];
   private eventIds = new Set<string>();
   private messages: MessageEvent[] = [];
+  private storeVersion = 0;
+  private cachedStore?: {
+    version: number;
+    events: Event[];
+    messages: MessageEvent[];
+  };
+  private lastPageNewEvents = 0;
   private title?: string;
   private error?: unknown;
   private closed = false;
@@ -120,9 +129,10 @@ export class ClientSession {
     const page = await this.submit(message);
     if (this.isTerminal()) {
       this.drainTerminalPage(page);
-      return this.result();
-    }
-    if (this.turnState !== "awaiting_action" || page.has_more) {
+      // The drain may still be polling for the trailing final message /
+      // title; only a finished drain has the complete result in hand.
+      if (!this.pollingActive) return this.result();
+    } else if (this.turnState !== "awaiting_action" || page.has_more) {
       this.startPolling();
     }
     return new Promise((resolve) => {
@@ -229,7 +239,16 @@ export class ClientSession {
     this.startOperation = operation;
     this.awaitingResume = false;
     this.terminalDrainUntil = undefined;
+    this.terminalTurnId = undefined;
     this.isSubmitting = true;
+    // The start response and even the first polls may not carry the user's
+    // message event yet (it can trail in a later page). Hold an optimistic
+    // echo so consumers can render the outbound message immediately; it is
+    // cleared the moment the server's own user message event lands.
+    this.pendingUserMessage = {
+      content: text,
+      sinceSequence: this.events.at(-1)?.sequence ?? 0,
+    };
     this.error = undefined;
     this.publish();
     try {
@@ -256,6 +275,7 @@ export class ClientSession {
       return page;
     } catch (error) {
       this.error = error;
+      this.pendingUserMessage = undefined;
       if (error instanceof AgentApiError && !error.retryable) {
         this.startOperation = undefined;
       }
@@ -293,6 +313,7 @@ export class ClientSession {
       throw new TypeError("Agent response session does not match the request");
     }
     this.applyingPage = true;
+    this.lastPageNewEvents = 0;
     try {
       for (const event of page.events) {
         if (this.eventIds.has(event.event_id)) continue;
@@ -302,13 +323,25 @@ export class ClientSession {
         }
         this.eventIds.add(event.event_id);
         this.events.push(event);
+        this.storeVersion += 1;
+        this.lastPageNewEvents += 1;
         this.turnId = event.turn_id ?? this.turnId;
         switch (event.type) {
           case "message":
             this.applyMessage(event);
+            if (
+              event.sender === "user" &&
+              this.pendingUserMessage &&
+              event.sequence > this.pendingUserMessage.sinceSequence
+            ) {
+              this.pendingUserMessage = undefined;
+            }
             break;
           case "turn_state_changed":
             this.turnState = event.state;
+            if (TERMINAL_TURN_STATES.has(event.state)) {
+              this.terminalTurnId = event.turn_id ?? this.turnId;
+            }
             if (event.state !== "awaiting_action") {
               this.awaitingResume = false;
             }
@@ -374,25 +407,45 @@ export class ClientSession {
   private finish(): void {
     this.awaitingResume = false;
     this.terminalDrainUntil = undefined;
+    this.terminalTurnId = undefined;
+    this.pendingUserMessage = undefined;
     this.stopPolling();
     this.resolvePending();
   }
 
   private drainTerminalPage(page: EventPage): void {
-    this.resolvePending();
-    const hasTitle = page.events.some(
-      (event) => event.type === "title_changed",
-    );
-    if (hasTitle || this.title) {
+    // A turn's final answer can trail its terminal state. Finish only after
+    // the current terminal turn has a settled, non-tool agent message and the
+    // current page is fully drained. Titles are asynchronous thread metadata:
+    // they may be unchanged, delayed, or absent, so they cannot be a sentinel.
+    if (!page.has_more && this.hasTerminalAnswer()) {
       this.finish();
       return;
     }
     this.terminalDrainUntil ??= Date.now() + TERMINAL_EVENT_DRAIN_MS;
-    if (page.events.length === 0 && Date.now() >= this.terminalDrainUntil) {
+    if (
+      !page.has_more &&
+      this.lastPageNewEvents === 0 &&
+      Date.now() >= this.terminalDrainUntil
+    ) {
       this.finish();
       return;
     }
     this.startPolling();
+  }
+
+  private hasTerminalAnswer(): boolean {
+    const turnId = this.terminalTurnId;
+    if (!turnId) return false;
+    return this.events.some(
+      (event) =>
+        event.type === "message" &&
+        event.turn_id === turnId &&
+        event.sender === "agent" &&
+        event.is_streaming !== true &&
+        !event.tool_result &&
+        event.content.trim().length > 0,
+    );
   }
 
   private isTerminal(): boolean {
@@ -410,17 +463,30 @@ export class ClientSession {
   }
 
   private buildSnapshot(): SessionSnapshot {
+    // Keep the events/messages array identities stable across publishes that
+    // did not apply new events, so downstream memoized projections (React's
+    // useMemo on snapshot.events) don't rebuild every poll tick.
+    if (!this.cachedStore || this.cachedStore.version !== this.storeVersion) {
+      this.cachedStore = {
+        version: this.storeVersion,
+        events: [...this.events],
+        messages: [...this.messages],
+      };
+    }
     return {
       sessionId: this.sessionId,
       ...(this.cursor ? { cursor: this.cursor } : {}),
       ...(this.turnId ? { turnId: this.turnId } : {}),
       ...(this.turnState ? { turnState: this.turnState } : {}),
-      events: [...this.events],
-      messages: [...this.messages],
+      events: this.cachedStore.events,
+      messages: this.cachedStore.messages,
       actions: this.actions.all(),
       ...(this.title ? { title: this.title } : {}),
       isPolling: this.pollingActive,
       isSubmitting: this.isSubmitting,
+      ...(this.pendingUserMessage
+        ? { pendingUserMessage: this.pendingUserMessage.content }
+        : {}),
       actionAttempts: this.actions.allAttempts(),
       ...(this.error === undefined ? {} : { error: this.error }),
     };

--- a/packages/client/src/session/types.ts
+++ b/packages/client/src/session/types.ts
@@ -24,6 +24,13 @@ export type SessionSnapshot = Readonly<{
   title?: string;
   isPolling: boolean;
   isSubmitting: boolean;
+  /**
+   * Optimistic echo of the outbound message for the in-flight turn. Set the
+   * moment `send`/`sendAsync` is called and cleared when the server's own
+   * user message event arrives (which can trail the start response by a
+   * poll or two). Render this so the just-sent message never disappears.
+   */
+  pendingUserMessage?: string;
   actionAttempts: ReadonlyMap<string, ActionAttempt>;
   error?: unknown;
 }>;

--- a/packages/client/test/agent-session.unit.test.ts
+++ b/packages/client/test/agent-session.unit.test.ts
@@ -31,9 +31,11 @@ function meta(type: string, sequence: number) {
 function turn(
   sequence: number,
   state: "processing" | "awaiting_action" | "complete",
+  turnId = "turn-1",
 ) {
   return {
     ...meta("turn_state_changed", sequence),
+    turn_id: turnId,
     type: "turn_state_changed",
     state,
   } as const;
@@ -132,7 +134,19 @@ describe("ClientSession Agent transport", () => {
       .mockRejectedValueOnce(
         new AgentApiError(503, "upstream_unavailable", "try again", true),
       )
-      .mockResolvedValue(page([turn(1, "complete")]));
+      .mockResolvedValue(
+        page([
+          {
+            ...meta("message", 1),
+            type: "message",
+            message_key: "message-1",
+            sender: "agent",
+            content: "done",
+            is_streaming: false,
+          },
+          turn(2, "complete"),
+        ]),
+      );
     const session = new Session(api, { sessionId: "session-agent" });
 
     await expect(session.send("hello")).rejects.toThrow("try again");
@@ -142,6 +156,75 @@ describe("ClientSession Agent transport", () => {
     expect(start.mock.calls[0]?.[1]?.idempotencyKey).toBe(
       start.mock.calls[1]?.[1]?.idempotencyKey,
     );
+    session.close();
+  });
+
+  it("drains the final agent message without waiting for another title", async () => {
+    vi.useFakeTimers();
+    const api = client();
+    // Turn 1 completed earlier and set a session title.
+    vi.spyOn(api.agent, "start")
+      .mockResolvedValueOnce(
+        page([
+          {
+            ...meta("message", 1),
+            type: "message",
+            message_key: "message-1",
+            sender: "agent",
+            content: "first answer",
+            is_streaming: false,
+          },
+          {
+            ...meta("title_changed", 2),
+            type: "title_changed",
+            title: "Existing title",
+          },
+          turn(3, "complete"),
+        ]),
+      )
+      // Turn 2: the start page carries only the new processing state.
+      .mockResolvedValueOnce(page([turn(4, "processing", "turn-2")]));
+    const session = new Session(api, {
+      sessionId: "session-agent",
+      pollIntervalMs: 10,
+    });
+    await session.send("first");
+
+    // Turn 2's ledger trails: complete arrives alone, then the final message.
+    // The thread title does not change, so no title event follows this turn.
+    vi.spyOn(api.agent, "poll")
+      .mockResolvedValueOnce(page([turn(5, "complete", "turn-2")]))
+      .mockResolvedValue(
+        page([
+          {
+            ...meta("message", 6),
+            turn_id: "turn-2",
+            type: "message",
+            message_key: "message-final",
+            sender: "agent",
+            content: "FINAL ANSWER",
+            is_streaming: false,
+          },
+        ]),
+      );
+
+    const result = session.send("second");
+    let settled = false;
+    void result.then(() => {
+      settled = true;
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(settled).toBe(true);
+    await expect(result).resolves.toMatchObject({
+      title: "Existing title",
+    });
+    expect(session.getSnapshot().messages.at(-1)).toMatchObject({
+      message_key: "message-final",
+      content: "FINAL ANSWER",
+    });
+    expect(session.getSnapshot().isPolling).toBe(false);
     session.close();
   });
 
@@ -306,14 +389,16 @@ describe("ClientSession Agent transport", () => {
       .mockResolvedValueOnce(
         page([turn(5, "complete")], { cursor: "cursor-5" }),
       )
-      .mockResolvedValueOnce(page([], { cursor: "cursor-5" }))
       .mockResolvedValueOnce(
         page(
           [
             {
-              ...meta("title_changed", 6),
-              type: "title_changed",
-              title: "Canonical title",
+              ...meta("message", 6),
+              type: "message",
+              message_key: "message-final",
+              sender: "agent",
+              content: "The action was rejected.",
+              is_streaming: false,
             },
           ],
           { cursor: "cursor-6" },
@@ -342,12 +427,6 @@ describe("ClientSession Agent transport", () => {
 
     expect(poll).toHaveBeenCalledTimes(3);
     expect(session.getSnapshot().title).toBeUndefined();
-    expect(session.getSnapshot().isPolling).toBe(true);
-
-    await vi.advanceTimersByTimeAsync(10);
-
-    expect(poll).toHaveBeenCalledTimes(4);
-    expect(session.getSnapshot().title).toBe("Canonical title");
     expect(session.getSnapshot().isPolling).toBe(false);
     session.close();
   });

--- a/packages/client/test/aomi-agent.unit.test.ts
+++ b/packages/client/test/aomi-agent.unit.test.ts
@@ -199,6 +199,14 @@ describe("high-level Aomi Agent", () => {
               occurred_at: occurredAt,
               state: "complete",
             },
+            {
+              type: "title_changed",
+              event_id: "event-title",
+              sequence: 7,
+              turn_id: "turn-1",
+              occurred_at: occurredAt,
+              title: "Execute action",
+            },
           ]),
         );
       }

--- a/packages/client/test/cli/cli-chat.unit.test.ts
+++ b/packages/client/test/cli/cli-chat.unit.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vitest";
 import { Keypair } from "@solana/web3.js";
 import bs58 from "bs58";
 
-import { resolveSvmAddressForChat } from "../../src/cli/commands/chat";
+import {
+  printBoundaryForTurn,
+  resolveSvmAddressForChat,
+} from "../../src/cli/commands/chat";
+import type { Event, MessageEvent } from "../../src/agent/types";
 
 const keypair = Keypair.generate();
 const secret = bs58.encode(keypair.secretKey);
@@ -28,5 +32,35 @@ describe("CLI chat wallet identity", () => {
 
   it("returns undefined without either source", () => {
     expect(resolveSvmAddressForChat(undefined, undefined)).toBeUndefined();
+  });
+});
+
+describe("CLI chat output boundary", () => {
+  it("skips prior-turn events and messages when resuming a session", () => {
+    const events = [
+      {
+        event_id: "old-message",
+        sequence: 1,
+        turn_id: "old-turn",
+        occurred_at: 1,
+        type: "message",
+        sender: "agent",
+        content: "old answer",
+      },
+      {
+        event_id: "new-processing",
+        sequence: 2,
+        turn_id: "new-turn",
+        occurred_at: 2,
+        type: "turn_state_changed",
+        state: "processing",
+      },
+    ] as Event[];
+    const messages = [events[0]] as MessageEvent[];
+
+    expect(printBoundaryForTurn(events, messages, "new-turn")).toEqual({
+      handledSequence: 1,
+      printedAgentCount: 1,
+    });
   });
 });

--- a/packages/client/test/cli/cli-context-auth.unit.test.ts
+++ b/packages/client/test/cli/cli-context-auth.unit.test.ts
@@ -9,6 +9,46 @@ import { createControlClient } from "../../src/cli/context";
 describe("CLI explicit API bearer", () => {
   afterEach(() => vi.unstubAllGlobals());
 
+  it("authorizes public Pipeline requests with an anonymous bearer", async () => {
+    vi.stubGlobal("location", undefined);
+    const fetchMock = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const path = new URL(String(input)).pathname;
+        if (path === "/api/auth/sign-in/anonymous") {
+          return Response.json({ token: "guest-session" });
+        }
+        if (path === "/v1/pipeline/apps") {
+          if (
+            new Headers(init?.headers).get("authorization") !==
+            "Bearer guest-session"
+          ) {
+            return Response.json(
+              { error: { code: "invalid_token" } },
+              { status: 401 },
+            );
+          }
+          return Response.json({
+            kind: "directory",
+            path: "/v1/pipeline/apps",
+            entries: [],
+          });
+        }
+        return new Response(null, { status: 404 });
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createControlClient({
+      baseUrl: "https://api.example",
+      secrets: {},
+    });
+    await client.pipeline.apps.list();
+
+    expect(
+      fetchMock.mock.calls.map(([input]) => new URL(String(input)).pathname),
+    ).toEqual(["/api/auth/sign-in/anonymous", "/v1/pipeline/apps"]);
+  });
+
   it("authorizes public Pipeline requests with the explicit scoped bearer", async () => {
     const fetchMock = vi.fn(
       async (_input: RequestInfo | URL, init?: RequestInit) => {

--- a/packages/client/test/cli/cli-oauth-device.unit.test.ts
+++ b/packages/client/test/cli/cli-oauth-device.unit.test.ts
@@ -59,6 +59,8 @@ describe("CLI OAuth device authorization", () => {
       resources: [AGENT_RESOURCE],
       scope: "agent:read offline_access",
     });
+    expect(registration).not.toHaveProperty("redirect_uris");
+    expect(registration).not.toHaveProperty("response_types");
     const deviceBody = new URLSearchParams(
       String(fetchImpl.mock.calls[1]?.[1]?.body),
     );

--- a/packages/client/test/cli/cli-output.unit.test.ts
+++ b/packages/client/test/cli/cli-output.unit.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import type { Event, MessageEvent } from "../../src/agent/types";
+import {
+  countToolCalls,
+  legacyToolResultFromMessage,
+} from "../../src/cli/output";
+
+const legacyToolMessage = {
+  event_id: "event-tool",
+  sequence: 2,
+  turn_id: "turn-1",
+  occurred_at: 1,
+  type: "message",
+  sender: "agent",
+  content: "",
+  tool_name: "get_account_info",
+  tool_arguments: { address: "0x0000" },
+  tool_result: ["Read balance", '{"balance_native":"1"}'],
+} as MessageEvent;
+
+describe("CLI tool output projection", () => {
+  it("reads tool traces from today's message event wire shape", () => {
+    expect(legacyToolResultFromMessage(legacyToolMessage)).toEqual({
+      name: "get_account_info",
+      result: '{"balance_native":"1"}',
+      turnId: "turn-1",
+    });
+  });
+
+  it("does not double-count compatibility messages after typed tool events arrive", () => {
+    const typedTool = {
+      event_id: "event-typed-tool",
+      sequence: 3,
+      turn_id: "turn-1",
+      occurred_at: 2,
+      type: "tool_complete",
+      id: "tool-1",
+      tool_name: "get_account_info",
+      result: { balance_native: "1" },
+    } as Event;
+
+    expect(countToolCalls([legacyToolMessage as Event, typedTool])).toBe(1);
+  });
+});

--- a/packages/client/test/cli/cli-output.unit.test.ts
+++ b/packages/client/test/cli/cli-output.unit.test.ts
@@ -3,10 +3,10 @@ import { describe, expect, it } from "vitest";
 import type { Event, MessageEvent } from "../../src/agent/types";
 import {
   countToolCalls,
-  legacyToolResultFromMessage,
+  inlineToolResultFromMessage,
 } from "../../src/cli/output";
 
-const legacyToolMessage = {
+const inlineToolMessage = {
   event_id: "event-tool",
   sequence: 2,
   turn_id: "turn-1",
@@ -21,7 +21,7 @@ const legacyToolMessage = {
 
 describe("CLI tool output projection", () => {
   it("reads tool traces from today's message event wire shape", () => {
-    expect(legacyToolResultFromMessage(legacyToolMessage)).toEqual({
+    expect(inlineToolResultFromMessage(inlineToolMessage)).toEqual({
       name: "get_account_info",
       result: '{"balance_native":"1"}',
       turnId: "turn-1",
@@ -40,6 +40,6 @@ describe("CLI tool output projection", () => {
       result: { balance_native: "1" },
     } as Event;
 
-    expect(countToolCalls([legacyToolMessage as Event, typedTool])).toBe(1);
+    expect(countToolCalls([inlineToolMessage as Event, typedTool])).toBe(1);
   });
 });

--- a/packages/client/test/cli/cli-session.unit.test.ts
+++ b/packages/client/test/cli/cli-session.unit.test.ts
@@ -23,6 +23,7 @@ describe("CLI session lifecycle", () => {
   });
 
   afterEach(() => {
+    vi.unstubAllGlobals();
     process.env = { ...ORIGINAL_ENV };
     rmSync(stateDir, { recursive: true, force: true });
   });
@@ -222,6 +223,89 @@ describe("CLI session lifecycle", () => {
     });
   });
 
+  it("uses an anonymous bearer for Agent requests without an OAuth grant", async () => {
+    vi.stubGlobal("location", undefined);
+    const fetchMock = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const path = new URL(String(input)).pathname;
+        if (path === "/api/auth/sign-in/anonymous") {
+          return Response.json({ token: "guest-session" });
+        }
+        if (path === "/v1/agent/sessions") {
+          if (
+            new Headers(init?.headers).get("authorization") !==
+            "Bearer guest-session"
+          ) {
+            return Response.json(
+              { error: { code: "invalid_token" } },
+              { status: 401 },
+            );
+          }
+          return Response.json({ sessions: [] });
+        }
+        return new Response(null, { status: 404 });
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { CliSession } = await import("../../src/cli/cli-session");
+    const cli = CliSession.create({
+      baseUrl: "https://chat-staging.aomi.dev",
+      secrets: {},
+    });
+    const session = cli.createClientSession();
+
+    await expect(session.client.agent.sessions.list()).resolves.toEqual({
+      sessions: [],
+    });
+    session.close();
+
+    expect(
+      fetchMock.mock.calls.map(([input]) => new URL(String(input)).pathname),
+    ).toEqual(["/api/auth/sign-in/anonymous", "/v1/agent/sessions"]);
+  });
+
+  it("reuses the anonymous bearer across CLI process sessions", async () => {
+    vi.stubGlobal("location", undefined);
+    const fetchMock = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const path = new URL(String(input)).pathname;
+        if (path === "/api/auth/sign-in/anonymous") {
+          return Response.json({ token: "guest-session" });
+        }
+        if (path === "/v1/agent/sessions") {
+          expect(new Headers(init?.headers).get("authorization")).toBe(
+            "Bearer guest-session",
+          );
+          return Response.json({ sessions: [] });
+        }
+        return new Response(null, { status: 404 });
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { CliSession } = await import("../../src/cli/cli-session");
+    const { readState } = await import("../../src/cli/state");
+    const first = CliSession.create({
+      baseUrl: "https://chat-staging.aomi.dev",
+      secrets: {},
+    });
+    const firstClient = first.createClientSession();
+    await firstClient.client.agent.sessions.list();
+    firstClient.close();
+
+    const reloaded = CliSession.load();
+    const secondClient = reloaded?.createClientSession();
+    await secondClient?.client.agent.sessions.list();
+    secondClient?.close();
+
+    expect(readState()?.guestBearer).toBe("guest-session");
+    expect(
+      fetchMock.mock.calls.filter(
+        ([input]) =>
+          new URL(String(input)).pathname === "/api/auth/sign-in/anonymous",
+      ),
+    ).toHaveLength(1);
+  });
+
   it("persists explicit wallet, chain, and backend settings on the active session", async () => {
     const { setWalletCommand, setChainCommand, setBackendCommand } =
       await import("../../src/cli/commands/preferences");
@@ -385,5 +469,4 @@ describe("CLI session lifecycle", () => {
 
     expect(readState()?.accountBearer).toBe("bearer-1");
   });
-
 });

--- a/packages/client/test/oauth-auth.unit.test.ts
+++ b/packages/client/test/oauth-auth.unit.test.ts
@@ -229,6 +229,32 @@ describe("Better Auth guest bootstrap", () => {
     );
   });
 
+  it("falls back to the anonymous cookie when Better Auth refuses a second anonymous sign-in", async () => {
+    vi.stubGlobal("location", { origin: "https://chat.aomi.dev" });
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(
+        Response.json(
+          {
+            code: "ANONYMOUS_USERS_CANNOT_SIGN_IN_AGAIN_ANONYMOUSLY",
+            message: "Anonymous users cannot sign in again anonymously",
+          },
+          { status: 400 },
+        ),
+      );
+    const guest = createGuestSessionProvider({
+      baseUrl: "https://chat.aomi.dev",
+      fetch: fetchImpl as typeof fetch,
+    });
+
+    // The live anonymous cookie IS a working credential; the refusal must
+    // not fail the caller's request, and the null result is cached so the
+    // provider does not re-POST on every call.
+    await expect(guest({ forceRefresh: true })).resolves.toBeNull();
+    await expect(guest()).resolves.toBeNull();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
   it("retries a same-origin 401 after establishing the guest cookie", async () => {
     vi.stubGlobal("location", { origin: "https://chat.aomi.dev" });
     const authFetch = vi.fn().mockResolvedValue(Response.json({}));

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aomi-labs/react",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Runtime, state, and utilities for the Aomi widget.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/react/src/runtime/__tests__/event-projection.test.ts
+++ b/packages/react/src/runtime/__tests__/event-projection.test.ts
@@ -3,7 +3,11 @@ import type { Event } from "@aomi-labs/client";
 
 import { projectAssistantMessages } from "../utils";
 
-const meta = (sequence: number, type: Event["type"], turnId: string | null) => ({
+const meta = (
+  sequence: number,
+  type: Event["type"],
+  turnId: string | null,
+) => ({
   event_id: `event-${sequence}`,
   sequence,
   turn_id: turnId,
@@ -70,10 +74,9 @@ describe("projectAssistantMessages", () => {
         sender: "agent",
         content: "",
         message_key: "tool-step-1",
-        tool_result: [
-          "Read vitalik.eth ETH balance",
-          '{"balance_eth":"6.64"}',
-        ],
+        tool_name: "get_balance",
+        tool_arguments: { owner: "vitalik.eth" },
+        tool_result: ["Read vitalik.eth ETH balance", '{"balance_eth":"6.64"}'],
       } as Event,
       {
         ...meta(2, "message", "turn-1"),
@@ -88,10 +91,51 @@ describe("projectAssistantMessages", () => {
       {
         type: "tool-call",
         toolCallId: "legacy:tool-step-1",
-        toolName: "Read vitalik.eth ETH balance",
+        toolName: "get_balance",
+        args: { owner: "vitalik.eth" },
         result: { balance_eth: "6.64" },
       },
       { type: "text", text: "vitalik.eth holds 6.64 ETH" },
+    ]);
+  });
+
+  it("prefers typed tool completion when both wire shapes are present", () => {
+    const events: Event[] = [
+      {
+        ...meta(1, "message", "turn-1"),
+        type: "message",
+        sender: "agent",
+        content: "",
+        message_key: "tool-step-1",
+        tool_name: "get_balance",
+        tool_result: ["Read balance", '{"balance_eth":"6.64"}'],
+      } as Event,
+      {
+        ...meta(2, "tool_complete", "turn-1"),
+        type: "tool_complete",
+        id: "tool-1",
+        call_id: "call-1",
+        tool_name: "get_balance",
+        result: { balance_eth: "6.64" },
+      },
+      {
+        ...meta(3, "message", "turn-1"),
+        type: "message",
+        sender: "agent",
+        content: "Done",
+        message_key: "agent-1",
+      },
+    ];
+
+    expect(projectAssistantMessages(events)[0]?.content).toEqual([
+      {
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "get_balance",
+        args: undefined,
+        result: { balance_eth: "6.64" },
+      },
+      { type: "text", text: "Done" },
     ]);
   });
 

--- a/packages/react/src/runtime/__tests__/event-projection.test.ts
+++ b/packages/react/src/runtime/__tests__/event-projection.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { Event } from "@aomi-labs/client";
 
-import { projectAssistantMessages } from "../utils";
+import { projectAssistantMessages, projectRuntimeMessages } from "../utils";
 
 const meta = (
   sequence: number,
@@ -16,6 +16,30 @@ const meta = (
 });
 
 describe("projectAssistantMessages", () => {
+  it("reconciles the optimistic user echo with the canonical event by id", () => {
+    const optimistic = projectRuntimeMessages([], "hello");
+    const canonical = projectRuntimeMessages([
+      {
+        ...meta(1, "message", "turn-1"),
+        type: "message",
+        sender: "user",
+        content: "hello",
+        message_key: "server-generated-id",
+      },
+    ]);
+
+    expect(optimistic[0]).toMatchObject({
+      id: "aomi-user-0",
+      role: "user",
+      content: [{ type: "text", text: "hello" }],
+    });
+    expect(canonical[0]).toMatchObject({
+      id: optimistic[0]?.id,
+      role: "user",
+      content: [{ type: "text", text: "hello" }],
+    });
+  });
+
   it("projects one ordered turn without owning a second reducer", () => {
     const events: Event[] = [
       {
@@ -64,9 +88,9 @@ describe("projectAssistantMessages", () => {
     ]);
   });
 
-  it("projects legacy tool_result message events as tool parts", () => {
-    // The recorder still bridges tool steps as agent messages carrying the
-    // legacy [label, json] tuple; the contract-typed events never arrive.
+  it("projects inline tool_result message events as tool parts", () => {
+    // The recorder bridges inline tool steps as agent messages carrying the
+    // [topic, json] tuple; the contract-typed events never arrive for them.
     const events: Event[] = [
       {
         ...meta(1, "message", "turn-1"),
@@ -77,7 +101,7 @@ describe("projectAssistantMessages", () => {
         tool_name: "get_balance",
         tool_arguments: { owner: "vitalik.eth" },
         tool_result: ["Read vitalik.eth ETH balance", '{"balance_eth":"6.64"}'],
-      } as Event,
+      },
       {
         ...meta(2, "message", "turn-1"),
         type: "message",
@@ -90,12 +114,56 @@ describe("projectAssistantMessages", () => {
     expect(projectAssistantMessages(events)[0]?.content).toMatchObject([
       {
         type: "tool-call",
-        toolCallId: "legacy:tool-step-1",
+        toolCallId: "inline:tool-step-1",
         toolName: "get_balance",
         args: { owner: "vitalik.eth" },
         result: { balance_eth: "6.64" },
       },
       { type: "text", text: "vitalik.eth holds 6.64 ETH" },
+    ]);
+  });
+
+  it("keeps an inline tool's trace when a different tool completed typed in the same turn", () => {
+    const events: Event[] = [
+      {
+        ...meta(1, "tool_complete", "turn-1"),
+        type: "tool_complete",
+        id: "tool-1",
+        call_id: "call-quote",
+        tool_name: "get_quote",
+        result: { price: "2437" },
+      },
+      {
+        ...meta(2, "message", "turn-1"),
+        type: "message",
+        sender: "agent",
+        content: "",
+        message_key: "tool-step-balance",
+        tool_name: "get_balance",
+        tool_result: ["Read balance", '{"balance_eth":"6.64"}'],
+      },
+      {
+        ...meta(3, "message", "turn-1"),
+        type: "message",
+        sender: "agent",
+        content: "Done",
+        message_key: "agent-1",
+      },
+    ];
+
+    expect(projectAssistantMessages(events)[0]?.content).toMatchObject([
+      {
+        type: "tool-call",
+        toolCallId: "call-quote",
+        toolName: "get_quote",
+      },
+      {
+        type: "tool-call",
+        toolCallId: "inline:tool-step-balance",
+        toolName: "get_balance",
+        result: { balance_eth: "6.64" },
+      },
+      { type: "text", text: "Done" },
     ]);
   });
 
@@ -109,7 +177,7 @@ describe("projectAssistantMessages", () => {
         message_key: "tool-step-1",
         tool_name: "get_balance",
         tool_result: ["Read balance", '{"balance_eth":"6.64"}'],
-      } as Event,
+      },
       {
         ...meta(2, "tool_complete", "turn-1"),
         type: "tool_complete",

--- a/packages/react/src/runtime/__tests__/task-runs.test.ts
+++ b/packages/react/src/runtime/__tests__/task-runs.test.ts
@@ -73,4 +73,26 @@ describe("selectTaskRuns", () => {
       ],
     });
   });
+
+  it("normalizes epoch-second timestamps so startedAt is comparable to Date.now()", () => {
+    // The wire sends occurred_at in epoch seconds. Stored raw, the trace
+    // header renders `Date.now() - startedAt` as ~56 years of elapsed time.
+    const startedAtSeconds = 1_756_000_000;
+    const events: Event[] = [
+      {
+        ...meta(1, "task_started"),
+        occurred_at: startedAtSeconds,
+        type: "task_started",
+        call_id: "call-1",
+        agent_id: "agent-1",
+        label: "Trader",
+        app: "swap",
+        resumed: false,
+      },
+    ];
+
+    expect(selectTaskRuns(events)["agent-1"]?.startedAt).toBe(
+      startedAtSeconds * 1000,
+    );
+  });
 });

--- a/packages/react/src/runtime/core.tsx
+++ b/packages/react/src/runtime/core.tsx
@@ -8,7 +8,11 @@ import {
   type AppendMessage,
 } from "@assistant-ui/react";
 
-import type { ActionCapabilities, AomiClient } from "@aomi-labs/client";
+import {
+  AgentApiError,
+  type ActionCapabilities,
+  type AomiClient,
+} from "@aomi-labs/client";
 import { useControl } from "../contexts/control-context";
 import { useUser } from "../contexts/ext-user-context";
 import { useThreadContext } from "../contexts/thread-context";
@@ -23,7 +27,7 @@ import {
   clearPersistedThreadId,
   writePersistedThreadId,
 } from "./thread-persistence";
-import { projectAssistantMessages } from "./utils";
+import { projectAssistantMessages, projectRuntimeMessages } from "./utils";
 
 /** Deduplicate in-flight async work keyed by thread id. */
 async function runSingleFlight(
@@ -141,11 +145,40 @@ export function AomiRuntimeCore({
           kind: "payment_required",
           title: "You're out of funds",
         });
+        // Prewarmed empty threads are intentionally durable. A quota failure
+        // keeps the same thread so payment setup can retry without another
+        // create/model round trip.
+        return;
       }
 
-      // Prewarmed empty threads are intentionally durable. A quota failure
-      // keeps the same thread so payment setup can retry without another
-      // create/model round trip.
+      if (
+        error instanceof AgentApiError &&
+        error.code === "session_not_found"
+      ) {
+        // The pinned thread belongs to another principal (sign-out, new
+        // guest). Drop the pin so the next attempt starts clean instead of
+        // 404ing forever.
+        if (threadPersistenceKey) {
+          clearPersistedThreadId(threadPersistenceKey);
+        }
+        notificationContext.showNotification({
+          type: "error",
+          title: "Conversation unavailable",
+          message: "This conversation is no longer accessible. Start a new chat and send your message again.",
+        });
+        return;
+      }
+
+      // Every other failure was previously swallowed — the composer text
+      // vanished with no feedback at all.
+      notificationContext.showNotification({
+        type: "error",
+        title: "Message not sent",
+        message:
+          error instanceof Error && error.message
+            ? error.message
+            : "Something went wrong sending your message. Please try again.",
+      });
     },
   });
 
@@ -242,9 +275,13 @@ export function AomiRuntimeCore({
     warmThread,
   ]);
 
+  // The server's user event can trail the start response by a poll or two.
+  // Echo it immediately with the same ordinal id the canonical projection will
+  // use, keeping the previous assistant reply complete without creating a
+  // phantom user-message branch when the server event arrives.
   const currentMessages = useMemo(
-    () => projectAssistantMessages(snapshot.events),
-    [snapshot.events],
+    () => projectRuntimeMessages(snapshot.events, snapshot.pendingUserMessage),
+    [snapshot.events, snapshot.pendingUserMessage],
   );
 
   useEffect(() => {
@@ -286,6 +323,7 @@ export function AomiRuntimeCore({
   // ---------------------------------------------------------------------------
   // External store runtime
   // ---------------------------------------------------------------------------
+  const restoreComposerTextRef = useRef<(text: string) => void>(() => {});
   const runtime = useExternalStoreRuntime({
     messages: currentMessages,
     isLoading: isThreadLoading,
@@ -297,6 +335,7 @@ export function AomiRuntimeCore({
           await orchestratorSendMessage(text, threadContext.currentThreadId);
         } catch (error) {
           console.error("Failed to send message:", error);
+          restoreComposerTextRef.current(text);
         }
       }
     },
@@ -306,6 +345,10 @@ export function AomiRuntimeCore({
     convertMessage: (msg) => msg,
     adapters: { threadList: threadListAdapter },
   });
+  restoreComposerTextRef.current = (text) => {
+    const composer = runtime.thread.composer;
+    if (!composer.getState().text) composer.setText(text);
+  };
 
   // ---------------------------------------------------------------------------
   // Cleanup on unmount.

--- a/packages/react/src/runtime/task-runs.ts
+++ b/packages/react/src/runtime/task-runs.ts
@@ -10,6 +10,7 @@ import type {
 } from "@aomi-labs/client";
 
 import { useAomiRuntime } from "../interface";
+import { parseTimestamp } from "./utils";
 
 export type TaskRunStep =
   | {
@@ -66,7 +67,8 @@ const emptyRun = (event: TaskEvent): TaskRunState => ({
   label: "",
   app: "",
   status: "running",
-  startedAt: event.occurred_at,
+  // The wire sends epoch seconds; consumers compare against Date.now() ms.
+  startedAt: parseTimestamp(event.occurred_at),
   steps: [],
 });
 
@@ -99,7 +101,7 @@ export function selectTaskRuns(events: readonly Event[]): ThreadTaskRuns {
             callId: event.call_id,
             label: event.label ?? "",
             app: event.app,
-            startedAt: event.occurred_at,
+            startedAt: parseTimestamp(event.occurred_at),
           };
           break;
         case "task_phase":

--- a/packages/react/src/runtime/utils.ts
+++ b/packages/react/src/runtime/utils.ts
@@ -50,6 +50,8 @@ type MessageContentPart =
     ? U
     : never;
 
+const userMessageId = (ordinal: number) => `aomi-user-${ordinal}`;
+
 export function toInboundMessage(
   msg: MessageEvent,
   /** Position in the raw list, the id fallback for a notice with no key. */
@@ -107,6 +109,9 @@ function buildInboundMessage(msg: MessageEvent): ThreadMessageLike | null {
   }
 
   const threadMessage = {
+    // A stable id keeps assistant-ui from assigning positional ids that
+    // shift (and re-key the row) when earlier projections change shape.
+    id: msg.message_key ?? msg.event_id,
     role,
     content: content as ThreadMessageLike["content"],
     createdAt: new Date(parseTimestamp(msg.occurred_at)),
@@ -150,22 +155,16 @@ const toolPart = (
   }) as MessageContentPart;
 
 /**
- * The backend's event ledger still bridges tool steps as agent `message`
- * events carrying a legacy `[label, json]` tuple in `tool_result` — a field
- * its OpenAPI contract does not declare, so the generated MessageEvent type
- * cannot see it. Until the recorder emits real tool_update/tool_complete
- * events, this is the only wire shape tool steps arrive in; drop it and every
- * trace renders as an empty "Working" shell.
+ * The backend's event ledger bridges INLINE (sync-executed) tool steps as agent
+ * `message` events carrying a `[topic, payload]` tuple in `tool_result`
+ * (declared on the client's MessageEvent shape). Until the recorder emits
+ * real tool_update/tool_complete events for inline tools, this is the only
+ * wire shape those steps arrive in; drop it and every trace renders as an
+ * empty "Working" shell.
  */
-type ToolBearingMessageEvent = MessageEvent & {
-  tool_result?: unknown;
-  tool_name?: unknown;
-  tool_arguments?: unknown;
-};
-
-const legacyToolResult = (event: MessageEvent) => {
-  const message = event as ToolBearingMessageEvent;
-  const raw = message.tool_result;
+const inlineToolResult = (event: MessageEvent) => {
+  // Declared on the type, but the wire is untrusted — validate before use.
+  const raw: unknown = event.tool_result;
   if (!Array.isArray(raw) || raw.length < 2) return null;
   const [topic, payload] = raw;
   if (typeof topic !== "string" || typeof payload !== "string") return null;
@@ -173,15 +172,15 @@ const legacyToolResult = (event: MessageEvent) => {
     topic,
     payload,
     toolName:
-      typeof message.tool_name === "string" && message.tool_name.length > 0
-        ? message.tool_name
+      typeof event.tool_name === "string" && event.tool_name.length > 0
+        ? event.tool_name
         : topic,
-    args: message.tool_arguments,
+    args: event.tool_arguments,
   };
 };
 
-const legacyToolPart = (
-  tool: NonNullable<ReturnType<typeof legacyToolResult>>,
+const inlineToolPart = (
+  tool: NonNullable<ReturnType<typeof inlineToolResult>>,
   key: string,
 ): MessageContentPart => {
   let result: unknown = tool.payload;
@@ -192,7 +191,7 @@ const legacyToolPart = (
   }
   return {
     type: "tool-call",
-    toolCallId: `legacy:${key}`,
+    toolCallId: `inline:${key}`,
     toolName: tool.toolName,
     args: tool.args,
     result,
@@ -210,13 +209,20 @@ export function projectAssistantMessages(
   const output: Array<ThreadMessageLike | AssistantProjection> = [];
   const assistantTurns = new Map<string, AssistantProjection>();
   const standaloneMessages = new Map<string, number>();
+  let userMessageOrdinal = 0;
   const turnKey = (event: Event) => event.turn_id ?? `event:${event.event_id}`;
-  const typedToolTurns = new Set(
-    events
-      .filter(
-        (event) => event.type === "tool_complete" && event.tool_name !== "task",
-      )
-      .map(turnKey),
+  // Inline results only ever arrive as `tool_result` message events, so an
+  // inline part may be suppressed only when the SAME tool also produced a
+  // typed completion in the turn — suppressing per turn would drop a sync
+  // tool's only trace whenever any other tool in the turn completed typed.
+  const typedToolKey = (turn: string, toolName: string) =>
+    `${turn}::${toolName}`;
+  const typedToolCompletions = new Set(
+    events.flatMap((event) =>
+      event.type === "tool_complete" && event.tool_name !== "task"
+        ? [typedToolKey(turnKey(event), event.tool_name)]
+        : [],
+    ),
   );
 
   const assistantTurn = (event: Event): AssistantProjection => {
@@ -245,14 +251,18 @@ export function projectAssistantMessages(
       if (event.sender === "agent") {
         const projection = assistantTurn(event);
         const key = event.message_key ?? event.event_id;
-        const toolResult = legacyToolResult(event);
+        const toolResult = inlineToolResult(event);
         if (toolResult) {
-          if (!typedToolTurns.has(turnKey(event))) {
+          if (
+            !typedToolCompletions.has(
+              typedToolKey(turnKey(event), toolResult.toolName),
+            )
+          ) {
             upsertPart(
               projection,
               projection.toolParts,
               key,
-              legacyToolPart(toolResult, key),
+              inlineToolPart(toolResult, key),
             );
           }
         } else {
@@ -264,15 +274,22 @@ export function projectAssistantMessages(
         continue;
       }
 
-      const projected = toInboundMessage(event, output.length);
+      let projected = toInboundMessage(event, output.length);
       if (!projected) continue;
       const key = event.message_key ?? event.event_id;
       const index = standaloneMessages.get(key);
       if (index === undefined) {
+        if (projected.role === "user") {
+          projected = { ...projected, id: userMessageId(userMessageOrdinal++) };
+        }
         standaloneMessages.set(key, output.length);
         output.push(projected);
       } else {
-        output[index] = projected;
+        const previous = output[index];
+        output[index] =
+          projected.role === "user" && previous && !("parts" in previous)
+            ? { ...projected, id: previous.id }
+            : projected;
       }
       continue;
     }
@@ -303,6 +320,34 @@ export function projectAssistantMessages(
       (message) =>
         typeof message.content === "string" || message.content.length > 0,
     );
+}
+
+/**
+ * Project the external-store snapshot, including the user message that has
+ * been submitted but has not reached the event ledger yet.
+ *
+ * User ids are ordinal because the ledger is append-only. This gives the
+ * optimistic row and its eventual server row the same identity, so
+ * assistant-ui updates the row instead of retaining both as sibling branches.
+ */
+export function projectRuntimeMessages(
+  events: readonly Event[],
+  pendingUserMessage?: string,
+): ThreadMessageLike[] {
+  const projected = projectAssistantMessages(events);
+  if (pendingUserMessage === undefined) return projected;
+
+  const userMessageOrdinal = projected.reduce(
+    (count, message) => count + Number(message.role === "user"),
+    0,
+  );
+  projected.push({
+    id: userMessageId(userMessageOrdinal),
+    role: "user",
+    content: [{ type: "text", text: pendingUserMessage }],
+    createdAt: new Date(),
+  });
+  return projected;
 }
 
 // ==================== Wallet Utilities ====================

--- a/packages/react/src/runtime/utils.ts
+++ b/packages/react/src/runtime/utils.ts
@@ -157,29 +157,44 @@ const toolPart = (
  * events, this is the only wire shape tool steps arrive in; drop it and every
  * trace renders as an empty "Working" shell.
  */
-const legacyToolResult = (event: MessageEvent): [string, string] | null => {
-  const raw = (event as { tool_result?: unknown }).tool_result;
+type ToolBearingMessageEvent = MessageEvent & {
+  tool_result?: unknown;
+  tool_name?: unknown;
+  tool_arguments?: unknown;
+};
+
+const legacyToolResult = (event: MessageEvent) => {
+  const message = event as ToolBearingMessageEvent;
+  const raw = message.tool_result;
   if (!Array.isArray(raw) || raw.length < 2) return null;
-  const [label, payload] = raw;
-  if (typeof label !== "string" || typeof payload !== "string") return null;
-  return [label, payload];
+  const [topic, payload] = raw;
+  if (typeof topic !== "string" || typeof payload !== "string") return null;
+  return {
+    topic,
+    payload,
+    toolName:
+      typeof message.tool_name === "string" && message.tool_name.length > 0
+        ? message.tool_name
+        : topic,
+    args: message.tool_arguments,
+  };
 };
 
 const legacyToolPart = (
-  [label, payload]: [string, string],
+  tool: NonNullable<ReturnType<typeof legacyToolResult>>,
   key: string,
 ): MessageContentPart => {
-  let result: unknown = payload;
+  let result: unknown = tool.payload;
   try {
-    result = JSON.parse(payload);
+    result = JSON.parse(tool.payload);
   } catch {
     // Non-JSON payloads render verbatim.
   }
   return {
     type: "tool-call",
     toolCallId: `legacy:${key}`,
-    toolName: label,
-    args: undefined,
+    toolName: tool.toolName,
+    args: tool.args,
     result,
   } as MessageContentPart;
 };
@@ -195,9 +210,17 @@ export function projectAssistantMessages(
   const output: Array<ThreadMessageLike | AssistantProjection> = [];
   const assistantTurns = new Map<string, AssistantProjection>();
   const standaloneMessages = new Map<string, number>();
+  const turnKey = (event: Event) => event.turn_id ?? `event:${event.event_id}`;
+  const typedToolTurns = new Set(
+    events
+      .filter(
+        (event) => event.type === "tool_complete" && event.tool_name !== "task",
+      )
+      .map(turnKey),
+  );
 
   const assistantTurn = (event: Event): AssistantProjection => {
-    const key = event.turn_id ?? `event:${event.event_id}`;
+    const key = turnKey(event);
     const existing = assistantTurns.get(key);
     if (existing) return existing;
     const projection: AssistantProjection = {
@@ -224,7 +247,14 @@ export function projectAssistantMessages(
         const key = event.message_key ?? event.event_id;
         const toolResult = legacyToolResult(event);
         if (toolResult) {
-          upsertPart(projection, projection.toolParts, key, legacyToolPart(toolResult, key));
+          if (!typedToolTurns.has(turnKey(event))) {
+            upsertPart(
+              projection,
+              projection.toolParts,
+              key,
+              legacyToolPart(toolResult, key),
+            );
+          }
         } else {
           upsertPart(projection, projection.textParts, key, {
             type: "text",


### PR DESCRIPTION
## Summary

- render the just-sent user message optimistically so a new turn never replays the prior assistant reply
- drain terminal pages until the current final answer arrives and honor remaining pages
- project current message-shaped tool results while remaining compatible with typed tool-complete events
- preserve failed sends and surface non-auth errors instead of silently losing composer text
- harden guest and CLI Agent auth, session handling, terminal output, and tool traces

## Verification

- package builds passed for client, React, deploy, and widget-lib
- lint and TypeScript checks passed
- 218 test files passed: 1,310 tests passed and 2 skipped
- Portal typecheck passed
- local browser E2E passed: no prior-turn replay, immediate user echo, visible tool trace, no 2/2 branch counter, and working Orchestrator selector

No deployment or package publish was performed.