### PR TITLE
Fix Privy auto-signing gate and embedded-EOA transaction sends

### DIFF
--- a/apps/portal/src/components/shell/overlay-portal.tsx
+++ b/apps/portal/src/components/shell/overlay-portal.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect, useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+
+/**
+ * Renders full-page overlays (settings, packages) at `<body>` while keeping
+ * their React tree where they are mounted.
+ *
+ * Both matter. The DOM escape lets one backdrop cover the sidebar and the chat
+ * as a single surface, which is why these overlays used to be siblings of
+ * `AomiFrame.Root`. But `AomiFrame.Root` is what mounts the Aomi runtime, so
+ * a sibling sees `useOptionalAomiRuntime() === null` and cannot read the live
+ * thread — that is how "Open a chat thread before enabling automatic signing."
+ * came to fire with a chat open. A portal keeps the context and moves only the
+ * DOM, so the overlays can live inside the frame.
+ */
+export function OverlayPortal({ children }: { children: ReactNode }) {
+  const [host, setHost] = useState<HTMLElement | null>(null);
+
+  // document.body only exists after mount; SSR renders nothing.
+  useEffect(() => setHost(document.body), []);
+
+  if (!host) return null;
+  return createPortal(
+    // `position: fixed` makes this a stacking context, so the z-index the
+    // modals set inside it counts only against each other. It needs its own
+    // to clear the sidebar's `z-10`.
+    <div
+      className="fixed inset-0"
+      data-slot="overlay-portal"
+      style={{ zIndex: 60 }}
+    >
+      {children}
+    </div>,
+    host,
+  );
+}

--- a/apps/portal/src/components/shell/portal-aomi-frame.test.tsx
+++ b/apps/portal/src/components/shell/portal-aomi-frame.test.tsx
@@ -1,5 +1,6 @@
 import { act, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
 
 import { PortalAomiFrame, ThreadUrlBootstrap } from "./portal-aomi-frame";
 
@@ -29,6 +30,7 @@ const runtimeState = vi.hoisted(() => ({
     currentThreadId: "initial",
     threadMetadata: new Map<string, unknown>(),
     selectThread: vi.fn(),
+    createThread: vi.fn(async () => "thread-new"),
   },
 }));
 
@@ -44,13 +46,17 @@ vi.mock("@aomi-labs/widget-lib", async () => {
       Root: ({
         accountSessionAvailable,
         applicationId,
+        children,
         showSidebar,
       }: {
         accountSessionAvailable: boolean;
         applicationId?: string | null;
+        children?: React.ReactNode;
         showSidebar?: boolean;
       }) => {
         const [instance] = React.useState(() => ++frameInstances.next);
+        // Renders children: the real Root mounts the Aomi runtime around
+        // them, so anything the portal shell nests here must stay nested.
         return (
           <div
             data-account-session-available={String(accountSessionAvailable)}
@@ -58,10 +64,14 @@ vi.mock("@aomi-labs/widget-lib", async () => {
             data-instance={instance}
             data-show-sidebar={String(showSidebar)}
             data-testid="aomi-frame"
-          />
+          >
+            {children}
+          </div>
         );
       },
-      Header: () => null,
+      Header: ({ children }: { children?: React.ReactNode }) => (
+        <div>{children}</div>
+      ),
       Composer: () => null,
     },
     useAomiWalletKit: () => walletKitState.current,
@@ -79,6 +89,28 @@ vi.mock("@portal/lib/settings-api", () => ({
 
 vi.mock("@portal/components/shell/use-portal-wallet-account-menu", () => ({
   usePortalWalletAccountMenu: () => undefined,
+}));
+
+vi.mock("@portal/components/shell/header-controls", () => ({
+  HeaderControls: ({ onOpenSettings }: { onOpenSettings: () => void }) => (
+    <button type="button" onClick={onOpenSettings}>
+      Open settings
+    </button>
+  ),
+}));
+
+vi.mock("@portal/components/settings/settings-modal", () => ({
+  SettingsModal: () => <div data-testid="settings-modal" />,
+}));
+
+// Renders in place so the assertion below can check where the overlay is
+// mounted in the React tree; the real component portals it to <body>.
+vi.mock("@portal/components/shell/overlay-portal", () => ({
+  OverlayPortal: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@portal/features/general/svm-wallet-binding-gate", () => ({
+  SvmWalletBindingGate: () => null,
 }));
 
 describe("PortalAomiFrame account bootstrap", () => {
@@ -114,6 +146,25 @@ describe("PortalAomiFrame account bootstrap", () => {
       "true",
     );
     expect(document.querySelector('main[aria-busy="true"]')).toBeNull();
+  });
+
+  it("mounts settings inside the frame so it can read the Aomi runtime", async () => {
+    walletKitState.current = {
+      accountStatus: "ready",
+      accountUser: { id: "acct-a" },
+    };
+    render(<PortalAomiFrame />);
+
+    await act(async () => {
+      screen.getByRole("button", { name: "Open settings" }).click();
+    });
+
+    // Rendered as a sibling of the frame, the settings account tab sees no
+    // runtime and reports "Open a chat thread before enabling automatic
+    // signing." with a chat open. It must stay a descendant.
+    expect(screen.getByTestId("aomi-frame")).toContainElement(
+      screen.getByTestId("settings-modal"),
+    );
   });
 
   it("mounts the anonymous frame after a signed-out lookup resolves", async () => {

--- a/apps/portal/src/components/shell/portal-aomi-frame.tsx
+++ b/apps/portal/src/components/shell/portal-aomi-frame.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { AomiFrame, useAomiWalletKit } from "@aomi-labs/widget-lib";
 import { useAomiRuntime, usePerThreadControl } from "@aomi-labs/react";
 import { HeaderControls } from "@portal/components/shell/header-controls";
+import { OverlayPortal } from "@portal/components/shell/overlay-portal";
 import { PackagesModal } from "@portal/components/shell/packages-modal";
 import { SettingsModal } from "@portal/components/settings/settings-modal";
 import {
@@ -219,13 +220,20 @@ export function PortalAomiFrame() {
           }}
         />
         <SvmWalletBindingGate />
+        {/* Inside the frame so they see the Aomi runtime (the settings
+            account tab needs the live thread id); portalled to <body> so one
+            backdrop still covers the sidebar and chat as one surface. */}
+        {overlay === "settings" && (
+          <OverlayPortal>
+            <SettingsModal onClose={() => setOverlay("none")} />
+          </OverlayPortal>
+        )}
+        {overlay === "packages" && (
+          <OverlayPortal>
+            <PackagesModal onClose={() => setOverlay("none")} />
+          </OverlayPortal>
+        )}
       </AomiFrame.Root>
-      {overlay === "settings" && (
-        <SettingsModal onClose={() => setOverlay("none")} />
-      )}
-      {overlay === "packages" && (
-        <PackagesModal onClose={() => setOverlay("none")} />
-      )}
     </main>
   );
 }

--- a/apps/shadcn-registry/src/components/runtime-tx-handler.tsx
+++ b/apps/shadcn-registry/src/components/runtime-tx-handler.tsx
@@ -350,8 +350,9 @@ export function RuntimeTxHandler() {
               });
 
           if (!adapter.sendTransaction) {
-            await rejectWalletRequest(req.id, "Wallet provider is not ready");
-            return;
+            throw new Error(
+              "This wallet cannot send transactions. Reconnect a wallet that can and retry.",
+            );
           }
 
           const defaultChainId =
@@ -512,10 +513,21 @@ export function RuntimeTxHandler() {
         }
       } catch (error) {
         console.error("[RuntimeTxHandler] Request failed:", error);
-        await rejectWalletRequest(
-          req.id,
-          error instanceof Error ? error.message : "Request failed",
-        );
+        const reason =
+          error instanceof Error ? error.message : "Request failed";
+        // A rejection only travels back to the agent. Surface it to the user
+        // too: when the wallet never prompts, a silent reject reads as the
+        // request having been ignored.
+        showNotification({
+          type: "error",
+          title:
+            req.kind === "signing"
+              ? "Could not sign the request"
+              : "Could not send the transaction",
+          message: reason,
+          duration: 8000,
+        });
+        await rejectWalletRequest(req.id, reason);
       }
     }
   }, [

--- a/apps/shadcn-registry/src/lib/wallet-kit/providers/privy/PrivyPluginProvider.tsx
+++ b/apps/shadcn-registry/src/lib/wallet-kit/providers/privy/PrivyPluginProvider.tsx
@@ -39,6 +39,11 @@ import {
 import type { PrivyClientConfig } from "@privy-io/react-auth";
 import { buildPrivySvmWalletState } from "./privy-svm";
 import { sendPrivySmartWalletTransaction } from "./privy-execution";
+import {
+  sendPrivyEmbeddedTransaction,
+  switchPrivyEmbeddedChain,
+  type PrivyEmbeddedEvmWallet,
+} from "./privy-embedded-execution";
 import { useEmbeddedSessionSource } from "../sources/embedded-session-source";
 
 export type AomiPrivyPluginProviderProps = {
@@ -235,6 +240,32 @@ export function AomiPrivyPluginProvider({
     [privy.authenticated],
   );
 
+  // Which key actually signs and sends for EVM, decided once so signing and
+  // execution can never disagree about the address.
+  //
+  // An external wallet (MetaMask, Rabby, WalletConnect) wins when one is
+  // connected: it owns both lanes through wagmi, so we add no overrides. Then
+  // the embedded EOA, which is also the address the kit publishes as the
+  // user's identity (`sessionEvmAddress` above) and therefore the address the
+  // backend quotes against. The client smart account is last: it only becomes
+  // the signer when there is no embedded EOA to be the identity, so a swap
+  // priced for the EOA can never be sent from the smart account.
+  const externalSignerActive = evmRuntime.shouldUseExternalSigner;
+  const embeddedSigner = useMemo<{
+    wallet: PrivyEmbeddedEvmWallet;
+    owner: Hex;
+  } | null>(
+    () =>
+      !externalSignerActive && embeddedEvmWallet && embeddedEvmAddress
+        ? { wallet: embeddedEvmWallet, owner: embeddedEvmAddress }
+        : null,
+    [embeddedEvmAddress, embeddedEvmWallet, externalSignerActive],
+  );
+  const smartWalletSigner =
+    !externalSignerActive && !embeddedSigner && smartWalletClient
+      ? smartWalletClient
+      : null;
+
   const svmRuntime = useSvmWalletRuntime({
     preferDirectSend,
     registryStore: evmRuntime.registryStore,
@@ -246,83 +277,117 @@ export function AomiPrivyPluginProvider({
   const executionRuntime = useMemo<ExecutionRuntime>(
     () => ({
       evm: buildEvmExecutionRuntime(evmRuntime, {
-        signMessage:
-          embeddedEvmWallet && embeddedEvmAddress
-            ? async (payload: WalletEip712Payload) => {
-                const owner = payload.signer ?? embeddedEvmAddress;
-                if (owner.toLowerCase() !== embeddedEvmAddress.toLowerCase()) {
+        signMessage: embeddedSigner
+          ? async (payload: WalletEip712Payload) => {
+              const owner = payload.signer ?? embeddedSigner.owner;
+              if (owner.toLowerCase() !== embeddedSigner.owner.toLowerCase()) {
+                throw new Error(
+                  "The active Privy EOA is not the requested signer",
+                );
+              }
+              if (!payload.non_typed_data) {
+                throw new Error("Missing non_typed_data payload");
+              }
+              const provider =
+                await embeddedSigner.wallet.getEthereumProvider();
+              const signature = await provider.request({
+                method: "personal_sign",
+                params: [payload.non_typed_data, owner],
+              });
+              if (typeof signature !== "string") {
+                throw new Error("Privy returned an invalid signature");
+              }
+              return { signature };
+            }
+          : undefined,
+        // The embedded EOA deliberately sets no `sendTransaction`: leaving it
+        // unset lets `buildEvmExecutionRuntime` wrap the primitives below in
+        // the shared executor, which handles chain selection, sequential
+        // batches, nonce-safe ordering and partial-batch reporting.
+        sendTransaction:
+          smartWalletSigner && execution?.aa !== "off"
+            ? async (payload) =>
+                sendPrivySmartWalletTransaction({
+                  payload,
+                  smartWalletClient: smartWalletSigner,
+                  getClientForChain,
+                  wagmiChainId: evmRuntime.activeEvmConnection?.chainId,
+                  smartAddress,
+                })
+            : undefined,
+        ...(embeddedSigner
+          ? {
+              sendTransactionAsync: async (args: {
+                chainId?: number;
+                to: Hex;
+                value?: bigint;
+                data?: Hex;
+              }) => {
+                // wagmi types both as optional; the shared executor always
+                // resolves a chain before it calls this.
+                if (args.chainId === undefined) {
                   throw new Error(
-                    "The active Privy EOA is not the requested signer",
+                    "Privy embedded sends require a resolved chain id",
                   );
                 }
-                if (!payload.non_typed_data) {
-                  throw new Error("Missing non_typed_data payload");
-                }
-                const provider = await embeddedEvmWallet.getEthereumProvider();
-                const signature = await provider.request({
-                  method: "personal_sign",
-                  params: [payload.non_typed_data, owner],
+                return sendPrivyEmbeddedTransaction({
+                  wallet: embeddedSigner.wallet,
+                  owner: embeddedSigner.owner,
+                  chainId: args.chainId,
+                  to: args.to,
+                  value: args.value ?? BigInt(0),
+                  data: args.data,
                 });
-                if (typeof signature !== "string") {
-                  throw new Error("Privy returned an invalid signature");
-                }
+              },
+              switchChainAsync: async ({ chainId }: { chainId: number }) =>
+                switchPrivyEmbeddedChain(embeddedSigner.wallet, chainId),
+              // No EIP-5792 on the embedded EOA, so batches go out as
+              // sequential sends rather than a `sendCalls` the wallet would
+              // reject.
+              sendCallsSyncAsync: undefined,
+              capabilities: undefined,
+            }
+          : {}),
+        signTypedData: embeddedSigner
+          ? async (payload: WalletEip712Payload) => {
+              const owner = payload.signer ?? embeddedSigner.owner;
+              if (owner.toLowerCase() !== embeddedSigner.owner.toLowerCase()) {
+                throw new Error(
+                  "The active Privy EOA is not the requested signer",
+                );
+              }
+              const args = toViemSignTypedDataArgs(payload);
+              if (!args) throw new Error("Missing typed_data payload");
+              const provider =
+                await embeddedSigner.wallet.getEthereumProvider();
+              const signature = await provider.request({
+                method: "eth_signTypedData_v4",
+                params: [owner, JSON.stringify(args)],
+              });
+              if (typeof signature !== "string") {
+                throw new Error("Privy returned an invalid signature");
+              }
+              return { signature };
+            }
+          : smartWalletSigner
+            ? async (payload: WalletEip712Payload) => {
+                const args = toViemSignTypedDataArgs(payload);
+                if (!args) throw new Error("Missing typed_data payload");
+                const signature = await smartWalletSigner.signTypedData(
+                  args as never,
+                );
                 return { signature };
               }
             : undefined,
-        sendTransaction:
-          execution?.aa === "off"
-            ? undefined
-            : smartWalletClient
-              ? async (payload) =>
-                  sendPrivySmartWalletTransaction({
-                    payload,
-                    smartWalletClient,
-                    getClientForChain,
-                    wagmiChainId: evmRuntime.activeEvmConnection?.chainId,
-                    smartAddress,
-                  })
-              : undefined,
-        signTypedData:
-          embeddedEvmWallet && embeddedEvmAddress
-            ? async (payload: WalletEip712Payload) => {
-                const owner = payload.signer ?? embeddedEvmAddress;
-                if (owner.toLowerCase() !== embeddedEvmAddress.toLowerCase()) {
-                  throw new Error(
-                    "The active Privy EOA is not the requested signer",
-                  );
-                }
-                const args = toViemSignTypedDataArgs(payload);
-                if (!args) throw new Error("Missing typed_data payload");
-                const provider = await embeddedEvmWallet.getEthereumProvider();
-                const signature = await provider.request({
-                  method: "eth_signTypedData_v4",
-                  params: [owner, JSON.stringify(args)],
-                });
-                if (typeof signature !== "string") {
-                  throw new Error("Privy returned an invalid signature");
-                }
-                return { signature };
-              }
-            : smartWalletClient
-              ? async (payload: WalletEip712Payload) => {
-                  const args = toViemSignTypedDataArgs(payload);
-                  if (!args) throw new Error("Missing typed_data payload");
-                  const signature = await smartWalletClient.signTypedData(
-                    args as never,
-                  );
-                  return { signature };
-                }
-              : undefined,
       }),
     }),
     [
-      embeddedEvmAddress,
-      embeddedEvmWallet,
+      embeddedSigner,
       evmRuntime,
       execution,
       getClientForChain,
       smartAddress,
-      smartWalletClient,
+      smartWalletSigner,
     ],
   );
   const accountRuntime = useResolvedAccountRuntime({

--- a/apps/shadcn-registry/src/lib/wallet-kit/providers/privy/privy-embedded-execution.test.ts
+++ b/apps/shadcn-registry/src/lib/wallet-kit/providers/privy/privy-embedded-execution.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from "vitest";
+import { mainnet, base } from "viem/chains";
+import { buildEvmExecutionRuntime } from "../../execution/execution-runtime";
+import type { EvmWalletRuntime } from "../../runtime/evm/wallet-runtime";
+import {
+  parseCaip2EvmChainId,
+  sendPrivyEmbeddedTransaction,
+  switchPrivyEmbeddedChain,
+  type PrivyEmbeddedEvmWallet,
+} from "./privy-embedded-execution";
+
+const OWNER = "0xac4f2C0e2C9C1B4C4E7C5f2b1a9d8e7C6b5A4321";
+
+function embeddedWallet(overrides?: {
+  chainId?: string;
+  request?: ReturnType<typeof vi.fn>;
+}): PrivyEmbeddedEvmWallet & {
+  request: ReturnType<typeof vi.fn>;
+  switchChain: ReturnType<typeof vi.fn>;
+} {
+  const request =
+    overrides?.request ?? vi.fn(async () => "0x" + "1".repeat(64));
+  const switchChain = vi.fn(async () => {});
+  return {
+    address: OWNER,
+    chainId: overrides?.chainId ?? "eip155:1",
+    switchChain,
+    getEthereumProvider: async () => ({ request }),
+    request,
+  };
+}
+
+describe("parseCaip2EvmChainId", () => {
+  it("reads the reference out of an eip155 CAIP-2 id", () => {
+    expect(parseCaip2EvmChainId("eip155:8453")).toBe(8453);
+  });
+
+  it("ignores non-EVM and malformed ids", () => {
+    expect(parseCaip2EvmChainId("solana:mainnet")).toBeUndefined();
+    expect(parseCaip2EvmChainId(undefined)).toBeUndefined();
+    expect(parseCaip2EvmChainId("eip155:not-a-number")).toBeUndefined();
+  });
+});
+
+describe("switchPrivyEmbeddedChain", () => {
+  it("skips the switch when the wallet is already on the chain", async () => {
+    const wallet = embeddedWallet({ chainId: "eip155:8453" });
+    await switchPrivyEmbeddedChain(wallet, 8453);
+    expect(wallet.switchChain).not.toHaveBeenCalled();
+  });
+
+  it("switches when the wallet is on another chain", async () => {
+    const wallet = embeddedWallet({ chainId: "eip155:1" });
+    await switchPrivyEmbeddedChain(wallet, 8453);
+    expect(wallet.switchChain).toHaveBeenCalledWith(8453);
+  });
+});
+
+describe("sendPrivyEmbeddedTransaction", () => {
+  it("broadcasts through the embedded provider after switching chains", async () => {
+    const wallet = embeddedWallet({ chainId: "eip155:1" });
+
+    const hash = await sendPrivyEmbeddedTransaction({
+      wallet,
+      owner: OWNER,
+      chainId: 8453,
+      to: "0x1111111111111111111111111111111111111111",
+      value: BigInt(255),
+      data: "0xdeadbeef",
+    });
+
+    expect(wallet.switchChain).toHaveBeenCalledWith(8453);
+    expect(wallet.request).toHaveBeenCalledWith({
+      method: "eth_sendTransaction",
+      params: [
+        {
+          from: OWNER,
+          to: "0x1111111111111111111111111111111111111111",
+          value: "0xff",
+          data: "0xdeadbeef",
+        },
+      ],
+    });
+    expect(hash).toMatch(/^0x/);
+  });
+
+  it("refuses to send from an address that is not the embedded EOA", async () => {
+    const wallet = embeddedWallet();
+    await expect(
+      sendPrivyEmbeddedTransaction({
+        wallet,
+        owner: "0x9999999999999999999999999999999999999999",
+        chainId: 1,
+        to: "0x1111111111111111111111111111111111111111",
+        value: BigInt(0),
+      }),
+    ).rejects.toThrow("not the requested sender");
+    expect(wallet.request).not.toHaveBeenCalled();
+  });
+
+  it("rejects a provider that answers with something other than a hash", async () => {
+    const wallet = embeddedWallet({ request: vi.fn(async () => null) });
+    await expect(
+      sendPrivyEmbeddedTransaction({
+        wallet,
+        owner: OWNER,
+        chainId: 1,
+        to: "0x1111111111111111111111111111111111111111",
+        value: BigInt(0),
+      }),
+    ).rejects.toThrow("invalid transaction hash");
+  });
+});
+
+describe("embedded EOA execution through the shared executor", () => {
+  /**
+   * The regression this guards: with no `sendTransaction` and no Privy smart
+   * wallet, the kit used to fall through to a wagmi connector that was never
+   * connected, so a swap was rejected before any Privy prompt appeared.
+   */
+  it("sends a pending transaction from the embedded EOA", async () => {
+    const wallet = embeddedWallet({ chainId: "eip155:1" });
+    const evmRuntime = {
+      activeConnector: undefined,
+      capabilities: undefined,
+      chainsById: { 1: mainnet, 8453: base },
+      activeEvmConnection: { address: OWNER, chainId: 1 },
+      shouldUseExternalSigner: false,
+    } as unknown as EvmWalletRuntime;
+
+    const runtime = buildEvmExecutionRuntime(evmRuntime, {
+      chainsById: { 1: mainnet, 8453: base },
+      currentChainId: 1,
+      sendTransactionAsync: async (args) =>
+        sendPrivyEmbeddedTransaction({
+          wallet,
+          owner: OWNER,
+          chainId: args.chainId as number,
+          to: args.to,
+          value: args.value ?? BigInt(0),
+          data: args.data,
+        }),
+      sendCallsSyncAsync: undefined,
+      capabilities: undefined,
+    });
+
+    expect(runtime.sendTransaction).toBeDefined();
+    const result = await runtime.sendTransaction!({
+      to: "0x1111111111111111111111111111111111111111",
+      value: "0x0",
+      data: "0xabcdef",
+      chainId: 1,
+    });
+
+    expect(wallet.request).toHaveBeenCalledTimes(1);
+    expect(result.txHash).toMatch(/^0x/);
+  });
+});

--- a/apps/shadcn-registry/src/lib/wallet-kit/providers/privy/privy-embedded-execution.ts
+++ b/apps/shadcn-registry/src/lib/wallet-kit/providers/privy/privy-embedded-execution.ts
@@ -1,0 +1,92 @@
+"use client";
+
+import type { Hex } from "viem";
+
+/**
+ * The slice of Privy's `ConnectedWallet` the embedded EOA execution path uses.
+ * Narrow on purpose: the tests build one from a couple of stubs.
+ */
+export type PrivyEmbeddedEvmWallet = {
+  address: string;
+  /** CAIP-2, e.g. `eip155:8453`. */
+  chainId?: string;
+  switchChain: (chainId: `0x${string}` | number) => Promise<void>;
+  getEthereumProvider: () => Promise<{
+    request: (args: { method: string; params?: unknown[] }) => Promise<unknown>;
+  }>;
+};
+
+/** `eip155:8453` -> `8453`. Undefined for anything that isn't an EVM CAIP-2. */
+export function parseCaip2EvmChainId(
+  caip2: string | undefined,
+): number | undefined {
+  if (!caip2) return undefined;
+  const [namespace, reference] = caip2.split(":");
+  if (namespace !== "eip155") return undefined;
+  const chainId = Number(reference);
+  return Number.isInteger(chainId) && chainId > 0 ? chainId : undefined;
+}
+
+function toQuantity(value: bigint): Hex {
+  return `0x${value.toString(16)}`;
+}
+
+/**
+ * Put the embedded wallet on `chainId` if it isn't already.
+ *
+ * Privy pins a provider to the chain it was built on and does not migrate
+ * existing instances, so callers must re-request `getEthereumProvider()`
+ * afterwards — `sendPrivyEmbeddedTransaction` does exactly that.
+ */
+export async function switchPrivyEmbeddedChain(
+  wallet: PrivyEmbeddedEvmWallet,
+  chainId: number,
+): Promise<void> {
+  if (parseCaip2EvmChainId(wallet.chainId) === chainId) return;
+  await wallet.switchChain(chainId);
+}
+
+/**
+ * Broadcast one call from Privy's embedded EOA.
+ *
+ * This is the path the portal takes for every Privy user without a client
+ * smart account. Without it the kit had no EVM send for the embedded wallet
+ * at all: the request fell through to a wagmi connector that was never
+ * connected, threw, and was rejected before any Privy prompt could appear.
+ */
+export async function sendPrivyEmbeddedTransaction({
+  wallet,
+  owner,
+  chainId,
+  to,
+  value,
+  data,
+}: {
+  wallet: PrivyEmbeddedEvmWallet;
+  owner: string;
+  chainId: number;
+  to: Hex;
+  value: bigint;
+  data?: Hex;
+}): Promise<string> {
+  if (owner.toLowerCase() !== wallet.address.toLowerCase()) {
+    throw new Error("The active Privy EOA is not the requested sender");
+  }
+  await switchPrivyEmbeddedChain(wallet, chainId);
+  const provider = await wallet.getEthereumProvider();
+  const hash = await provider.request({
+    method: "eth_sendTransaction",
+    params: [
+      {
+        from: owner,
+        to,
+        value: toQuantity(value),
+        ...(data ? { data } : {}),
+      },
+    ],
+  });
+  if (typeof hash !== "string") {
+    throw new Error("Privy returned an invalid transaction hash");
+  }
+  return hash;
+}

--- a/apps/shadcn-registry/src/registry.ts
+++ b/apps/shadcn-registry/src/registry.ts
@@ -366,6 +366,7 @@ export const registry: RegistryComponent[] = [
       "lib/wallet-kit/providers/privy/PrivyPluginProvider.tsx",
       "lib/wallet-kit/providers/privy/PrivyProvider.tsx",
       "lib/wallet-kit/providers/privy/privy-auth.ts",
+      "lib/wallet-kit/providers/privy/privy-embedded-execution.ts",
       "lib/wallet-kit/providers/privy/privy-execution.ts",
       "lib/wallet-kit/providers/privy/privy-delegation-context.ts",
       "lib/wallet-kit/providers/privy/privy-delegation.tsx",

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -2,6 +2,47 @@
 
 ## Last Updated
 
+2026-08-26 — Two Privy bugs reported from #builders (Waves): the automatic-
+signing toggle always answered "Open a chat thread before enabling automatic
+signing." with a chat open, and a swap's approve never popped a Privy prompt.
+
+Bug 1 was structural. SettingsModal/PackagesModal were siblings of
+`AomiFrame.Root`, which is what mounts `AomiRuntimeApiProvider`, so
+`useOptionalAomiRuntime()` in `use-account-acl.ts` was ALWAYS null and the
+thread guard could never pass from settings. They now render inside
+`AomiFrame.Root` and reach `<body>` through the new
+`apps/portal/src/components/shell/overlay-portal.tsx`, which keeps the React
+context and moves only the DOM so one backdrop still covers sidebar + chat.
+The portal container needs its own `zIndex: 60`: `position: fixed` makes it a
+stacking context, so the modals' own z-60 counts only inside it and the
+sidebar's z-10 painted over the left edge (caught in the browser, fixed,
+re-verified). Deliberately NOT fixed by feeding it the synthetic settings
+session id from `settings-api.ts` — that would bind the delegation grant to an
+unrelated "settings thread". The portal-aomi-frame test mock now renders Root's
+children (it did not before, which is what hid this) and asserts the nesting.
+
+Bug 2: the portal runs Privy through the plugin lane (`privyPlugin.wrap` ->
+plain `PrivyProvider`, no `@privy-io/wagmi`), so the embedded EOA is a
+synthetic session, not a wagmi connector. `PrivyPluginProvider` gave it
+`signMessage`/`signTypedData` but no send path — `sendTransaction` existed only
+when a client smart wallet did — so sends fell through to a wagmi connector
+that was never connected, threw, and `RuntimeTxHandler` rejected them into the
+console. New `privy-embedded-execution.ts` sends via
+`switchChain` + fresh `getEthereumProvider()` + `eth_sendTransaction`, wired in
+as `sendTransactionAsync`/`switchChainAsync` overrides so the shared executor
+keeps owning batching, nonce ordering and partial-batch reporting.
+Signer choice is now one decision (`embeddedSigner` / `smartWalletSigner`):
+external wagmi wallet wins, then the embedded EOA — which is the identity the
+backend quotes against — and the client smart account only when there is no
+embedded EOA, so a swap priced for the EOA can no longer be sent from the smart
+account. `RuntimeTxHandler` now also surfaces failures as an error
+notification instead of console-only.
+UNVERIFIED end to end: no Privy credentials or backend in this worktree, so the
+delegation call and a real embedded-EOA broadcast were not exercised. Covered
+by unit tests (`privy-embedded-execution.test.ts`, incl. one through
+`buildEvmExecutionRuntime`) and the overlay was browser-verified against the
+portal dev server.
+
 2026-08-25 — Payment rails split out of /pricing (Cecilia). The x402 deferred
 credit gate explainer from aomi-design
 `communication/info/x402-deferred-credit-gate.html` now lives at


### PR DESCRIPTION
Fixes the two Privy issues reported by Waves in `#🛠-builders`. Both live in the Privy **plugin lane** — the one the portal actually uses (`AomiWalletKitProvider` → `privyPlugin.wrap`), not the standalone `AomiPrivyProvider` lane.

## 1. "Open a chat thread before enabling automatic signing." with a chat open

`use-account-acl.ts` reads the thread id from `useOptionalAomiRuntime()`, but `SettingsModal` was rendered as a **sibling** of `<AomiFrame.Root>` — and `AomiFrame.Root` is what mounts `AomiRuntimeApiProvider`. So the hook returned `null` every time and the guard could never pass, chat open or not. The existing test mocked the runtime as present, which is why CI stayed green.

Fix: the settings and packages overlays now render **inside** `AomiFrame.Root` and reach `<body>` through a new `OverlayPortal`. React portals preserve context, so the modal keeps the live thread id while one backdrop still covers the sidebar and the chat as a single surface.

Deliberately **not** fixed by handing it the synthetic settings session id from `settings-api.ts` — that would bind the delegation grant to an unrelated "settings thread".

One subtlety worth knowing: the portal container needs its own `z-index`. `position: fixed` makes it a stacking context, so the modals' `z-60` counts only inside it and the sidebar's `z-10` painted over the panel's left edge. Caught in the browser, fixed, re-verified.

## 2. Swap approval never pops a Privy prompt

In this lane the Privy embedded EOA is a *synthetic* session, not a wagmi connector (no `@privy-io/wagmi` provider here). `PrivyPluginProvider` gave it `signMessage` and `signTypedData` but **no send path** — `sendTransaction` existed only when a client smart wallet did. Without one, sends fell through to `sendTransactionAsync({ connector: undefined })`, threw connector-not-connected, and `RuntimeTxHandler` rejected the request into the console. No dialog, no Privy modal.

Fix: `privy-embedded-execution.ts` sends from the embedded EOA — `switchChain` (skipped when already on the target, read from its CAIP-2 `chainId`), a fresh `getEthereumProvider()` (Privy does not migrate existing provider instances), then `eth_sendTransaction`. It is wired in as `sendTransactionAsync` / `switchChainAsync` overrides rather than a whole `sendTransaction`, so the shared executor keeps owning chain selection, sequential batches, nonce-safe ordering and partial-batch reporting.

## 3. Address consistency

Signer choice is now one decision instead of three independent ternaries:

1. an external wagmi wallet (MetaMask/Rabby/WalletConnect) if one is connected — no overrides, wagmi owns both lanes;
2. otherwise the embedded EOA, which is the address the kit publishes as the identity and therefore the address the backend quotes against;
3. the client smart account only when there is no embedded EOA to be the identity.

Previously a smart-wallet user got quotes priced for the EOA and sends executed from the smart account.

Also: `RuntimeTxHandler` now surfaces wallet failures as an error notification instead of `console.error` only — a silent reject reads to the user as the request having been ignored.

## Expected behaviour after this

- Auto-signing off → a swap's approve pops the Privy confirmation.
- Privy delegation granted and the wallet set to auto → the backend signs; no prompt.

## Testing

- `privy-embedded-execution.test.ts` — chain-switch skip/switch, `eth_sendTransaction` params, owner mismatch, bad provider reply, plus one end-to-end through `buildEvmExecutionRuntime` that guards the exact regression.
- `portal-aomi-frame.test.tsx` — the `AomiFrame.Root` mock now renders children (it silently dropped them before, which is what hid bug 1) and asserts the settings overlay stays a descendant of the frame.
- Full suites green: shadcn-registry 361, portal 399. Typecheck and eslint clean.
- Overlay layering browser-verified against the portal dev server (settings + packages, backdrop dismiss).

**Not verified end to end**: this worktree has no Privy credentials, `DATABASE_URL`, or backend, so the delegation call and a real embedded-EOA broadcast were not exercised against live Privy. Worth a manual pass on staging with Waves' setup before release.

## Known adjacent issue, not fixed here

When an external wallet is active in this lane, `signTypedData`/`signMessage` now correctly fall back to wagmi instead of throwing "The active Privy EOA is not the requested signer". That was previously a hard throw and is improved by the routing change, but the external-wallet-plus-Privy combination has had no dedicated test coverage either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790341902&installation_model_id=12362&pr_number=538&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F538&signature=e24505040f7208163d953ac9ddcbbdb54697d371f299a0823ba8656477512a92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->