### PR TITLE
Resolve opaque bearer session tokens in public API principal resolution

### DIFF
--- a/apps/portal/src/server/oauth/principal.test.ts
+++ b/apps/portal/src/server/oauth/principal.test.ts
@@ -126,7 +126,13 @@ describe("public OAuth and session principal resolution", () => {
     expect(mocks.getBetterAuthSession).not.toHaveBeenCalled();
   });
 
-  it("rejects opaque legacy bearer sessions", async () => {
+  it("resolves opaque bearer session tokens through Better Auth, rejecting unknowns", async () => {
+    // The guest/SDK flow carries the Better Auth session token as a Bearer
+    // (no cookie cross-origin); the bearer plugin resolves it via getSession.
+    mocks.getBetterAuthSession.mockResolvedValueOnce({
+      user: { id: "ba-guest", isAnonymous: true },
+      session: {},
+    });
     await expect(
       resolveApiPrincipal({
         request: new Request(resource, {
@@ -136,8 +142,20 @@ describe("public OAuth and session principal resolution", () => {
         requiredScopes: ["agent:read"],
         sessionScopes: ["agent:read"],
       }),
+    ).resolves.toMatchObject({ principalClass: "guest" });
+
+    // A bearer no session resolves to is still rejected.
+    mocks.getBetterAuthSession.mockResolvedValueOnce(null);
+    await expect(
+      resolveApiPrincipal({
+        request: new Request(resource, {
+          headers: { authorization: "Bearer unknown-token" },
+        }),
+        resource,
+        requiredScopes: ["agent:read"],
+        sessionScopes: ["agent:read"],
+      }),
     ).rejects.toMatchObject({ code: "invalid_token", status: 401 });
-    expect(mocks.getBetterAuthSession).not.toHaveBeenCalled();
   });
 
   it("rejects canonical identity disagreement and elevated guest scopes", async () => {

--- a/apps/portal/src/server/oauth/principal.ts
+++ b/apps/portal/src/server/oauth/principal.ts
@@ -106,13 +106,18 @@ export async function resolveApiPrincipal(input: {
     return principal;
   }
 
-  if (input.request.headers.has("authorization")) {
-    throw new ApiPrincipalError(401, "invalid_token");
-  }
-
+  // A non-JWT bearer is a Better Auth session token: the bearer plugin lets
+  // getSession resolve it, which is how guest/SDK clients (no cookie
+  // cross-origin) carry their session. An unresolvable credential still lands
+  // on the trailing 401.
   const session = await getBetterAuthSession(input.request);
   if (session?.user?.id) {
-    enforceCookieCsrf(input.request);
+    // Cookie-carried sessions are browser-ambient and need CSRF proof; a
+    // request bearing an Authorization header cannot be forged cross-site
+    // (custom headers force a CORS preflight), so it passes without one.
+    if (!input.request.headers.has("authorization")) {
+      enforceCookieCsrf(input.request);
+    }
     const canonical = await getOrCreateAomiUserForBetterAuthSession({
       betterAuthUserId: session.user.id,
       email: session.user.email,


### PR DESCRIPTION
Staging chat was bouncing every guest turn: the client sends the Better Auth session token (from `set-auth-token`) as an Authorization bearer on `/v1/agent/*`, and `resolveApiPrincipal` hard-401'd any non-JWT authorization header before consulting `getSession` — the FE then looped through `sign-in/anonymous` (400, already signed in) and reverted to the start page.

- Non-JWT bearers now resolve through Better Auth's bearer plugin via `getSession`; unknown credentials still 401.
- CSRF proof stays required for cookie-carried sessions and is skipped when an Authorization header is present (custom headers force a CORS preflight, so they cannot be forged cross-site).
- Updated the principal test that pinned the old reject-all-opaque-bearers contract; guest bearer now resolves, unknown bearer still rejects. 400/400 oauth suite green, portal typecheck clean.

Pairs with the staging infra fix already applied: `agent-staging-2.aomi.dev` tunnel ingress + DNS for the api-server, and `AOMI_AGENT_API_URL`/guest-REST flags on the chat-portal preview env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/550"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790665152&installation_model_id=12362&pr_number=550&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F550&signature=0b063d94afc39288a495ca40e1b21527ee0b4a72052dd562356017e93d5b79e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->