### PR TITLE
fix(landing): restore browser wallet account auth

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -200,6 +200,18 @@ toggle persistence, route continuity, contrast, and console errors pass.
 
 # Auth BFF BetterAuth Cleanup Goal
 
+## Landing browser-wallet authentication recovery
+
+Current session goal: **IMPLEMENTED AND PREVIEW VERIFIED 2026-08-26** — restore
+account sign-in for external wallets on `aomi.dev`. The landing demo now uses
+the Portal's wallet-signed widget session instead of its unconfigured Para
+login, forwards that account bearer to the frame client, and sends widget API
+traffic directly to `chat.aomi.dev`. The production database showed no account
+or bound-wallet row for the reported Rabby address, confirming that its prior
+login never reached signature verification. The hosted preview and Portal
+nonce route were verified cross-origin; a wallet-extension confirmation still
+requires a browser with Rabby installed.
+
 ## Application-scoped discovery regressions
 
 Current session goal: **IMPLEMENTED AND LOCALLY VERIFIED 2026-08-24** — keep

--- a/apps/landing/app/_marketing/sections/human-demo.tsx
+++ b/apps/landing/app/_marketing/sections/human-demo.tsx
@@ -1,11 +1,38 @@
 "use client";
 
 import { Component, type ReactNode } from "react";
-import { AomiFrame } from "@aomi-labs/widget-lib";
-import { LandingWalletKitProvider } from "../../components/landing-wallet-kit-provider";
+import { AomiFrame, useAomiWalletKit } from "@aomi-labs/widget-lib";
+import {
+  landingPortalUrl,
+  LandingWalletKitProvider,
+} from "../../components/landing-wallet-kit-provider";
 import styles from "../../sections/hero.module.css";
 
-const DEMO_BACKEND_URL = "/";
+function LandingDemoFrame() {
+  const walletKit = useAomiWalletKit();
+
+  return (
+    <AomiFrame.Root
+      key={walletKit.accountUser?.id ?? "anonymous"}
+      height="100%"
+      width="100%"
+      className={`${styles.demoFrame} aui-suggestions-marquee overflow-hidden rounded-3xl bg-white`}
+      defaultSidebarOpen={false}
+      walletPosition="footer"
+      walletFamilies={["evm", "solana"]}
+      backendUrl={landingPortalUrl}
+      accountSessionAvailable={Boolean(walletKit.accountUser)}
+      clientOptions={{ getAccountBearer: walletKit.getAccountBearer }}
+    >
+      <AomiFrame.Header />
+      <AomiFrame.Composer
+        withControl
+        welcomeTitle="What should happen on-chain?"
+        controlBarProps={{ hideApiKey: true, hideNetwork: false }}
+      />
+    </AomiFrame.Root>
+  );
+}
 
 class DemoErrorBoundary extends Component<
   { children: ReactNode },
@@ -51,22 +78,7 @@ export function HumanDemo() {
       <div className="relative z-10 h-full w-full">
         <DemoErrorBoundary>
           <LandingWalletKitProvider>
-            <AomiFrame.Root
-              height="100%"
-              width="100%"
-              className={`${styles.demoFrame} aui-suggestions-marquee overflow-hidden rounded-3xl bg-white`}
-              defaultSidebarOpen={false}
-              walletPosition="footer"
-              walletFamilies={["evm", "solana"]}
-              backendUrl={DEMO_BACKEND_URL}
-            >
-              <AomiFrame.Header />
-              <AomiFrame.Composer
-                withControl
-                welcomeTitle="What should happen on-chain?"
-                controlBarProps={{ hideApiKey: true, hideNetwork: false }}
-              />
-            </AomiFrame.Root>
+            <LandingDemoFrame />
           </LandingWalletKitProvider>
         </DemoErrorBoundary>
       </div>

--- a/apps/landing/app/components/landing-wallet-kit-provider.tsx
+++ b/apps/landing/app/components/landing-wallet-kit-provider.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import "@aomi-labs/widget-lib/providers/para";
 import { useEffect, useState, type ReactNode } from "react";
 import { defineChain, type Chain } from "viem";
 import { useAccount, useSwitchChain } from "wagmi";
@@ -30,9 +29,13 @@ const LOCALHOST_CHAIN_ID = 31337;
 const walletConnectProjectId =
   process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID ||
   process.env.NEXT_PUBLIC_PROJECT_ID;
-const paraApiKey = process.env.NEXT_PUBLIC_PARA_API_KEY;
-const paraEnvironment: "PROD" | "BETA" =
-  process.env.NEXT_PUBLIC_PARA_ENVIRONMENT === "PROD" ? "PROD" : "BETA";
+
+export const landingPortalUrl = (
+  process.env.NEXT_PUBLIC_AOMI_PORTAL_URL ??
+  (process.env.NODE_ENV === "development"
+    ? "http://localhost:3000"
+    : "https://chat.aomi.dev")
+).replace(/\/+$/, "");
 
 const localhost = defineChain({
   id: 31337,
@@ -192,18 +195,11 @@ export function LandingWalletKitProvider({
   return (
     <AomiWalletKitProvider
       preset="wallets-only"
-      auth={{ provider: "para", methods: ["google", "email", "wallet"] }}
-      providers={{
-        para: {
-          apiKey: paraApiKey,
-          environment: paraEnvironment,
-          appName: "Aomi Labs",
-          appDescription: "Interactive Aomi widget demo",
-          appUrl:
-            typeof window !== "undefined"
-              ? window.location.origin
-              : "https://aomi.dev",
-        },
+      auth={false}
+      account={{
+        mode: "aomi-backend",
+        baseUrl: landingPortalUrl,
+        widgetAuth: { mode: "wallet" },
       }}
       execution={{
         aa: "optional",


### PR DESCRIPTION
## Summary
- replace the landing demo's unconfigured Para auth with browser-wallet widget auth
- route landing account and widget requests through `https://chat.aomi.dev`
- forward the account bearer into `AomiFrame` so authenticated requests no longer report an unbound wallet

## Verification
- landing ESLint and TypeScript checks
- production implementation: Next.js production build, 26 account-runtime tests, and 10 widget-session tests
- Vercel preview deployed successfully
- live Portal SIWE nonce preflight and POST accept the preview origin

## Production
The exact production hotfix preview is `https://landing-page-p4mef58hl-aomi-labs.vercel.app`. Vercel promotion requires an owner-level production role.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790329365&installation_model_id=12362&pr_number=536&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F536&signature=f36eaeb484418f671a59e431b4b5940d8ac34be0644b481d00f0ac4ccae683a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->