### PR TITLE
hotfix(prod): recover Safari client load failures

### DIFF
--- a/apps/portal/src/app/client-error-recovery.test.ts
+++ b/apps/portal/src/app/client-error-recovery.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  claimClientReload,
+  isRecoverableClientError,
+} from "./client-error-recovery";
+
+function memoryStorage() {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, value),
+  };
+}
+
+describe("client error recovery", () => {
+  it.each([
+    new Error("Load failed"),
+    new Error("Loading chunk 123 failed"),
+    new TypeError("Failed to fetch dynamically imported module"),
+    new TypeError("Importing a module script failed"),
+  ])("recognizes browser module loading failures", (error) => {
+    expect(isRecoverableClientError(error)).toBe(true);
+  });
+
+  it("does not reload for an application exception", () => {
+    expect(isRecoverableClientError(new Error("Invalid wallet state"))).toBe(
+      false,
+    );
+  });
+
+  it("allows one automatic reload per cooldown", () => {
+    const storage = memoryStorage();
+
+    expect(claimClientReload(storage, 1_000)).toBe(true);
+    expect(claimClientReload(storage, 2_000)).toBe(false);
+    expect(claimClientReload(storage, 61_000)).toBe(true);
+  });
+
+  it("fails closed when Safari storage is unavailable", () => {
+    const storage = {
+      getItem: () => {
+        throw new Error("SecurityError");
+      },
+      setItem: () => undefined,
+    };
+
+    expect(claimClientReload(storage)).toBe(false);
+  });
+});

--- a/apps/portal/src/app/client-error-recovery.ts
+++ b/apps/portal/src/app/client-error-recovery.ts
@@ -1,0 +1,35 @@
+const RELOAD_KEY = "aomi:portal:client-recovery";
+const RELOAD_COOLDOWN_MS = 60_000;
+
+const recoverableMessages = [
+  /chunkloaderror/i,
+  /loading chunk [\s\S]* failed/i,
+  /failed to fetch dynamically imported module/i,
+  /importing a module script failed/i,
+  /unable to preload css/i,
+  /(^|: )load failed$/i,
+];
+
+export function isRecoverableClientError(error: Error): boolean {
+  const message = `${error.name}: ${error.message}`;
+  return recoverableMessages.some((pattern) => pattern.test(message));
+}
+
+export function claimClientReload(
+  storage: Pick<Storage, "getItem" | "setItem">,
+  now = Date.now(),
+): boolean {
+  try {
+    const stored = storage.getItem(RELOAD_KEY);
+    const previous = stored === null ? Number.NaN : Number(stored);
+    if (Number.isFinite(previous) && now - previous < RELOAD_COOLDOWN_MS) {
+      return false;
+    }
+    storage.setItem(RELOAD_KEY, String(now));
+    return true;
+  } catch {
+    // Safari can deny storage access in constrained/private contexts. A
+    // reload without a marker could loop forever, so leave recovery manual.
+    return false;
+  }
+}

--- a/apps/portal/src/app/global-error.tsx
+++ b/apps/portal/src/app/global-error.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect } from "react";
+
+import {
+  claimClientReload,
+  isRecoverableClientError,
+} from "./client-error-recovery";
+
+export default function GlobalError({ error }: { error: Error }) {
+  useEffect(() => {
+    if (
+      isRecoverableClientError(error) &&
+      claimClientReload(window.sessionStorage)
+    ) {
+      window.location.reload();
+    }
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body style={{ margin: 0 }}>
+        <main
+          style={{
+            alignItems: "center",
+            background: "#f7f7f5",
+            color: "#171717",
+            display: "flex",
+            fontFamily:
+              'Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+            justifyContent: "center",
+            minHeight: "100vh",
+            padding: "24px",
+          }}
+        >
+          <section style={{ maxWidth: "440px", textAlign: "center" }}>
+            <p
+              style={{
+                fontSize: "20px",
+                fontWeight: 700,
+                letterSpacing: "-0.04em",
+                margin: "0 0 24px",
+              }}
+            >
+              aomi
+            </p>
+            <h1
+              style={{
+                fontSize: "28px",
+                letterSpacing: "-0.03em",
+                lineHeight: 1.15,
+                margin: "0 0 12px",
+              }}
+            >
+              Aomi needs a fresh start
+            </h1>
+            <p
+              style={{ color: "#5f5f5b", lineHeight: 1.6, margin: "0 0 24px" }}
+            >
+              This browser could not finish loading the session. Saved chats are
+              safe.
+            </p>
+            <button
+              type="button"
+              onClick={() => window.location.reload()}
+              style={{
+                background: "#171717",
+                border: 0,
+                borderRadius: "999px",
+                color: "white",
+                cursor: "pointer",
+                fontSize: "15px",
+                fontWeight: 600,
+                padding: "12px 22px",
+              }}
+            >
+              Reload Aomi
+            </button>
+          </section>
+        </main>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
## Production hotfix

Promotes the Safari client-load recovery in #541 to the `prod` branch.

- candidate SHA: `f6404a4f568d5672e1810728cb50bd2ae04faf24`
- current production frontend SHA: `3bab836546eb42e3ea5b2aafddbeef5fde70761e`
- target: `prod` / `chat.aomi.dev`
- scope: Portal client error recovery only; no backend, database, auth, wallet policy, or environment change

## Required order

#541 must merge to `main` before this production PR merges, preserving an identical fix on the normal release line. This PR is intentionally left unmerged for explicit review/merge authorization.

## Verification

- `pnpm --filter portal test` — 429 passed
- `pnpm --filter portal type-check`
- `pnpm --filter portal lint` — 0 errors, 3 pre-existing warnings
- `pnpm exec prettier --check ...`
- `git diff --check`
- local production build was blocked only by network access to the existing Google Fonts imports; required GitHub/Vercel checks must pass before merge

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790433737&installation_model_id=12362&pr_number=542&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F542&signature=563e3594362cc5868e4fd16a7acd90d80bca7fa73715f640dce8966db66daea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->