### PR TITLE
Fix auth surface URL routing

### DIFF
--- a/apps/portal/src/app/.well-known/oauth-authorization-server/api/auth/route.test.ts
+++ b/apps/portal/src/app/.well-known/oauth-authorization-server/api/auth/route.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  metadata: vi.fn(),
+}));
+
+vi.mock("@aomi-labs/account/better-auth", () => ({ auth: {} }));
+vi.mock("@better-auth/oauth-provider", () => ({
+  oauthProviderAuthServerMetadata: () => mocks.metadata,
+}));
+vi.mock("@portal/server/oauth/cors", () => ({
+  publicDiscoveryResponse: (response: Response) => response,
+}));
+
+import { GET } from "./route";
+
+describe("path-scoped OAuth authorization-server discovery", () => {
+  it("serves metadata for the /api/auth issuer", async () => {
+    mocks.metadata.mockResolvedValue(
+      Response.json({ issuer: "https://chat.aomi.dev/api/auth" }),
+    );
+    const request = new Request(
+      "https://chat.aomi.dev/.well-known/oauth-authorization-server/api/auth",
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      issuer: "https://chat.aomi.dev/api/auth",
+    });
+    expect(mocks.metadata).toHaveBeenCalledWith(request);
+  });
+});

--- a/apps/portal/src/app/.well-known/oauth-authorization-server/api/auth/route.ts
+++ b/apps/portal/src/app/.well-known/oauth-authorization-server/api/auth/route.ts
@@ -1,0 +1,4 @@
+export { GET, HEAD, OPTIONS } from "../../route";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aomi-labs/client",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Platform-agnostic TypeScript client for the Aomi backend API",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/client/src/cli/device-auth.ts
+++ b/packages/client/src/cli/device-auth.ts
@@ -50,6 +50,15 @@ type LinkIntentResponse = {
 
 const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
 
+function deviceAuthPortalUrl(baseUrl: string): string {
+  const url = new URL(normalizeBaseUrl(baseUrl));
+  if (url.hostname === "api.aomi.dev") url.hostname = "chat.aomi.dev";
+  if (url.hostname === "api-staging.aomi.dev") {
+    url.hostname = "chat-staging.aomi.dev";
+  }
+  return normalizeBaseUrl(url.toString());
+}
+
 export async function signInWithDeviceProvider({
   baseUrl,
   provider,
@@ -59,7 +68,7 @@ export async function signInWithDeviceProvider({
   openBrowser = openUrlInBrowser,
   randomBytes: randomBytesImpl = randomBytes,
 }: DeviceProviderAuthOptions): Promise<DeviceProviderAuthResult> {
-  const portalUrl = normalizeBaseUrl(baseUrl);
+  const portalUrl = deviceAuthPortalUrl(baseUrl);
   const state = base64Url(randomBytesImpl(32));
   const verifier = base64Url(randomBytesImpl(32));
   const codeChallenge = sha256Base64Url(verifier);
@@ -146,7 +155,7 @@ export async function getDeviceProviderCredential({
   if (!sessionToken) {
     throw new Error("Device auth provider linking requires an account session");
   }
-  const portalUrl = normalizeBaseUrl(baseUrl);
+  const portalUrl = deviceAuthPortalUrl(baseUrl);
   const state = base64Url(randomBytesImpl(32));
   const verifier = base64Url(randomBytesImpl(32));
   const codeChallenge = sha256Base64Url(verifier);

--- a/packages/client/test/cli/cli-device-auth.unit.test.ts
+++ b/packages/client/test/cli/cli-device-auth.unit.test.ts
@@ -44,7 +44,7 @@ describe("CLI device provider auth", () => {
     expect(parsed.searchParams.get("link_intent")).toBe("intent-123");
   });
 
-  it("exchanges a loopback callback code for a BetterAuth session", async () => {
+  it("canonicalizes the raw staging API before provider login", async () => {
     const originalFetch = globalThis.fetch;
     const exchangeFetch = vi.fn(
       async (url: string | URL | Request, init?: RequestInit) => {
@@ -53,7 +53,8 @@ describe("CLI device provider auth", () => {
           return originalFetch(url, init);
         }
         if (
-          target === "https://chat.aomi.dev/v1/account/device-auth/exchange"
+          target ===
+          "https://chat-staging.aomi.dev/v1/account/device-auth/exchange"
         ) {
           const body = JSON.parse(String(init?.body));
           expect(body.code).toBe("grant-code");
@@ -69,7 +70,7 @@ describe("CLI device provider auth", () => {
             provider: "para",
           });
         }
-        if (target === "https://chat.aomi.dev/v1/account") {
+        if (target === "https://chat-staging.aomi.dev/v1/account") {
           expect(new Headers(init?.headers).get("Authorization")).toBe(
             "Bearer better-auth-session",
           );
@@ -87,10 +88,11 @@ describe("CLI device provider auth", () => {
 
     try {
       const result = await signInWithDeviceProvider({
-        baseUrl: "https://chat.aomi.dev",
+        baseUrl: "https://api-staging.aomi.dev",
         provider: "para",
         openBrowser: async (url) => {
           const parsed = new URL(url);
+          expect(parsed.origin).toBe("https://chat-staging.aomi.dev");
           expect(parsed.searchParams.get("provider")).toBe("para");
           const redirectUri = parsed.searchParams.get("redirect_uri");
           const state = parsed.searchParams.get("state");
@@ -172,7 +174,7 @@ describe("CLI device provider auth", () => {
 
     try {
       const result = await getDeviceProviderCredential({
-        baseUrl: "https://chat.aomi.dev",
+        baseUrl: "https://api.aomi.dev",
         provider: "privy",
         sessionToken: "current-session",
         openBrowser: async (url) => {


### PR DESCRIPTION
## Summary

- serve OAuth authorization-server metadata at the RFC 8414 path for the `/api/auth` issuer
- canonicalize provider auth from known raw Aomi API hosts to their matching Portal hosts
- bump `@aomi-labs/client` to `0.6.9` and cover both regressions

## Root cause

Codex follows the issuer-scoped discovery path `/.well-known/oauth-authorization-server/api/auth`, but Portal only exposed root discovery. Separately, explicit provider login treated the CLI backend URL as the browser/auth surface, so `api-staging.aomi.dev/device-auth` returned 404.

## Verification

- `pnpm exec vitest run packages/client/test` (257 passed, 1 skipped)
- `pnpm --filter @aomi-labs/client typecheck`
- `pnpm --filter @aomi-labs/client build`
- `pnpm --filter portal test` (434 passed)
- `pnpm --filter portal type-check`
- targeted ESLint and Prettier checks
- Next route type generation includes `/.well-known/oauth-authorization-server/api/auth`

No UI screenshots: this changes server discovery and CLI URL routing only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790936301&installation_model_id=12362&pr_number=559&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F559&signature=d57fbc2aa23d797fb0a6d883478a769868ffa361429fefb7e9d3e4eb20dd42a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->