### PR TITLE
Project legacy tool_result message events as tool parts

### DIFF
--- a/packages/react/src/runtime/__tests__/event-projection.test.ts
+++ b/packages/react/src/runtime/__tests__/event-projection.test.ts
@@ -60,6 +60,41 @@ describe("projectAssistantMessages", () => {
     ]);
   });
 
+  it("projects legacy tool_result message events as tool parts", () => {
+    // The recorder still bridges tool steps as agent messages carrying the
+    // legacy [label, json] tuple; the contract-typed events never arrive.
+    const events: Event[] = [
+      {
+        ...meta(1, "message", "turn-1"),
+        type: "message",
+        sender: "agent",
+        content: "",
+        message_key: "tool-step-1",
+        tool_result: [
+          "Read vitalik.eth ETH balance",
+          '{"balance_eth":"6.64"}',
+        ],
+      } as Event,
+      {
+        ...meta(2, "message", "turn-1"),
+        type: "message",
+        sender: "agent",
+        content: "vitalik.eth holds 6.64 ETH",
+        message_key: "agent-1",
+      },
+    ];
+
+    expect(projectAssistantMessages(events)[0]?.content).toMatchObject([
+      {
+        type: "tool-call",
+        toolCallId: "legacy:tool-step-1",
+        toolName: "Read vitalik.eth ETH balance",
+        result: { balance_eth: "6.64" },
+      },
+      { type: "text", text: "vitalik.eth holds 6.64 ETH" },
+    ]);
+  });
+
   it("replaces streaming message revisions by message key", () => {
     const messages: Event[] = [
       {

--- a/packages/react/src/runtime/utils.ts
+++ b/packages/react/src/runtime/utils.ts
@@ -122,6 +122,22 @@ type AssistantProjection = {
   toolParts: Map<string, number>;
 };
 
+/** Insert a part once per key, replacing it in place on re-delivery. */
+const upsertPart = (
+  projection: AssistantProjection,
+  registry: Map<string, number>,
+  key: string,
+  part: MessageContentPart,
+) => {
+  const index = registry.get(key);
+  if (index === undefined) {
+    registry.set(key, projection.parts.length);
+    projection.parts.push(part);
+  } else {
+    projection.parts[index] = part;
+  }
+};
+
 const toolPart = (
   event: ToolUpdateEvent | ToolCompleteEvent,
 ): MessageContentPart =>
@@ -132,6 +148,41 @@ const toolPart = (
     args: undefined,
     result: event.result,
   }) as MessageContentPart;
+
+/**
+ * The backend's event ledger still bridges tool steps as agent `message`
+ * events carrying a legacy `[label, json]` tuple in `tool_result` — a field
+ * its OpenAPI contract does not declare, so the generated MessageEvent type
+ * cannot see it. Until the recorder emits real tool_update/tool_complete
+ * events, this is the only wire shape tool steps arrive in; drop it and every
+ * trace renders as an empty "Working" shell.
+ */
+const legacyToolResult = (event: MessageEvent): [string, string] | null => {
+  const raw = (event as { tool_result?: unknown }).tool_result;
+  if (!Array.isArray(raw) || raw.length < 2) return null;
+  const [label, payload] = raw;
+  if (typeof label !== "string" || typeof payload !== "string") return null;
+  return [label, payload];
+};
+
+const legacyToolPart = (
+  [label, payload]: [string, string],
+  key: string,
+): MessageContentPart => {
+  let result: unknown = payload;
+  try {
+    result = JSON.parse(payload);
+  } catch {
+    // Non-JSON payloads render verbatim.
+  }
+  return {
+    type: "tool-call",
+    toolCallId: `legacy:${key}`,
+    toolName: label,
+    args: undefined,
+    result,
+  } as MessageContentPart;
+};
 
 /**
  * Pure Assistant UI projection over the canonical ordered event ledger.
@@ -171,13 +222,14 @@ export function projectAssistantMessages(
       if (event.sender === "agent") {
         const projection = assistantTurn(event);
         const key = event.message_key ?? event.event_id;
-        const index = projection.textParts.get(key);
-        const part = { type: "text", text: event.content } as MessageContentPart;
-        if (index === undefined) {
-          projection.textParts.set(key, projection.parts.length);
-          projection.parts.push(part);
+        const toolResult = legacyToolResult(event);
+        if (toolResult) {
+          upsertPart(projection, projection.toolParts, key, legacyToolPart(toolResult, key));
         } else {
-          projection.parts[index] = part;
+          upsertPart(projection, projection.textParts, key, {
+            type: "text",
+            text: event.content,
+          } as MessageContentPart);
         }
         continue;
       }
@@ -200,15 +252,12 @@ export function projectAssistantMessages(
       event.tool_name !== "task"
     ) {
       const projection = assistantTurn(event);
-      const key = event.call_id ?? event.id;
-      const index = projection.toolParts.get(key);
-      const part = toolPart(event);
-      if (index === undefined) {
-        projection.toolParts.set(key, projection.parts.length);
-        projection.parts.push(part);
-      } else {
-        projection.parts[index] = part;
-      }
+      upsertPart(
+        projection,
+        projection.toolParts,
+        event.call_id ?? event.id,
+        toolPart(event),
+      );
     }
   }
 


### PR DESCRIPTION
Fix (b) from the staging chat diagnosis: tool steps arrive in the public event ledger as agent `message` events carrying the legacy `[label, json]` `tool_result` tuple (undeclared in the OpenAPI contract), while the FE projection consumes only `tool_update`/`tool_complete` events the recorder never emits — so every tool trace rendered as an empty "Working" shell and chats looked like no tools ran.

- One typed accessor (`legacyToolResult`) documents the contract gap and narrows the undeclared field; matching messages project as tool-call parts keyed by `message_key`.
- The canonical tool-event path is untouched — both wire shapes coexist, so when the backend starts emitting contract events this path simply stops firing.
- The three part-upsert sites now share one `upsertPart` helper.
- New projection test with the real wire shape; 730 package tests green, apps typecheck clean.

Verified against live staging: a read-only probe turn's ledger (`activate_skills`, chain-context, balance-read steps) projects into visible tool parts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/552"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790686407&installation_model_id=12362&pr_number=552&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F552&signature=95267901478fc6178758ab15a653e77cabbf747ba58de0f6c12de78afd6d75e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->