### PR TITLE
Remove trailing gap below landing footer

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -1,5 +1,12 @@
 # Canonical Landing
 
+Current session goal: **FULL-BLEED FOOTER BOUNDARY VERIFIED 2026-08-30** — the
+blue footer now stays flush with every viewport edge and the decorative
+atmosphere layer ends at the real landing-content boundary instead of extending
+the document below the footer. Playwright checks at 390px, 1440px, 2048px, and
+3090px confirm zero visible bottom or side gaps, no horizontal overflow, clean
+console output, and retained animated canvases.
+
 Current session goal: **HOMEPAGE PRIORITY COPY AND LINK AUDIT VERIFIED
 2026-08-29** — applied the approved homepage language updates from the latest
 `main`, routed the primary conversation CTA and team CTA to Contact, and removed

--- a/apps/landing/public/assets/landing/home/atmosphere.js
+++ b/apps/landing/public/assets/landing/home/atmosphere.js
@@ -56,10 +56,16 @@
         Math.max(0, window.scrollY + rect.bottom),
       );
     }, 0);
-    const documentHeight = Math.max(
-      document.documentElement.scrollHeight,
-      document.body.scrollHeight,
-    );
+    const page = Array.from(
+      document.querySelectorAll("#dc-root .landing-page"),
+    ).find((candidate) => {
+      const rect = candidate.getBoundingClientRect();
+      return rect.width > 0 && rect.height > 0;
+    });
+    const pageRect = page?.getBoundingClientRect();
+    const documentHeight = pageRect
+      ? window.scrollY + pageRect.bottom
+      : document.body.scrollHeight;
 
     if (atmosphereStart <= 0 || documentHeight <= window.innerHeight) return;
 


### PR DESCRIPTION
## Summary
- bound the decorative landing atmosphere to the rendered landing-page height instead of the self-influenced document scroll height
- remove the fixed-size strip below the blue footer while preserving the animated background scenes
- keep the footer flush with both viewport sides and the document bottom

## Root cause
`#landing-atmosphere` used `documentElement.scrollHeight`, which included an extra fixed-nav-sized contribution in the local Next document. The absolute atmosphere layer therefore extended about 54px beyond the real landing content and became the document scroll boundary.

## Verification
- `pnpm exec prettier --check GOAL.md apps/landing/public/assets/landing/home/atmosphere.js`
- `pnpm run lint`
- `pnpm run lint:landing`
- `pnpm run typecheck:landing` after clearing stale generated `.next/types`
- `pnpm run build:lib`
- `pnpm run build:landing`
- optimized-build Playwright checks at 390, 1440, 2048, and 3090px: zero side/bottom gaps, zero horizontal overflow, no console errors, atmosphere canvases initialized

## Visual QA
Local bottom-of-page capture confirmed the blue footer fills the viewport edge-to-edge with no trailing white strip.

## Package audit
No publishable npm package source changed, so no package version bump is required.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790664089&installation_model_id=12362&pr_number=549&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F549&signature=fe0412535e9a193b3d6294bbbf4baa3e090379f0c5cfd49fedb18f6c7c8789c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->