### PR TITLE
Enable self-custodial guest SDK flows

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -1,5 +1,16 @@
 # Canonical Landing
 
+Current session goal: **GUEST SELF-CUSTODY API AND SDK FIXES VERIFIED
+2026-08-30** — guest Agent sessions can resolve their own staged actions and
+guest Pipeline sessions can execute self-custodial operations without gaining
+delegated custody or payment authority. Node clients now reuse Better Auth's
+opaque guest bearer directly, local widget origins can bootstrap against hosted
+Portal environments, third-party widget origins no longer conflict with the
+internal anonymous sign-in, and the Portal exposes the Pipeline root, OpenAPI,
+and API catalog routes backed by api-server. Client/account/Portal typechecks,
+scoped lint, the client build, 431 tests, and a live staging guest Agent plus
+Pipeline catalog smoke pass.
+
 Current session goal: **PRIVY LOGIN POLICY DRIFT FIXED 2026-08-30** — the
 portal no longer hard-codes login methods into Privy's modal. The Privy app
 configuration is now the single authority, so disabled providers such as

--- a/apps/examples/headless-client/src/agent/guest.ts
+++ b/apps/examples/headless-client/src/agent/guest.ts
@@ -2,8 +2,8 @@ import { Aomi } from "@aomi-labs/client";
 
 const baseUrl = process.env.AOMI_BASE_URL?.trim() || "http://localhost:3000";
 
-// Guest mode is the SDK default. The first request creates an anonymous
-// session; the client then keeps and reuses its official session cookie.
+// Guest mode is the SDK default. In Node, the first request creates an
+// anonymous Better Auth session and reuses its opaque bearer credential.
 const aomi = new Aomi({ baseUrl });
 const sessionId = crypto.randomUUID();
 

--- a/apps/examples/headless-client/src/pipeline/guest.ts
+++ b/apps/examples/headless-client/src/pipeline/guest.ts
@@ -2,8 +2,9 @@ import { Aomi } from "@aomi-labs/client";
 
 const baseUrl = process.env.AOMI_BASE_URL?.trim() || "http://localhost:3000";
 
-// Guest mode can inspect the guest-safe Pipeline catalog without an OAuth
-// client. Executing protected operations requires the appropriate authority.
+// Guest mode can inspect and execute self-custodial Pipeline operations
+// without an OAuth client. Payments and delegated custody still require an
+// authenticated account grant.
 const aomi = new Aomi({ baseUrl });
 const [apps, skills] = await Promise.all([
   aomi.raw.pipeline.apps.list(),

--- a/apps/examples/headless-client/src/walkthrough.ts
+++ b/apps/examples/headless-client/src/walkthrough.ts
@@ -12,9 +12,9 @@ const baseUrl = process.env.AOMI_BASE_URL?.trim() || "http://localhost:3000";
 // 1. Create one SDK facade.
 //
 // With only `baseUrl`, guest mode is on by default. The client creates one
-// Better Auth anonymous session on the first request, keeps its official
-// session cookie in memory in Node, and reuses it. There is no API key setup
-// step. Public `/v1` account login is a separate OAuth or first-party session
+// Better Auth anonymous session on the first request, keeps its opaque session
+// bearer in memory in Node, and reuses it. There is no API key setup step.
+// Public `/v1` account login is a separate OAuth or first-party session
 // concern; this walkthrough intentionally demonstrates the working guest path.
 const aomi = new Aomi({ baseUrl });
 

--- a/apps/portal/src/app/.well-known/api-catalog/route.ts
+++ b/apps/portal/src/app/.well-known/api-catalog/route.ts
@@ -1,0 +1,8 @@
+import { proxyAgentApiDiscovery } from "@portal/server/agent-api-proxy";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export function GET(request: Request): Promise<Response> {
+  return proxyAgentApiDiscovery(request);
+}

--- a/apps/portal/src/app/api/auth/widget/guest/route.test.ts
+++ b/apps/portal/src/app/api/auth/widget/guest/route.test.ts
@@ -54,11 +54,18 @@ describe("widget guest bootstrap", () => {
     const response = await POST(
       new Request("https://portal.example/api/auth/widget/guest", {
         method: "POST",
-        headers: { origin: "https://partner.example" },
+        headers: {
+          origin: "https://partner.example",
+          referer: "https://partner.example/app",
+        },
       }),
     );
 
     expect(response.status).toBe(200);
+    const authHeaders = mocks.signInAnonymous.mock.calls[0]?.[0]
+      ?.headers as Headers;
+    expect(authHeaders.get("origin")).toBeNull();
+    expect(authHeaders.get("referer")).toBeNull();
     expect(mocks.issueWidgetSession).toHaveBeenCalledWith({
       userId: "user-1",
       origin: "https://partner.example",

--- a/apps/portal/src/app/api/auth/widget/guest/route.ts
+++ b/apps/portal/src/app/api/auth/widget/guest/route.ts
@@ -15,8 +15,14 @@ export const POST = widgetRoute(async (request: Request) => {
   const limited = widgetAuthRateLimit(request);
   if (limited) return limited;
   const origin = requireWidgetOrigin(request);
+  // The widget origin was validated above. Better Auth's server-side anonymous
+  // sign-in must not re-interpret that third-party Origin as a request to one
+  // of its own browser endpoints.
+  const authHeaders = new Headers(request.headers);
+  authHeaders.delete("origin");
+  authHeaders.delete("referer");
   const anonymous = await auth.api.signInAnonymous({
-    headers: request.headers,
+    headers: authHeaders,
   });
   const user = await getOrCreateAomiUserForBetterAuthSession({
     betterAuthUserId: anonymous.user.id,

--- a/apps/portal/src/app/openapi.json/route.ts
+++ b/apps/portal/src/app/openapi.json/route.ts
@@ -1,0 +1,8 @@
+import { proxyAgentApiDiscovery } from "@portal/server/agent-api-proxy";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export function GET(request: Request): Promise<Response> {
+  return proxyAgentApiDiscovery(request);
+}

--- a/apps/portal/src/app/v1/pipeline/route.ts
+++ b/apps/portal/src/app/v1/pipeline/route.ts
@@ -1,0 +1,1 @@
+export { GET } from "./[...slug]/route";

--- a/apps/portal/src/server/agent-api-proxy.test.ts
+++ b/apps/portal/src/server/agent-api-proxy.test.ts
@@ -6,7 +6,11 @@ vi.mock("@aomi-labs/account", () => ({
   mintAgentApiBearer: mocks.mintAgentApiBearer,
 }));
 
-import { configuredAgentApiUrl, proxyAgentApi } from "./agent-api-proxy";
+import {
+  configuredAgentApiUrl,
+  proxyAgentApi,
+  proxyAgentApiDiscovery,
+} from "./agent-api-proxy";
 
 const principal = {
   canonicalUserId: "canonical-user",
@@ -118,6 +122,53 @@ describe("Agent API proxy", () => {
     expect(headers.get("idempotency-key")).toBe("pipeline-1");
     expect(headers.get("payment-signature")).toBe("payment-1");
   });
+
+  it("proxies the exact Pipeline root", async () => {
+    vi.stubEnv("AOMI_AGENT_API_URL", "http://api-server:8082");
+    const upstream = vi
+      .fn()
+      .mockResolvedValue(Response.json({ resources: [] }));
+    const response = await proxyAgentApi(
+      new Request("https://portal.example/v1/pipeline"),
+      {
+        ...principal,
+        scopes: ["pipeline:catalog"],
+        resource: "https://portal.example/v1/pipeline",
+      },
+      upstream,
+    );
+    expect(response.status).toBe(200);
+    expect(String(upstream.mock.calls[0]?.[0])).toBe(
+      "http://api-server:8082/v1/pipeline",
+    );
+  });
+
+  it.each(["/openapi.json", "/.well-known/api-catalog"])(
+    "proxies public API discovery at %s without minting a bearer",
+    async (path) => {
+      vi.stubEnv("AOMI_AGENT_API_URL", "http://api-server:8082");
+      const upstream = vi.fn().mockResolvedValue(Response.json({ ok: true }));
+      const response = await proxyAgentApiDiscovery(
+        new Request(`https://portal.example${path}`, {
+          headers: {
+            accept: "application/json",
+            "payment-signature": "must-not-forward",
+            "x-request-id": "discovery-1",
+          },
+        }),
+        upstream,
+      );
+      expect(response.status).toBe(200);
+      expect(String(upstream.mock.calls[0]?.[0])).toBe(
+        `http://api-server:8082${path}`,
+      );
+      const headers = new Headers(upstream.mock.calls[0]?.[1]?.headers);
+      expect(headers.get("accept")).toBe("application/json");
+      expect(headers.get("x-request-id")).toBe("discovery-1");
+      expect(headers.get("payment-signature")).toBeNull();
+      expect(mocks.mintAgentApiBearer).not.toHaveBeenCalled();
+    },
+  );
 
   it("rejects paths outside the public Agent and Pipeline namespaces", async () => {
     const upstream = vi.fn();

--- a/apps/portal/src/server/agent-api-proxy.ts
+++ b/apps/portal/src/server/agent-api-proxy.ts
@@ -48,7 +48,9 @@ export async function proxyAgentApi(
 ): Promise<Response> {
   const incoming = new URL(request.url);
   if (
+    incoming.pathname !== "/v1/agent" &&
     !incoming.pathname.startsWith("/v1/agent/") &&
+    incoming.pathname !== "/v1/pipeline" &&
     !incoming.pathname.startsWith("/v1/pipeline/")
   ) {
     return Response.json(
@@ -85,6 +87,37 @@ export async function proxyAgentApi(
     // Node fetch requires this for a streamed Request body.
     duplex: "half",
   } as RequestInit & { duplex: "half" });
+  return new Response(response.body, {
+    status: response.status,
+    headers: allowlisted(response.headers, RESPONSE_HEADERS),
+  });
+}
+
+const DISCOVERY_PATHS = new Set(["/openapi.json", "/.well-known/api-catalog"]);
+const DISCOVERY_REQUEST_HEADERS = new Set(["accept", "x-request-id"]);
+
+/** Public read-only discovery proxy for the api-server contract. */
+export async function proxyAgentApiDiscovery(
+  request: Request,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Response> {
+  const incoming = new URL(request.url);
+  if (request.method !== "GET" || !DISCOVERY_PATHS.has(incoming.pathname)) {
+    return Response.json(
+      { error: { code: "not_found", message: "Not found" } },
+      { status: 404 },
+    );
+  }
+  const upstream = new URL(
+    `${incoming.pathname}${incoming.search}`,
+    configuredAgentApiUrl(),
+  );
+  const response = await fetchImpl(upstream, {
+    method: "GET",
+    headers: allowlisted(request.headers, DISCOVERY_REQUEST_HEADERS),
+    cache: "no-store",
+    redirect: "manual",
+  });
   return new Response(response.body, {
     status: response.status,
     headers: allowlisted(response.headers, RESPONSE_HEADERS),

--- a/apps/portal/src/server/oauth/principal.test.ts
+++ b/apps/portal/src/server/oauth/principal.test.ts
@@ -48,7 +48,12 @@ vi.mock("./resources", () => ({
   }),
   guestScopesForAomiResource: (_resource: string, scopes: string[]) =>
     scopes.filter((scope) =>
-      ["agent:read", "agent:write", "offline_access"].includes(scope),
+      [
+        "agent:read",
+        "agent:write",
+        "agent:actions:resolve",
+        "offline_access",
+      ].includes(scope),
     ),
 }));
 
@@ -181,7 +186,7 @@ describe("public OAuth and session principal resolution", () => {
     expect(mocks.getBetterAuthSession).not.toHaveBeenCalled();
   });
 
-  it("keeps anonymous widget sessions capability-bounded and unable to resolve actions", async () => {
+  it("lets anonymous widgets resolve their own actions within the guest ceiling", async () => {
     mocks.resolveWidgetSession.mockResolvedValue({
       userId: "canonical-guest",
       origin: "https://partner.example",
@@ -204,7 +209,7 @@ describe("public OAuth and session principal resolution", () => {
       }),
     ).resolves.toMatchObject({
       canonicalUserId: "canonical-guest",
-      scopes: ["agent:write"],
+      scopes: ["agent:write", "agent:actions:resolve"],
       principalClass: "user",
     });
 
@@ -221,7 +226,11 @@ describe("public OAuth and session principal resolution", () => {
         requiredScopes: ["agent:actions:resolve"],
         sessionScopes: ["agent:read", "agent:write", "agent:actions:resolve"],
       }),
-    ).rejects.toMatchObject({ code: "insufficient_scope", status: 403 });
+    ).resolves.toMatchObject({
+      canonicalUserId: "canonical-guest",
+      scopes: ["agent:actions:resolve"],
+      principalClass: "user",
+    });
   });
 
   it.each(["siwe", "siws"])(

--- a/apps/portal/src/server/oauth/principal.ts
+++ b/apps/portal/src/server/oauth/principal.ts
@@ -93,14 +93,12 @@ export async function resolveApiPrincipal(input: {
       }
     }
     const scopes = [...new Set(input.requiredScopes)];
-    // An authenticated widget that can create an agent turn also needs to
-    // resolve that turn's staged action. Keep the grant narrow: anonymous
-    // widgets cannot resolve actions and no custody/MCP OAuth scopes are
-    // inherited.
+    // A widget that can create an agent turn also needs to resolve that
+    // turn's staged action. The guest ceiling permits that self-custodial
+    // continuation while still excluding custody, payment, and MCP scopes.
     if (
-      !isAnonymousWidget &&
       input.requiredScopes.includes("agent:write") &&
-      input.sessionScopes.includes("agent:actions:resolve")
+      allowedSessionScopes.includes("agent:actions:resolve")
     ) {
       scopes.push("agent:actions:resolve");
     }
@@ -115,7 +113,7 @@ export async function resolveApiPrincipal(input: {
       // Widget requests are delegated through the BFF as user-class thread
       // credentials so the backend can select the configured guest-safe
       // model. The original widget auth method still applies the guest scope
-      // ceiling above, including denial of action resolution.
+      // ceiling above.
       principalClass: "user",
       sid: "widget-session",
       widgetOrigin: widget.origin,

--- a/docs/local-dev-stack.md
+++ b/docs/local-dev-stack.md
@@ -112,8 +112,8 @@ exercise independent rollback with `AOMI_OAUTH_ISSUANCE_ENABLED`,
 `AOMI_REST_OAUTH_ENABLED`, `AOMI_AGENT_MCP_OAUTH_ENABLED`,
 `AOMI_PIPELINE_MCP_OAUTH_ENABLED`, `AOMI_LEGACY_SESSION_AUTH_ENABLED`,
 `AOMI_GUEST_AGENT_REST_ENABLED`, and `AOMI_GUEST_PIPELINE_REST_ENABLED`.
-Pipeline guest execution has a separate
-`AOMI_GUEST_PIPELINE_EXECUTION_ENABLED` switch and backend allowlists.
+Guest Agent and Pipeline sessions can complete self-custodial work, while
+payment submission and delegated custody remain outside the guest scope ceiling.
 
 ## Product-Mono Notes
 

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aomi-labs/account",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Server-only account graph: resolve-or-create the canonical user and mint AccountBearers. Node-only; never bundle into a browser.",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/account/src/better-auth/oauth-policy.test.ts
+++ b/packages/account/src/better-auth/oauth-policy.test.ts
@@ -41,15 +41,32 @@ describe("Aomi OAuth resource policy", () => {
     }
   });
 
-  it("centralizes guest ceilings and the MCP DPoP rollout switch", () => {
+  it("allows self-custodial guest work without privileged scopes", () => {
     const resources = aomiOAuthResources(env);
     expect(
       guestScopesForAomiResource(
         resources.agentRest,
-        ["agent:read", "custody:delegate"],
+        ["agent:read", "agent:actions:resolve", "custody:delegate"],
         env,
       ),
-    ).toEqual(["agent:read"]);
+    ).toEqual(["agent:read", "agent:actions:resolve"]);
+    expect(
+      guestScopesForAomiResource(
+        resources.pipelineRest,
+        ["pipeline:catalog", "pipeline:execute", "payments:submit"],
+        env,
+      ),
+    ).toEqual(["pipeline:catalog", "pipeline:execute"]);
+    expect(
+      guestScopesForAomiResource(
+        resources.pipelineMcp,
+        ["mcp:pipeline", "pipeline:execute", "custody:delegate"],
+        env,
+      ),
+    ).toEqual(["mcp:pipeline", "pipeline:execute"]);
+  });
+
+  it("centralizes the MCP DPoP rollout switch", () => {
     expect(
       aomiOAuthResourcePolicies({
         ...env,

--- a/packages/account/src/better-auth/oauth-policy.ts
+++ b/packages/account/src/better-auth/oauth-policy.ts
@@ -85,28 +85,25 @@ export function aomiOAuthResourcePolicies(
   env: Record<string, string | undefined> = process.env,
 ): readonly AomiOAuthResourcePolicy[] {
   const resources = aomiOAuthResources(env);
-  const guestPipelineExecute =
-    env.AOMI_GUEST_PIPELINE_EXECUTION_ENABLED?.trim().toLowerCase() === "true"
-      ? ["pipeline:execute"]
-      : [];
   const dpopRequired = isMcpDpopRequired(env);
   return [
     {
       kind: "agentRest",
       identifier: resources.agentRest,
       allowedScopes: AGENT_REST_SCOPES,
-      guestScopes: ["agent:read", "agent:write", "offline_access"],
+      guestScopes: [
+        "agent:read",
+        "agent:write",
+        "agent:actions:resolve",
+        "offline_access",
+      ],
       dpopBoundAccessTokensRequired: false,
     },
     {
       kind: "pipelineRest",
       identifier: resources.pipelineRest,
       allowedScopes: PIPELINE_REST_SCOPES,
-      guestScopes: [
-        "pipeline:catalog",
-        ...guestPipelineExecute,
-        "offline_access",
-      ],
+      guestScopes: ["pipeline:catalog", "pipeline:execute", "offline_access"],
       dpopBoundAccessTokensRequired: false,
     },
     {
@@ -123,7 +120,7 @@ export function aomiOAuthResourcePolicies(
       guestScopes: [
         "mcp:pipeline",
         "pipeline:catalog",
-        ...guestPipelineExecute,
+        "pipeline:execute",
         "offline_access",
       ],
       dpopBoundAccessTokensRequired: dpopRequired,

--- a/packages/account/src/widget-auth/origin.ts
+++ b/packages/account/src/widget-auth/origin.ts
@@ -18,7 +18,7 @@ export function requireWidgetOrigin(request: Request): string {
 
 export function observedWidgetOrigin(
   request: Request,
-  nodeEnv = process.env.NODE_ENV,
+  _nodeEnv = process.env.NODE_ENV,
 ): string | null {
   const rawOrigin = request.headers.get("origin");
   if (!rawOrigin || rawOrigin === "null") return null;
@@ -30,11 +30,7 @@ export function observedWidgetOrigin(
   }
   if (origin.origin !== rawOrigin) return null;
   if (origin.protocol === "https:") return origin.origin;
-  if (
-    nodeEnv !== "production" &&
-    origin.protocol === "http:" &&
-    LOCAL_WIDGET_HOSTS.has(origin.hostname)
-  ) {
+  if (origin.protocol === "http:" && LOCAL_WIDGET_HOSTS.has(origin.hostname)) {
     return origin.origin;
   }
   return null;

--- a/packages/account/test/widget-session.test.ts
+++ b/packages/account/test/widget-session.test.ts
@@ -107,7 +107,7 @@ describe("widget sessions", () => {
     expect(tickets.size).toBe(0);
   });
 
-  it("requires explicit secure origins, with localhost HTTP only outside production", () => {
+  it("requires explicit secure origins, with localhost HTTP in every environment", () => {
     expect(
       observedWidgetOrigin(
         new Request("https://portal.example", {
@@ -128,6 +128,14 @@ describe("widget sessions", () => {
       observedWidgetOrigin(
         new Request("https://portal.example", {
           headers: { Origin: "http://localhost:3001" },
+        }),
+        "production",
+      ),
+    ).toBe("http://localhost:3001");
+    expect(
+      observedWidgetOrigin(
+        new Request("https://portal.example", {
+          headers: { Origin: "http://192.168.1.20:3001" },
         }),
         "production",
       ),

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aomi-labs/client",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Platform-agnostic TypeScript client for the Aomi backend API",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/client/src/guest-auth.ts
+++ b/packages/client/src/guest-auth.ts
@@ -7,7 +7,13 @@ export function createGuestSessionProvider(input: {
   fetch?: typeof fetch;
 }): GuestSessionProvider {
   const fetchImpl = input.fetch ?? globalThis.fetch.bind(globalThis);
+  const browser = typeof location !== "undefined";
   const crossOriginBrowser = isCrossOriginBrowser(input.baseUrl);
+  const runtime = crossOriginBrowser
+    ? "cross-origin-browser"
+    : browser
+      ? "same-origin-browser"
+      : "server";
   let credential: string | null | undefined;
   let pending: Promise<string | null> | null = null;
   const provider = async (options?: { forceRefresh?: boolean }) => {
@@ -16,14 +22,14 @@ export function createGuestSessionProvider(input: {
     // Same-origin requests already carry the Better Auth cookie. Try it before
     // creating an anonymous account so a signed-in user is never replaced by a
     // guest merely because the Agent client initialized.
-    if (!crossOriginBrowser && !options?.forceRefresh) return null;
-    pending ??= signInAnonymous(
-      fetchImpl,
-      input.baseUrl,
-      crossOriginBrowser,
-    ).finally(() => {
-      pending = null;
-    });
+    if (runtime === "same-origin-browser" && !options?.forceRefresh) {
+      return null;
+    }
+    pending ??= signInAnonymous(fetchImpl, input.baseUrl, runtime).finally(
+      () => {
+        pending = null;
+      },
+    );
     credential = await pending;
     return credential;
   };
@@ -42,12 +48,12 @@ function isCrossOriginBrowser(baseUrl: string): boolean {
 async function signInAnonymous(
   fetchImpl: typeof fetch,
   baseUrl: string,
-  crossOriginBrowser: boolean,
+  runtime: "cross-origin-browser" | "same-origin-browser" | "server",
 ) {
   const normalizedBase = baseUrl.replace(/\/+$/, "");
   const authEndpoint = `${normalizedBase}/api/auth/sign-in/anonymous`;
   const response = await fetchImpl(
-    crossOriginBrowser
+    runtime === "cross-origin-browser"
       ? `${normalizedBase}/api/auth/widget/guest`
       : authEndpoint,
     {
@@ -57,7 +63,7 @@ async function signInAnonymous(
         "content-type": "application/json",
       },
       body: "{}",
-      credentials: crossOriginBrowser ? "omit" : "include",
+      credentials: runtime === "same-origin-browser" ? "include" : "omit",
     },
   );
   if (
@@ -69,19 +75,21 @@ async function signInAnonymous(
   if (!response.ok) {
     throw new Error(`Aomi guest sign-in failed with HTTP ${response.status}`);
   }
-  if (!crossOriginBrowser) return null;
-  const token = await response
-    .json()
-    .then((body: unknown) =>
-      body &&
-      typeof body === "object" &&
-      "access_token" in body &&
-      typeof body.access_token === "string"
-        ? body.access_token
-        : null,
-    );
+  if (runtime === "same-origin-browser") return null;
+  const body = await response.json().catch(() => null);
+  const token =
+    runtime === "cross-origin-browser"
+      ? stringProperty(body, "access_token")
+      : (stringProperty(body, "token") ??
+        response.headers.get("set-auth-token"));
   if (!token) throw new Error("Aomi guest sign-in returned no bearer session");
   return token;
+}
+
+function stringProperty(value: unknown, property: string): string | null {
+  if (!value || typeof value !== "object" || !(property in value)) return null;
+  const candidate = (value as Record<string, unknown>)[property];
+  return typeof candidate === "string" && candidate ? candidate : null;
 }
 
 async function responseCode(response: Response) {

--- a/packages/client/test/oauth-auth.unit.test.ts
+++ b/packages/client/test/oauth-auth.unit.test.ts
@@ -141,6 +141,43 @@ describe("public API OAuth transport", () => {
 });
 
 describe("Better Auth guest bootstrap", () => {
+  it("uses the opaque Better Auth session as a bearer in server runtimes", async () => {
+    vi.stubGlobal("window", undefined);
+    vi.stubGlobal("location", undefined);
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(Response.json({ token: "server-guest-session" }));
+    const guest = createGuestSessionProvider({
+      baseUrl: "https://portal.example",
+      fetch: fetchImpl as typeof fetch,
+    });
+
+    await expect(guest()).resolves.toBe("server-guest-session");
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://portal.example/api/auth/sign-in/anonymous",
+      expect.objectContaining({ credentials: "omit" }),
+    );
+  });
+
+  it("accepts Better Auth's session response header in server runtimes", async () => {
+    vi.stubGlobal("window", undefined);
+    vi.stubGlobal("location", undefined);
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(
+        Response.json(
+          { user: { id: "guest" } },
+          { headers: { "set-auth-token": "header-guest-session" } },
+        ),
+      );
+    const guest = createGuestSessionProvider({
+      baseUrl: "https://portal.example",
+      fetch: fetchImpl as typeof fetch,
+    });
+
+    await expect(guest()).resolves.toBe("header-guest-session");
+  });
+
   it("uses the origin-bound widget guest route without credentialed CORS", async () => {
     vi.stubGlobal("location", { origin: "https://widget.example" });
     const fetchImpl = vi


### PR DESCRIPTION
## Summary

- grant guest Agent sessions action-resolution authority and guest Pipeline sessions execution authority without granting payments or delegated custody
- let Node clients bootstrap once and reuse the official opaque Better Auth session bearer
- make hosted widget guest bootstrap work for HTTPS consumers and localhost development by avoiding duplicate third-party Origin validation inside Better Auth
- expose the exact Pipeline root, OpenAPI document, and API catalog through the Portal BFF
- update the guest examples and package patch versions

## Security boundaries

- guests still cannot receive custody:delegate or payments:submit
- action results remain bound to the canonical guest and session by the backend action ledger
- discovery forwarding is GET-only and forwards only Accept and request ID headers
- non-local HTTP widget origins remain rejected

## Verification

- 431 frontend, account, client, and Portal tests passed; one existing test skipped
- client, account, and Portal TypeScript checks passed
- scoped ESLint and Prettier checks passed
- client package build passed
- Next route type generation passed
- live rebuilt-SDK smoke against chat-staging.aomi.dev created a guest bearer, listed 3 Pipeline apps, and completed an Agent turn with the expected reply

## Companion backend PR

- https://github.com/aomi-labs/product-mono/pull/1028

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790709911&installation_model_id=12362&pr_number=553&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F553&signature=654ffae4d33aa7e58213b8c4db8d79f703ee84c4a39e33f889a0f9d8b8a4ac22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->