### PR TITLE
Fix landing SDK and API demos

### DIFF
--- a/apps/landing/app/(marketing)/components/home-interactive.tsx
+++ b/apps/landing/app/(marketing)/components/home-interactive.tsx
@@ -24,19 +24,21 @@ const installers = [
   {
     id: "cli",
     label: "CLI",
-    command: "npm install -g @aomi-labs/cli",
+    command: "npm install -g @aomi-labs/client",
     icon: Terminal,
   },
   {
     id: "mcp",
     label: "MCP",
-    command: "codex mcp add aomi --url https://chat.aomi.dev/api/mcp",
+    command:
+      "codex mcp add aomi-agent --url https://chat.aomi.dev/v1/agent/mcp",
     icon: Waypoints,
   },
   {
     id: "api",
     label: "API",
-    command: "curl https://api.aomi.dev/v1/agents",
+    command:
+      'curl -H "Authorization: Bearer $AOMI_TOKEN" https://chat.aomi.dev/v1/pipeline/apps',
     icon: Code2,
   },
 ] as const;
@@ -246,16 +248,22 @@ const walletSnippets = {
     description:
       "Authenticate an existing EOA. No embedded-provider import required.",
     auth: 'auth={{ kind: "browser_wallet" }}',
+    providerImport: "",
+    login: "aomi account login --wallet",
   },
   Para: {
     description:
       "Resolve a Para wallet while the integrator retains provider credentials.",
-    auth: 'auth={{ kind: "para", provider: para }}',
+    auth: 'auth={{ kind: "embedded_wallet", provider: "para", environment: "PROD" }}',
+    providerImport: 'import "@aomi-labs/widget-lib/providers/para";\n',
+    login: "aomi account login --provider para",
   },
   Privy: {
     description:
       "Use the signed-in Privy wallet as the owner and signing boundary.",
-    auth: 'auth={{ kind: "privy", provider: privy }}',
+    auth: 'auth={{ kind: "embedded_wallet", provider: "privy", environment: "production" }}',
+    providerImport: 'import "@aomi-labs/widget-lib/providers/privy";\n',
+    login: "aomi account login --provider privy",
   },
 } as const;
 
@@ -265,8 +273,8 @@ export function WalletCodeDemo() {
   const [surface, setSurface] = useState<"UI" | "Terminal">("UI");
   const snippet =
     surface === "UI"
-      ? `import { AomiWidget } from "@aomi-labs/widget-lib";\nimport "@aomi-labs/widget-lib/styles.css";\n\nexport default function Assistant() {\n  return (\n    <AomiWidget\n      applicationId={process.env.AOMI_APPLICATION_ID!}\n      apiUrl={process.env.AOMI_API_URL!}\n      ${walletSnippets[wallet].auth}\n    />\n  );\n}`
-      : `aomi auth login --wallet ${wallet.toLowerCase().replace(" ", "-")}\naomi chat "rebalance approved liquidity"\naomi tx list\naomi tx sign <request-id>`;
+      ? `import { AomiWidget } from "@aomi-labs/widget-lib";\n${walletSnippets[wallet].providerImport}import "@aomi-labs/widget-lib/styles.css";\n\nexport default function Assistant() {\n  return (\n    <AomiWidget\n      applicationId={process.env.AOMI_APPLICATION_ID!}\n      apiUrl={process.env.AOMI_API_URL!}\n      ${walletSnippets[wallet].auth}\n    />\n  );\n}`
+      : `${walletSnippets[wallet].login}\naomi chat "rebalance approved liquidity"\naomi tx list\naomi tx sign <request-id>`;
 
   return (
     <div className={styles.walletDemo}>

--- a/apps/landing/app/_marketing/products/api/action-summary-showcase.tsx
+++ b/apps/landing/app/_marketing/products/api/action-summary-showcase.tsx
@@ -7,7 +7,7 @@ import styles from "./rest-api.module.css";
 
 type SourceKey = "agent" | "pipeline" | "safe";
 
-type FieldKey = "title" | "steps" | "cost" | "warnings" | "expiresAt";
+type FieldKey = "id" | "revision" | "state" | "request" | "result";
 
 type SheetStep = {
   label: string;
@@ -35,8 +35,8 @@ const sheetExamples: Record<SourceKey, SheetExample> = {
   agent: {
     tabLabel: "Agent API",
     tabTag: "v1",
-    sourceExpr: "event.action.summary",
-    sourceNote: "from a chat turn",
+    sourceExpr: "event.request",
+    sourceNote: "Action event from a chat turn",
     title: "Swap 0.5 ETH for ~1,240 USDC",
     steps: [
       { label: "Wrap 0.5 ETH", amount: "−0.5 ETH", direction: "out" },
@@ -49,7 +49,7 @@ const sheetExamples: Record<SourceKey, SheetExample> = {
     ],
     cost: "Gas: you pay ~$1.20",
     warning: "Price impact 2.3%",
-    usedFields: ["title", "steps", "cost", "warnings"],
+    usedFields: ["id", "revision", "state", "request"],
     requestLabel: "one call · chat",
     request: [
       "POST /v1/agent/chat",
@@ -58,14 +58,14 @@ const sheetExamples: Record<SourceKey, SheetExample> = {
       "",
       '{ "message": "Swap 0.5 ETH to USDC on Base",',
       '  "app": "aomi",',
-      '  "wallets": { "evm": { "address": "0xAb5…", "chainId": 8453 } } }',
+      '  "userState": { "evm": { "address": "0xAb5…", "chain_id": 8453 } } }',
     ],
   },
   pipeline: {
     tabLabel: "Pipeline API",
-    tabTag: "preview",
-    sourceExpr: "plan.action.summary",
-    sourceNote: "from /v1/pipeline/evm/build",
+    tabTag: "v1",
+    sourceExpr: "commit.action?.request",
+    sourceNote: "when commit returns awaiting_wallet",
     title: "Rotate 2,000 USDC into Morpho",
     steps: [
       {
@@ -82,26 +82,26 @@ const sheetExamples: Record<SourceKey, SheetExample> = {
       },
     ],
     cost: "Gas: sponsored · 1 signature",
-    usedFields: ["title", "steps", "cost"],
-    requestLabel: "three calls · stage, stage, commit",
+    usedFields: ["id", "revision", "state", "request"],
+    requestLabel: "portable build · stage, simulate, commit",
     request: [
       "POST /v1/pipeline/evm/stage",
-      '{ "action": "aave.withdraw", "args": { "amount": "ALL" },',
-      '  "wallet": "0xAb5…", "chainId": 8453 }',
-      '→ { "state": "pst_…", "staged": [{ "id": 1 }] }',
+      '{ "actions": [{ "chainId": 8453, "calls": [',
+      '  { "to": "0x…", "data": "0x…", "value": "0" }',
+      "] }] }",
       "",
-      "POST /v1/pipeline/evm/stage",
-      '{ "state": "pst_…", "action": "morpho.deposit", "args": { "amount": "ALL" } }',
+      "POST /v1/pipeline/evm/simulate",
+      '{ "build": { "version": 1, "status": "staged", … } }',
       "",
       "POST /v1/pipeline/evm/commit",
-      '{ "state": "pst_…", "ids": [1, 2] }        // one batch, one signature',
+      '{ "build": { "version": 1, "status": "simulated", … } }',
     ],
   },
   safe: {
     tabLabel: "Safe signer",
-    tabTag: "deferred",
-    sourceExpr: 'aomi.actions.get("act_…").summary',
-    sourceNote: "same object, any device",
+    tabTag: "recovery",
+    sourceExpr: "pendingAction.request",
+    sourceNote: "same Action revision, any device",
     title: "Transfer 50,000 USDC to treasury ops",
     steps: [
       {
@@ -113,14 +113,12 @@ const sheetExamples: Record<SourceKey, SheetExample> = {
     ],
     cost: "Gas: paid by the Safe",
     deferredHint: "Awaiting 2 of 3 signatures. The Action waits.",
-    usedFields: ["title", "steps", "cost", "expiresAt"],
-    requestLabel: "recover, then report deferred",
+    usedFields: ["id", "revision", "state", "request"],
+    requestLabel: "recover a pending Action",
     request: [
       "GET /v1/agent/chat/{session}?cursor=cur_…",
       "// unresolved actions come back in every delta, from any device",
-      "",
-      "POST /v1/agent/chat/{session}/actions/{action}/result",
-      '{ "status": "deferred", "reference": "safe:tx:0x…" }   // quorum still open',
+      '// report only a supported result: "submitted", "signed", or "rejected"',
     ],
   },
 };
@@ -131,140 +129,71 @@ function interfaceLines(): CodeLine[] {
   const kw = styles.showcaseKw;
   const ty = styles.showcaseTy;
   const cm = styles.showcaseCm;
-  const str = styles.showcaseStr;
-
   return [
     {
       content: (
         <>
           <span className={kw}>interface</span>{" "}
-          <span className={ty}>ActionSummary</span> {"{"}
+          <span className={ty}>Action</span> {"{"}
         </>
       ),
     },
+    { content: '  type: "action"' },
+    { content: "  event_id: string" },
+    { content: "  sequence: number" },
+    { content: "  turn_id: string | null" },
+    { content: "  occurred_at: number" },
     {
-      field: "title",
+      field: "id",
       content: (
         <>
-          {"  title: "}
+          {"  id: "}
           <span className={ty}>string</span>
         </>
       ),
     },
     {
-      field: "steps",
+      field: "revision",
       content: (
         <>
-          {"  steps: "}
-          <span className={ty}>Step</span>
-          {"[]        "}
-          <span className={cm}>{"// what happens, in order"}</span>
+          {"  revision: "}
+          <span className={ty}>number</span>
         </>
       ),
     },
     {
-      field: "cost",
+      field: "state",
       content: (
         <>
-          {"  cost: "}
-          <span className={ty}>Cost</span>
-          {"           "}
-          <span className={cm}>{"// gas payer, fees, all-in"}</span>
+          {"  state: "}
+          <span className={ty}>Action</span>[
+          <span className={cm}>{'"state"'}</span>]
         </>
       ),
     },
     {
-      field: "warnings",
+      field: "request",
       content: (
         <>
-          {"  warnings: "}
-          <span className={ty}>Warning</span>
-          {"[]  "}
-          <span className={cm}>{"// empty = clean"}</span>
+          {"  request: "}
+          <span className={ty}>ActionRequest</span>
+          {"  "}
+          <span className={cm}>{"// execute_evm | execute_svm | sign"}</span>
         </>
       ),
     },
     {
-      field: "expiresAt",
+      field: "result",
       content: (
         <>
-          {"  expiresAt: "}
-          <span className={ty}>string</span> <span className={kw}>|</span>{" "}
+          {"  result?: "}
+          <span className={ty}>ActionResult</span> <span className={kw}>|</span>{" "}
           <span className={kw}>null</span>
         </>
       ),
     },
-    { content: "}" },
-    { content: " " },
-    {
-      content: (
-        <>
-          <span className={kw}>interface</span> <span className={ty}>Step</span>{" "}
-          {"{"}
-        </>
-      ),
-    },
-    {
-      content: (
-        <>
-          {"  label: "}
-          <span className={ty}>string</span>
-        </>
-      ),
-    },
-    {
-      content: (
-        <>
-          {"  detail?: "}
-          <span className={ty}>string</span>
-        </>
-      ),
-    },
-    {
-      content: (
-        <>
-          {"  asset?: {            "}
-          <span className={cm}>{"// present when value moves"}</span>
-        </>
-      ),
-    },
-    {
-      content: (
-        <>
-          {"    direction: "}
-          <span className={str}>&apos;out&apos;</span>{" "}
-          <span className={kw}>|</span>{" "}
-          <span className={str}>&apos;in&apos;</span>
-        </>
-      ),
-    },
-    {
-      content: (
-        <>
-          {"    amount: "}
-          <span className={ty}>string</span>
-          {"    "}
-          <span className={cm}>{"// human units, always"}</span>
-        </>
-      ),
-    },
-    {
-      content: (
-        <>
-          {"    symbol: "}
-          <span className={ty}>string</span>
-        </>
-      ),
-    },
-    {
-      content: (
-        <>
-          {"    usd?: "}
-          <span className={ty}>string</span>
-        </>
-      ),
-    },
-    { content: "  }" },
+    { content: "  created_at: number" },
+    { content: "  expires_at: number | null" },
     { content: "}" },
   ];
 }
@@ -362,14 +291,14 @@ export function ActionSummaryShowcase() {
           ))}
         </div>
         <span className={styles.showcaseChip}>
-          <ShieldCheck aria-hidden /> one ConfirmSheet · every source
+          <ShieldCheck aria-hidden /> one Action renderer · every source
         </span>
       </div>
 
       <div className={styles.showcaseRequest} key={`${source}-req`}>
         <div className={styles.showcaseTypeLabel}>
           <span>{example.requestLabel}</span>
-          <span>raw http · the call that produced the Action</span>
+          <span>raw http · contract-accurate request flow</span>
         </div>
         <RequestCode lines={example.request} />
       </div>
@@ -377,13 +306,13 @@ export function ActionSummaryShowcase() {
       <div className={styles.showcaseBody}>
         <div className={styles.showcaseType}>
           <div className={styles.showcaseTypeLabel}>
-            <span>action.summary</span>
-            <span>typed · sealed by the kernel</span>
+            <span>Action</span>
+            <span>exported by @aomi-labs/client</span>
           </div>
           <InterfaceCode used={example.usedFields} />
           <p className={styles.showcaseTypeFoot}>
             <span>filled by this example</span>
-            {(["title", "steps", "cost", "warnings", "expiresAt"] as const).map(
+            {(["id", "revision", "state", "request", "result"] as const).map(
               (field) => (
                 <em
                   key={field}
@@ -452,15 +381,15 @@ export function ActionSummaryShowcase() {
           </article>
 
           <p className={styles.showcaseFoot}>
-            rendered entirely from the type · the renderer maps over steps
+            approval view derived from Action.request and its simulation
           </p>
         </div>
       </div>
 
       <p className={styles.showcaseCaption}>
-        A single swap, an ordered batch, a transfer waiting on a Safe quorum:
-        the renderer never branches. Ship one confirm sheet and it covers
-        everything either API will ever produce.
+        The host branches on Action.request.type, then renders its exact
+        transactions or signing payload and attached simulation. Pending Actions
+        remain revisioned and recoverable until a supported result is reported.
       </p>
     </div>
   );

--- a/apps/landing/app/_marketing/products/api/api-workbench.tsx
+++ b/apps/landing/app/_marketing/products/api/api-workbench.tsx
@@ -11,81 +11,77 @@ const examples = {
     label: "Agent API",
     version: "v1",
     endpoint: "POST /v1/agent/chat",
-    request: `curl https://api.aomi.dev/v1/agent/chat \\
+    request: `curl https://chat.aomi.dev/v1/agent/chat \\
   -H "Authorization: Bearer $AOMI_TOKEN" \\
   -H "Idempotency-Key: 7c1e…" \\
   -H "Content-Type: application/json" \\
   -d '{
     "message": "Swap 0.5 ETH to USDC on Base",
     "app": "aomi",
-    "wallets": {
+    "userState": {
+      "connection": { "is_connected": true },
       "evm": {
         "address": "0xAb5…",
-        "chainId": 8453
+        "chain_id": 8453
       }
     }
   }'`,
     response: `{
-  "session": "sess_…",
-  "status": "awaiting_action",
-  "actions": [{
-    "id": "act_…",
-    "type": "external_transaction",
-    "summary": {
-      "title": "Swap 0.5 ETH for ~1,240 USDC"
-    },
-    "chainId": 8453,
-    "transactions": [{
-      "to": "0x…",
-      "data": "0x…",
-      "value": "0x0",
-      "simulation": { "success": true }
-    }]
+  "session_id": "sess_…",
+  "cursor": "cur_…",
+  "events": [{
+    "type": "message",
+    "event_id": "evt_…",
+    "sequence": 1,
+    "turn_id": "turn_…",
+    "occurred_at": 1788174000,
+    "sender": "user",
+    "content": "Swap 0.5 ETH to USDC on Base"
   }],
-  "cursor": "cur_…"
+  "has_more": false
 }`,
-    status: "awaiting_action",
-    title: "Swap 0.5 ETH for ~1,240 USDC",
-    detail: "Uniswap v3 · Base · simulated",
+    status: "event page",
+    title: "Ordered events with a durable cursor",
+    detail: "Messages, activity, turn state, and Actions share one event log",
   },
   pipeline: {
     label: "Pipeline API",
-    version: "preview",
-    endpoint: "POST /v1/pipeline/evm/build",
-    request: `curl https://api.aomi.dev/v1/pipeline/evm/build \\
+    version: "v1",
+    endpoint: "POST /v1/pipeline/evm/stage",
+    request: `curl https://chat.aomi.dev/v1/pipeline/evm/stage \\
   -H "Authorization: Bearer $AOMI_TOKEN" \\
   -H "Idempotency-Key: 9a40…" \\
   -H "Content-Type: application/json" \\
   -d '{
-    "action": "aave.supply",
-    "args": {
-      "token": "USDC",
-      "amount": "1000"
-    },
-    "wallet": "0xAb5…",
-    "chainId": 8453
+    "actions": [{
+      "chainId": 8453,
+      "description": "Supply USDC",
+      "calls": [{
+        "to": "0x…",
+        "data": "0x…",
+        "value": "0"
+      }]
+    }]
   }'`,
     response: `{
-  "status": "guards_passed",
-  "plan": {
-    "action": "aave.supply",
+  "version": 1,
+  "status": "staged",
+  "actions": [{
+    "id": "action_0",
+    "chainFamily": "evm",
+    "kind": "calls",
     "chainId": 8453,
-    "guardChecks": [
-      "wallet_bound",
-      "policy_allowed",
-      "simulation_passed"
-    ],
-    "transactions": [{
+    "calls": [{
       "to": "0x…",
       "data": "0x…",
       "value": "0x0"
     }]
-  },
-  "signable": { "ready": true }
+  }],
+  "digest": "sha256:…"
 }`,
-    status: "guards_passed",
-    title: "Supply 1,000 USDC to Aave v3",
-    detail: "3 checks passed · signable ready",
+    status: "staged",
+    title: "Portable staged EVM Build",
+    detail: "Exact ordered calls and a stable digest",
   },
 } as const;
 
@@ -149,10 +145,12 @@ export function ApiWorkbench() {
               <span>
                 <Check aria-hidden /> {example.status}
               </span>
-              <span>One durable Action · HTTP 200</span>
+              <span>Typed v1 response · HTTP 200</span>
             </div>
             <div className={styles.actionCardTop}>
-              <span>ACTION SUMMARY</span>
+              <span>
+                {surface === "agent" ? "EVENT PAGE" : "PIPELINE BUILD"}
+              </span>
               <ShieldCheck aria-hidden />
             </div>
             <h3>{example.title}</h3>
@@ -160,18 +158,29 @@ export function ApiWorkbench() {
             <div className={styles.actionStep}>
               <span>01</span>
               <div>
-                <strong>Review signable payload</strong>
+                <strong>
+                  {surface === "agent"
+                    ? "Continue from the returned cursor"
+                    : "Simulate the staged Build"}
+                </strong>
                 <small>
-                  The sealed transaction goes to the wallet already in your
-                  product. Aomi receives the verified result, never the key.
+                  {surface === "agent"
+                    ? "Poll the same session for later events and pending Actions."
+                    : "POST /simulate with { build }; commit accepts the returned simulated Build."}
                 </small>
               </div>
               <ChevronRight aria-hidden />
             </div>
             <div className={styles.responseFacts}>
-              <span>fork simulated</span>
-              <span>policy checked</span>
-              <span>unsigned out</span>
+              <span>
+                {surface === "agent" ? "ordered events" : "portable build"}
+              </span>
+              <span>
+                {surface === "agent" ? "durable cursor" : "exact calls"}
+              </span>
+              <span>
+                {surface === "agent" ? "actions recoverable" : "digest bound"}
+              </span>
             </div>
           </div>
         </div>
@@ -180,12 +189,12 @@ export function ApiWorkbench() {
           <li>
             <span>01</span>
             <strong>Request</strong>
-            <small>Intent or exact action enters the kernel</small>
+            <small>Intent or exact operation enters the API</small>
           </li>
           <li>
             <span>02</span>
-            <strong>Seal</strong>
-            <small>Simulation and policy attach to the Action</small>
+            <strong>Build</strong>
+            <small>Transactions and simulation form a portable Build</small>
           </li>
           <li>
             <span>03</span>

--- a/apps/landing/app/_marketing/products/api/client-example.tsx
+++ b/apps/landing/app/_marketing/products/api/client-example.tsx
@@ -91,7 +91,7 @@ export function ClientExample({
             TypeScript
           </button>
         </div>
-        <span>{mode === "curl" ? "api.aomi.dev" : "@aomi-labs/client"}</span>
+        <span>{mode === "curl" ? "chat.aomi.dev" : "@aomi-labs/client"}</span>
       </div>
       <div className={styles.codeBody}>
         <button

--- a/apps/landing/app/_marketing/products/api/page.tsx
+++ b/apps/landing/app/_marketing/products/api/page.tsx
@@ -131,31 +131,31 @@ const guarantees = [
   },
 ] as const;
 
-const sdkExample = `import { createAomiClient } from "@aomi-labs/client";
-import { wagmi } from "@aomi-labs/client/wagmi";
+const sdkExample = `import { Aomi } from "@aomi-labs/client";
 
-const aomi = createAomiClient({
-  app: "aomi",
-  wallet: wagmi(config),
+const aomi = new Aomi({
+  baseUrl: "https://chat.aomi.dev",
 });
 
-for await (const event of aomi.chat(
+const run = aomi.agent.run(
   "Move my USDC into the best yield on Base",
-)) {
-  if (event.type === "message") render(event.text);
-  if (event.type === "action") await event.action.approve();
-}`;
+  { app: "aomi" },
+);
 
-const curlExample = `curl https://api.aomi.dev/v1/agent/chat \\
+run.on("action", (action) => renderApproval(action));
+const result = await run.result();
+console.log(result.sessionId, result.actions);`;
+
+const curlExample = `curl https://chat.aomi.dev/v1/agent/chat \\
   -H "Authorization: Bearer $AOMI_TOKEN" \\
   -H "Idempotency-Key: $(uuidgen)" \\
+  -H "Content-Type: application/json" \\
   -d '{ "message": "Move idle USDC into the best yield on Base",
-        "wallets": { "evm": { "address": "0xAb5…", "chainId": 8453 } } }'
+        "app": "aomi",
+        "userState": { "evm": { "address": "0xAb5…", "chain_id": 8453 } } }'
 
-# → 200 { "status": "awaiting_action", "actions": [ { "id": "act_…",
-#         "summary": { "title": "Supply 2,000 USDC to Morpho Blue", … },
-#         "transactions": [ { "to": "0x…", "data": "0x…", "simulation": { "success": true } } ] } ],
-#       "cursor": "cur_…" }`;
+# → 200 { "session_id": "sess_…", "cursor": "cur_…",
+#         "events": […], "has_more": false }`;
 
 const integrationLedger = [
   {
@@ -323,21 +323,16 @@ export default function RestApiProductPage({
                 <span className={`${styles.apiIcon} ${styles.pipelineIcon}`}>
                   <Waypoints aria-hidden />
                 </span>
-                <span
-                  className={styles.previewBadge}
-                  title="Available to design partners today. The contract is stable; public self-serve access is rolling out."
-                >
-                  PREVIEW
-                </span>
+                <span className={styles.contractBadge}>V1 CONTRACT</span>
               </div>
               <p className={styles.apiIndex}>
                 02 · YOUR SYSTEM SELECTS THE ACTION
               </p>
               <h3>Pipeline API</h3>
               <p className={styles.apiCardBody}>
-                Select a catalog action or assemble a batch directly. Receive a
-                Plan containing the simulation verdict, typed guard checks, and
-                unsigned signable—with no Aomi inference or chat session.
+                Select a catalog operation or assemble a batch directly. Receive
+                a portable Build with ordered actions, simulation evidence, and
+                a stable digest—with no chat session.
               </p>
               <div className={styles.endpointList}>
                 <span>
@@ -370,21 +365,21 @@ export default function RestApiProductPage({
         <div className={styles.shell}>
           <div className={styles.contractCopy}>
             <p className={styles.eyebrow}>THE SHARED CONTRACT</p>
-            <h2>Both APIs resolve to the same Action.</h2>
+            <h2>Both APIs can reach the same Action boundary.</h2>
             <p>
-              Agent chat and pipeline builds resolve into the same durable,
-              sealed approval object. One confirmation UI, one wallet binding,
-              both APIs—move between them without rebuilding either.
+              Agent chat emits Actions in its event log. Pipeline commit returns
+              an Action when wallet approval is required. One confirmation UI
+              can render the same request union from either path.
             </p>
             <ul>
               <li>
-                <Check aria-hidden /> Kernel-authored summary
+                <Check aria-hidden /> Typed Action request union
               </li>
               <li>
                 <Check aria-hidden /> EVM and SVM execution envelopes
               </li>
               <li>
-                <Check aria-hidden /> Deferred and multisig-aware lifecycle
+                <Check aria-hidden /> Revisioned, recoverable lifecycle
               </li>
             </ul>
           </div>
@@ -398,7 +393,7 @@ export default function RestApiProductPage({
                   <Bot aria-hidden /> Agent event
                 </span>
                 <span>
-                  <Braces aria-hidden /> Pipeline Plan
+                  <Braces aria-hidden /> Pipeline commit
                 </span>
               </div>
               <div className={styles.contractLines} aria-hidden>
@@ -456,10 +451,10 @@ export default function RestApiProductPage({
               </div>
               <p>
                 The Agent API accepts customer intent and lets Aomi plan. The
-                Pipeline API accepts the exact action or batch your own agent,
-                strategy, or product selected. Both resolve to the same Action
-                contract and cross the same simulation, policy, signer, and
-                verification boundary.
+                Pipeline API accepts the exact operation or batch your own
+                agent, strategy, or product selected. Its portable Build crosses
+                simulation before commit; commit returns an Action when a wallet
+                must finish the work.
               </p>
             </div>
 
@@ -486,12 +481,14 @@ export default function RestApiProductPage({
                   Keep your own model, strategy, and routing logic. Submit one
                   catalog action or an ordered batch directly.
                 </p>
-                <code>ActionSpec | ActionSpec[]</code>
+                <code>PipelineOperationBuildInput</code>
               </article>
             </div>
 
             <div className={styles.sharedActionBand}>
-              <span>Both surfaces resolve to the same sealed Action</span>
+              <span>
+                Both surfaces can hand the same Action union to a signer
+              </span>
               <strong>
                 One confirmation UI · one wallet binding · one evidence trail
               </strong>
@@ -593,9 +590,8 @@ export default function RestApiProductPage({
               <p>
                 The API is plain JSON over HTTPS—call it from the backend
                 language already in production. Teams shipping in TypeScript can
-                use the client, which hides sessions, cursors, retries,
-                idempotency keys, and signature routing behind one wallet
-                binding.
+                use the client, which manages sessions, cursors, retries, and
+                idempotency while keeping Action approval explicit.
               </p>
               <div className={styles.adapterRow}>
                 <span>
@@ -675,8 +671,8 @@ export default function RestApiProductPage({
               Integrating into an existing product? Start here. Want Aomi to
               host the agent and the customer-facing surface too? See the{" "}
               <Link href={humanInterfaceHref}>Human Interface</Link> and{" "}
-              <Link href={pluginSdkHref}>Plugin SDK</Link>—same Action, same
-              signer, no rebuild when you move between them.
+              <Link href={pluginSdkHref}>Plugin SDK</Link>—the same signer can
+              remain in control across every surface.
             </p>
           </div>
           <div className={styles.finalActions}>

--- a/apps/landing/app/_marketing/products/cli-mcp/agentic-lab.tsx
+++ b/apps/landing/app/_marketing/products/cli-mcp/agentic-lab.tsx
@@ -46,20 +46,20 @@ const mcpClients: Record<
   codex: {
     label: "Codex",
     format: "Terminal",
-    code: "codex mcp add aomi --url https://chat.aomi.dev/api/mcp\ncodex mcp login aomi",
+    code: "codex mcp add aomi-agent --url https://chat.aomi.dev/v1/agent/mcp\ncodex mcp login aomi-agent",
   },
   claude: {
     label: "Claude Code",
     format: "Terminal",
-    code: "claude mcp add --transport http aomi https://chat.aomi.dev/api/mcp",
+    code: "claude mcp add --transport http aomi-agent https://chat.aomi.dev/v1/agent/mcp",
   },
   cursor: {
     label: "Cursor",
     format: "mcp.json",
     code: `{
   "mcpServers": {
-    "aomi": {
-      "url": "https://chat.aomi.dev/api/mcp"
+    "aomi-agent": {
+      "url": "https://chat.aomi.dev/v1/agent/mcp"
     }
   }
 }`,
@@ -86,7 +86,7 @@ const surfaceMatrix = [
   {
     id: "mcp-agent",
     name: "MCP · agent",
-    sub: "/api/mcp",
+    sub: "/v1/agent/mcp",
     api: "Agent API · aomi_chat",
     runs: "Aomi server",
     state: "Thread on your account",
@@ -100,19 +100,19 @@ const surfaceMatrix = [
     ],
   },
   {
-    id: "mcp-direct",
-    name: "MCP · direct",
-    sub: "/api/mcp/direct",
-    api: "Pipeline API · aomi_call_tool",
+    id: "mcp-pipeline",
+    name: "MCP · pipeline",
+    sub: "/v1/pipeline/mcp",
+    api: "Pipeline API · catalog + tools",
     runs: "Aomi server",
     state: "Stateless · App passed per call",
     signing: "Hand-off → portal or CLI",
     trace: [
-      "aomi_search_tools",
+      "aomi_list_apps",
+      "aomi_select_app",
+      "aomi_list_tools",
       "aomi_describe_tool",
-      "aomi_run",
-      "awaiting_user",
-      "confirmed ✓",
+      "aomi_call_tool",
     ],
   },
   {
@@ -123,13 +123,7 @@ const surfaceMatrix = [
     runs: "Your machine",
     state: "Local sessions · session resume",
     signing: "Local key · tx sign",
-    trace: [
-      "aomi --prompt",
-      "tx list",
-      "tx simulate",
-      "tx sign",
-      "session resume",
-    ],
+    trace: ["aomi chat", "tx list", "tx simulate", "tx sign", "session resume"],
   },
 ] as const;
 

--- a/apps/landing/app/_marketing/products/widget/widget-install-code.tsx
+++ b/apps/landing/app/_marketing/products/widget/widget-install-code.tsx
@@ -57,12 +57,13 @@ const terminalSnippets = {
   CLI: `# Sign in with an embedded provider in your browser
 aomi account login --provider privy
 
-# Or authenticate with the wallet itself
-aomi account login --siwe
+# Or authenticate with the configured EVM wallet
+aomi account login --wallet
 
 aomi wallet current --json`,
   MCP: `npx skills add aomi-labs/skills
-codex mcp add aomi --url https://chat.aomi.dev/api/mcp
+codex mcp add aomi-agent --url https://chat.aomi.dev/v1/agent/mcp
+codex mcp login aomi-agent
 
 # OAuth binds the session to your Aomi account.
 # Wallets remain account-scoped.`,


### PR DESCRIPTION
## Summary
- replace retired CLI, MCP, API, and TypeScript SDK examples across the landing surfaces
- align Agent examples with StartTurnIntent/EventPage and Pipeline examples with portable stage/simulate/commit Build contracts
- replace the invented ActionSummary/deferred-result model with the exported Action request/result union
- update widget authentication snippets for browser, Para, and Privy wallets

## Verified against
- `packages/client` SDK, generated Agent v1 types, and Pipeline transports
- current Agent and Pipeline MCP routes and tool implementations in main

## Checks
- `tsc --noEmit --project apps/landing/tsconfig.json`
- `eslint apps/landing`
- Prettier check for all touched files
- landing production build (1,648 static pages)

## Deployment note
The current `chat.aomi.dev` deployment returns 404 for the new `/v1/agent/*` and `/v1/pipeline/*` routes even though main and the generated OpenAPI define them. This PR intentionally documents the current v1 contract rather than restoring the retired `/api/mcp` routes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790767334&installation_model_id=12362&pr_number=554&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F554&signature=dcaac679d05ae9b5dff7c085de59afe6c805cf784100c4a0546cb0473e61703f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->