### PR TITLE
Make identity revocation durable

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -1,5 +1,20 @@
 # Canonical Landing
 
+Current session goal: **IDENTITY REVOCATION RACES AND CONSENT BOUNDARIES
+LOCALLY VERIFIED 2026-09-02** — canonical account resolution now locks and
+revalidates the backing Better Auth user inside its transaction, so a browser
+session read concurrently with provider unlink or account deletion cannot
+recreate an identity binding for a deleted carrier. Provider identities remain
+unlinkable, while last-factor protection applies only to actual SIWE/SIWS
+wallet removal and ignores non-login email rows. Guest consent preserves the
+server-approved scopes but rejects unknown scopes before guest narrowing. The
+real Better Auth migration cascade was exercised in a disposable local
+PostgreSQL database across two browser sessions, access and refresh tokens,
+consent, an approved device code, and WST storage. All 465 Portal and 149
+account tests pass locally;
+the database integration adds one passing test when its disposable URL is set,
+and no provider credentials or staging services were used.
+
 Current session goal: **PROVIDER AND DEVICE AUTH RECOVERY LOCALLY VERIFIED
 2026-09-02** — `/device-auth` and `/oauth/device` now select Para or Privy at
 the single root wallet-provider boundary, OAuth device decisions claim and

--- a/apps/portal/src/app/api/auth/[...all]/route.test.ts
+++ b/apps/portal/src/app/api/auth/[...all]/route.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   getSession: vi.fn(),
   handler: vi.fn(),
   oauthRedirectFailureDiagnostics: vi.fn(),
+  validateAomiResourceScopes: vi.fn(),
 }));
 
 vi.mock("@aomi-labs/account/better-auth", () => ({
@@ -15,6 +16,7 @@ vi.mock("@aomi-labs/account/better-auth", () => ({
     portalOrigin: "https://portal.example",
   }),
   guestScopesForAomiResource: (_resource: string, scopes: string[]) => scopes,
+  validateAomiResourceScopes: mocks.validateAomiResourceScopes,
   BETTER_AUTH_OAUTH_PROVIDER_VERSION: "1.7.1",
   hashOAuthClientId: () => "hashed-client",
   oauthRedirectFailureDiagnostics: mocks.oauthRedirectFailureDiagnostics,
@@ -42,6 +44,7 @@ beforeEach(() => {
   mocks.getSession.mockReset();
   mocks.handler.mockReset().mockResolvedValue(Response.json({ ok: true }));
   mocks.oauthRedirectFailureDiagnostics.mockReset();
+  mocks.validateAomiResourceScopes.mockReset().mockReturnValue({ ok: true });
 });
 
 describe("OAuth redirect rejection diagnostics", () => {
@@ -182,5 +185,64 @@ describe("anonymous sign-in", () => {
 
     expect(response.status).toBe(200);
     expect(mocks.handler).toHaveBeenCalledWith(request);
+  });
+});
+
+describe("guest OAuth consent", () => {
+  it("submits the server-approved action scope unchanged", async () => {
+    mocks.getSession.mockResolvedValue({
+      session: { id: "session-1" },
+      user: { id: "guest-1", isAnonymous: true },
+    });
+    const scope = "agent:read agent:actions:resolve";
+
+    const response = await POST(
+      new Request("https://portal.example/api/auth/oauth2/consent", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          code: "consent-code",
+          scope,
+          oauth_query: new URLSearchParams({
+            resource: "https://portal.example/v1/agent",
+          }).toString(),
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const forwarded = mocks.handler.mock.calls[0]?.[0] as Request;
+    await expect(forwarded.clone().json()).resolves.toMatchObject({ scope });
+  });
+
+  it("rejects a scope outside the signed resource policy", async () => {
+    mocks.getSession.mockResolvedValue({
+      session: { id: "session-1" },
+      user: { id: "guest-1", isAnonymous: true },
+    });
+    mocks.validateAomiResourceScopes.mockReturnValue({
+      ok: false,
+      error: "invalid_scope",
+    });
+
+    const response = await POST(
+      new Request("https://portal.example/api/auth/oauth2/consent", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          code: "consent-code",
+          scope: "agent:read unknown:scope",
+          oauth_query: new URLSearchParams({
+            resource: "https://portal.example/v1/agent",
+          }).toString(),
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "invalid_scope",
+    });
+    expect(mocks.handler).not.toHaveBeenCalled();
   });
 });

--- a/apps/portal/src/app/api/auth/[...all]/route.test.ts
+++ b/apps/portal/src/app/api/auth/[...all]/route.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   getSession: vi.fn(),
   handler: vi.fn(),
+  guestScopesForAomiResource: vi.fn(),
   oauthRedirectFailureDiagnostics: vi.fn(),
   validateAomiResourceScopes: vi.fn(),
 }));
@@ -15,7 +16,7 @@ vi.mock("@aomi-labs/account/better-auth", () => ({
   aomiOAuthResources: () => ({
     portalOrigin: "https://portal.example",
   }),
-  guestScopesForAomiResource: (_resource: string, scopes: string[]) => scopes,
+  guestScopesForAomiResource: mocks.guestScopesForAomiResource,
   validateAomiResourceScopes: mocks.validateAomiResourceScopes,
   BETTER_AUTH_OAUTH_PROVIDER_VERSION: "1.7.1",
   hashOAuthClientId: () => "hashed-client",
@@ -43,6 +44,9 @@ import { GET, POST } from "./route";
 beforeEach(() => {
   mocks.getSession.mockReset();
   mocks.handler.mockReset().mockResolvedValue(Response.json({ ok: true }));
+  mocks.guestScopesForAomiResource
+    .mockReset()
+    .mockImplementation((_resource: string, scopes: string[]) => scopes);
   mocks.oauthRedirectFailureDiagnostics.mockReset();
   mocks.validateAomiResourceScopes.mockReset().mockReturnValue({ ok: true });
 });
@@ -189,6 +193,43 @@ describe("anonymous sign-in", () => {
 });
 
 describe("guest OAuth consent", () => {
+  it.each([
+    [
+      "Agent actions",
+      "https://portal.example/v1/agent",
+      "agent:read agent:actions:resolve custody:delegate",
+      ["agent:read", "agent:actions:resolve"],
+    ],
+    [
+      "Pipeline execution",
+      "https://portal.example/v1/pipeline",
+      "pipeline:catalog pipeline:execute custody:delegate",
+      ["pipeline:catalog", "pipeline:execute"],
+    ],
+  ])(
+    "bounds anonymous %s authorization before Better Auth creates consent",
+    async (_story, resource, requested, expected) => {
+      mocks.getSession.mockResolvedValue({
+        session: { id: "session-1" },
+        user: { id: "guest-1", isAnonymous: true },
+      });
+      mocks.guestScopesForAomiResource.mockReturnValue(expected);
+
+      const response = await GET(
+        new Request(
+          "https://portal.example/api/auth/oauth2/authorize?" +
+            new URLSearchParams({ resource, scope: requested }),
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      const forwarded = mocks.handler.mock.calls[0]?.[0] as Request;
+      expect(new URL(forwarded.url).searchParams.get("scope")).toBe(
+        expected.join(" "),
+      );
+    },
+  );
+
   it("submits the server-approved action scope unchanged", async () => {
     mocks.getSession.mockResolvedValue({
       session: { id: "session-1" },
@@ -232,6 +273,34 @@ describe("guest OAuth consent", () => {
         body: JSON.stringify({
           code: "consent-code",
           scope: "agent:read unknown:scope",
+          oauth_query: new URLSearchParams({
+            resource: "https://portal.example/v1/agent",
+          }).toString(),
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "invalid_scope",
+    });
+    expect(mocks.handler).not.toHaveBeenCalled();
+  });
+
+  it("rejects a resource-valid scope outside the guest ceiling", async () => {
+    mocks.getSession.mockResolvedValue({
+      session: { id: "session-1" },
+      user: { id: "guest-1", isAnonymous: true },
+    });
+    mocks.guestScopesForAomiResource.mockReturnValue(["agent:read"]);
+
+    const response = await POST(
+      new Request("https://portal.example/api/auth/oauth2/consent", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          code: "consent-code",
+          scope: "agent:read custody:delegate",
           oauth_query: new URLSearchParams({
             resource: "https://portal.example/v1/agent",
           }).toString(),

--- a/apps/portal/src/app/api/auth/[...all]/route.ts
+++ b/apps/portal/src/app/api/auth/[...all]/route.ts
@@ -5,6 +5,7 @@ import {
   guestScopesForAomiResource,
   hashOAuthClientId,
   oauthRedirectFailureDiagnostics,
+  validateAomiResourceScopes,
 } from "@aomi-labs/account/better-auth";
 
 import {
@@ -92,6 +93,17 @@ async function handleAuth(request: Request) {
           );
         }
         const resource = consentResources[0];
+        const validation = validateAomiResourceScopes(resource, requested);
+        if (!validation.ok) {
+          return Response.json(
+            {
+              error: validation.error,
+              error_description:
+                "Guest consent contains a scope outside the signed resource policy",
+            },
+            { status: 400 },
+          );
+        }
         const bounded = guestScopesForAomiResource(resource, requested);
         if (bounded.length === 0) {
           return Response.json(

--- a/apps/portal/src/app/api/auth/[...all]/route.ts
+++ b/apps/portal/src/app/api/auth/[...all]/route.ts
@@ -42,6 +42,33 @@ async function handleAuth(request: Request) {
   const policy = await enforceAomiOAuthRequestPolicy(request);
   if (policy.kind === "reject") return policy.response;
   request = policy.request;
+  if (request.method === "GET" && path.endsWith("/oauth2/authorize")) {
+    const session = await auth.api.getSession({ headers: request.headers });
+    if (session?.user.isAnonymous === true) {
+      const url = new URL(request.url);
+      const resources = url.searchParams.getAll("resource");
+      if (resources.length === 1) {
+        const requested = String(url.searchParams.get("scope") ?? "")
+          .split(/\s+/)
+          .filter(Boolean);
+        const bounded = guestScopesForAomiResource(resources[0], requested);
+        if (bounded.length === 0) {
+          return Response.json(
+            {
+              error: "invalid_scope",
+              error_description: "No guest-safe scope selected",
+            },
+            { status: 400 },
+          );
+        }
+        url.searchParams.set("scope", bounded.join(" "));
+        request = new Request(url, {
+          method: request.method,
+          headers: request.headers,
+        });
+      }
+    }
+  }
   if (request.method === "POST" && path.endsWith("/sign-in/anonymous")) {
     const session = await auth.api.getSession({ headers: request.headers });
     if (session) {
@@ -114,9 +141,16 @@ async function handleAuth(request: Request) {
             { status: 400 },
           );
         }
-        request = new Request(request, {
-          body: JSON.stringify({ ...body, scope: bounded.join(" ") }),
-        });
+        if (bounded.length !== requested.length) {
+          return Response.json(
+            {
+              error: "invalid_scope",
+              error_description:
+                "Guest consent contains a scope outside the guest policy",
+            },
+            { status: 400 },
+          );
+        }
       }
     }
   }

--- a/apps/portal/src/app/oauth/consent/consent-scopes.test.ts
+++ b/apps/portal/src/app/oauth/consent/consent-scopes.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { consentScopes } from "./consent-scopes";
+
+describe("consentScopes", () => {
+  it("preserves server-approved guest action and execution scopes", () => {
+    expect(
+      consentScopes(["agent:actions:resolve", "pipeline:execute"]),
+    ).toEqual(["agent:actions:resolve", "pipeline:execute"]);
+  });
+});

--- a/apps/portal/src/app/oauth/consent/consent-scopes.ts
+++ b/apps/portal/src/app/oauth/consent/consent-scopes.ts
@@ -1,0 +1,6 @@
+/** The authorization route has already applied the canonical resource policy.
+ * The consent UI must display and return that exact set instead of maintaining
+ * a second, inevitably drifting client-side allowlist. */
+export function consentScopes(scopes: readonly string[]): string[] {
+  return [...scopes];
+}

--- a/apps/portal/src/app/oauth/consent/oauth-consent-client.tsx
+++ b/apps/portal/src/app/oauth/consent/oauth-consent-client.tsx
@@ -3,8 +3,8 @@
 import { useCallback, useMemo, useState } from "react";
 import { Loader2, ShieldCheck } from "lucide-react";
 import { useSearchParams } from "next/navigation";
-import { authClient } from "@aomi-labs/account/better-auth/client";
 import { oauthConsentRedirect } from "./consent-response";
+import { consentScopes } from "./consent-scopes";
 
 const DESCRIPTIONS: Record<string, string> = {
   "agent:read": "Read your Agent sessions",
@@ -21,26 +21,14 @@ const DESCRIPTIONS: Record<string, string> = {
 
 export function OAuthConsentClient() {
   const params = useSearchParams();
-  const { data: session } = authClient.useSession();
   const code = params.get("code") ?? params.get("consent_code");
   const scopes = useMemo(
-    () => (params.get("scope") ?? "").split(/\s+/).filter(Boolean),
+    () =>
+      consentScopes((params.get("scope") ?? "").split(/\s+/).filter(Boolean)),
     [params],
   );
   const [pending, setPending] = useState(false);
   const [status, setStatus] = useState<string | null>(null);
-  const acceptedScopes = useMemo(() => {
-    if (session?.user.isAnonymous !== true) return scopes;
-    const ceiling = new Set([
-      "agent:read",
-      "agent:write",
-      "pipeline:catalog",
-      "mcp:agent",
-      "mcp:pipeline",
-      "offline_access",
-    ]);
-    return scopes.filter((scope) => ceiling.has(scope));
-  }, [scopes, session?.user.isAnonymous]);
 
   const decide = useCallback(
     async (accept: boolean) => {
@@ -54,7 +42,9 @@ export function OAuthConsentClient() {
           accept,
           code,
           consent_code: code,
-          scope: acceptedScopes.join(" "),
+          // The signed request has already passed the canonical server policy.
+          // Echo it unchanged; the route validates it again before minting.
+          scope: scopes.join(" "),
         }),
       });
       const redirect = oauthConsentRedirect(
@@ -67,7 +57,7 @@ export function OAuthConsentClient() {
       }
       window.location.assign(redirect);
     },
-    [acceptedScopes, code],
+    [code, scopes],
   );
 
   return (
@@ -79,7 +69,7 @@ export function OAuthConsentClient() {
           remain valid for at most five minutes.
         </p>
         <ul className="mt-5 grid gap-2">
-          {acceptedScopes.map((scope) => (
+          {scopes.map((scope) => (
             <li
               className="text-muted-foreground flex items-center gap-2 text-sm"
               key={scope}
@@ -89,12 +79,6 @@ export function OAuthConsentClient() {
             </li>
           ))}
         </ul>
-        {acceptedScopes.length !== scopes.length ? (
-          <p className="text-muted-foreground mt-4 text-sm">
-            Guest accounts receive only the guest-safe subset of the requested
-            access.
-          </p>
-        ) : null}
         {status ? (
           <p className="text-muted-foreground mt-4 text-sm">{status}</p>
         ) : null}

--- a/apps/portal/src/app/v1/account/identities/[id]/route.ts
+++ b/apps/portal/src/app/v1/account/identities/[id]/route.ts
@@ -7,7 +7,10 @@ import {
   accountResponseForPrincipal,
   requirePortalPrincipal,
 } from "@portal/server/widget-auth/principal";
-import { widgetPreflight, widgetRoute } from "@portal/server/widget-auth/response";
+import {
+  widgetPreflight,
+  widgetRoute,
+} from "@portal/server/widget-auth/response";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -48,9 +51,6 @@ export const DELETE = widgetRoute(
       return json(404, { error: "identity_not_found" });
     if (result === "protected")
       return json(403, { error: "protected_identity" });
-    if (result === "last_factor") {
-      return json(409, { error: "cannot_unlink_last_login_factor" });
-    }
     return Response.json({ status: "revoked" });
   },
   "identity.unlink",

--- a/apps/portal/src/server/widget-auth/response.test.ts
+++ b/apps/portal/src/server/widget-auth/response.test.ts
@@ -20,6 +20,7 @@ vi.mock("@portal/server/bff/failures", () => {
 });
 
 import { PortalPrincipalError } from "./principal";
+import { AccountSessionInvalidError } from "@aomi-labs/account/account";
 import { widgetRoute } from "./response";
 
 function widgetRequest(): Request {
@@ -71,6 +72,16 @@ describe("widgetRoute error handling", () => {
         response: { status: 400, error: "invalid_request" },
       }),
     );
+  });
+
+  it("treats a deleted Better Auth carrier as an invalid session", async () => {
+    const response = await throwingRoute(new AccountSessionInvalidError())(
+      widgetRequest(),
+    );
+    expect(response.status).toBe(401);
+    expect(await bodyOf(response)).toEqual({
+      error: "account_session_invalid",
+    });
   });
 
   it("maps provider-token verification failures to 401 with the code", async () => {

--- a/apps/portal/src/server/widget-auth/response.ts
+++ b/apps/portal/src/server/widget-auth/response.ts
@@ -1,4 +1,7 @@
-import { IdentityConflictError } from "@aomi-labs/account/account";
+import {
+  AccountSessionInvalidError,
+  IdentityConflictError,
+} from "@aomi-labs/account/account";
 import {
   WidgetAuthError,
   type WidgetChallenge,
@@ -40,7 +43,8 @@ export function identifyWidgetAuthFailure(
 ): FailureInput {
   if (
     error instanceof WidgetAuthError ||
-    error instanceof PortalPrincipalError
+    error instanceof PortalPrincipalError ||
+    error instanceof AccountSessionInvalidError
   ) {
     return {
       source: "expected",

--- a/memory/2026-09-02.md
+++ b/memory/2026-09-02.md
@@ -38,3 +38,15 @@
   API error bodies/statuses. Added focused regression coverage for scope,
   precedence, migration, subject mismatch, malformed token responses, rollback,
   remote failure, and complete local credential clearing.
+- Closed the identity-deletion race by requiring and row-locking the backing
+  Better Auth user inside canonical account resolution; a session captured
+  before deletion can no longer recreate a carrier or canonical account.
+- Scoped last-factor protection to real SIWE/SIWS wallet removal, excluding
+  email carrier rows and allowing an explicit Para/Privy identity unlink.
+- Made guest consent reject scopes outside the signed resource policy before
+  applying the server-owned guest ceiling.
+- Verified the production Better Auth foreign-key cascade in a disposable
+  local PostgreSQL database: deleting one login user removed two browser
+  sessions, an OAuth refresh token, its access token, consent, and an approved
+  device code; explicit canonical-account cleanup removed the WST row. Account
+  and Portal suites, typechecks, scoped lint, formatting, and diff checks passed.

--- a/packages/account/src/account.ts
+++ b/packages/account/src/account.ts
@@ -4,6 +4,7 @@ export { validWalletAddress } from "./providers/wallet-attestation";
 
 export {
   ensureAccountSchema,
+  AccountSessionInvalidError,
   deactivateAomiAccount,
   fetchAttestedProviderWallets,
   claimTelegramSessionOwner,

--- a/packages/account/src/db/queries.ts
+++ b/packages/account/src/db/queries.ts
@@ -197,6 +197,21 @@ export async function listBetterAuthSiwsWallets(
   }
 }
 
+/** Confirm that a Better Auth carrier still exists while holding a row lock for
+ * the rest of the canonical-account resolution transaction. This closes the
+ * delete race where a session was read immediately before its Better Auth user
+ * was removed: no canonical identity may be (re)created for a missing carrier. */
+export async function lockBetterAuthUser(
+  betterAuthUserId: string,
+  db: Db,
+): Promise<boolean> {
+  const result = await db.query(
+    `select 1 from ba_users where id = $1 for key share`,
+    [betterAuthUserId],
+  );
+  return (result.rowCount ?? result.rows.length) > 0;
+}
+
 export async function touchAomiUser(
   userId: AomiUserId,
   db: Db = getPool(),
@@ -299,7 +314,7 @@ export async function countLoginFactors(
     `select count(*)::int as count
        from auth_providers
       where user_id = $1
-        and provider not in ('betterauth', 'better_auth', 'wallet')`,
+        and provider not in ('betterauth', 'better_auth', 'email', 'wallet')`,
     [userId],
   );
   return Number(result.rows[0]?.count ?? 0);
@@ -462,15 +477,20 @@ export async function listBetterAuthUserIdsForAomiUser(
 }
 
 /** Delete Better Auth users only after their exact ids were resolved from the
- * canonical account. Foreign-key cascades revoke all browser sessions, OAuth
- * tokens/consents, wallet rows, and owned OAuth applications. */
+ * canonical account. Foreign-key cascades revoke browser sessions, OAuth
+ * tokens/consents, wallet rows, and owned OAuth applications. Better Auth's
+ * device-code user column has no FK, so remove those grants explicitly in the
+ * same statement. */
 export async function deleteBetterAuthUsers(input: {
   betterAuthUserIds: readonly string[];
   db?: Db;
 }): Promise<number> {
   if (input.betterAuthUserIds.length === 0) return 0;
   const result = await (input.db ?? getPool()).query(
-    `delete from ba_users where id = any($1::text[])`,
+    `with deleted_device_codes as (
+       delete from ba_oauth_device_codes where user_id = any($1::text[])
+     )
+     delete from ba_users where id = any($1::text[])`,
     [[...new Set(input.betterAuthUserIds)]],
   );
   return result.rowCount ?? 0;
@@ -630,6 +650,30 @@ export async function findAuthIdentityById(
   const result = await db.query(
     `select * from auth_providers where id = $1 limit 1`,
     [Number(identityId)],
+  );
+  return result.rows[0] ? mapIdentity(result.rows[0]) : null;
+}
+
+export async function findAuthIdentityForSubject(input: {
+  userId: AomiUserId;
+  provider: AuthIdentityProvider;
+  issuerEnvironment: string;
+  tenantId: string;
+  subject: string;
+  db?: Db;
+}): Promise<DbAomiAuthIdentity | null> {
+  const result = await (input.db ?? getPool()).query(
+    `select * from auth_providers
+      where user_id = $1 and provider = $2
+        and issuer_environment = $3 and tenant_id = $4 and subject = $5
+      limit 1`,
+    [
+      input.userId,
+      canonicalProvider(input.provider),
+      input.issuerEnvironment,
+      input.tenantId,
+      input.subject,
+    ],
   );
   return result.rows[0] ? mapIdentity(result.rows[0]) : null;
 }

--- a/packages/account/src/db/queries.ts
+++ b/packages/account/src/db/queries.ts
@@ -441,6 +441,41 @@ export async function clearAomiBetterAuthUserIds(input: {
   return (result.rowCount ?? 0) > 0;
 }
 
+/** Return every Better Auth carrier currently attached to one canonical user.
+ * The legacy spelling remains in persisted rows, so revocation deliberately
+ * matches both values while returning one canonical subject list. */
+export async function listBetterAuthUserIdsForAomiUser(
+  userId: AomiUserId,
+  db: Db = getPool(),
+): Promise<string[]> {
+  const result = await db.query(
+    `select distinct subject
+       from auth_providers
+      where user_id = $1
+        and provider = any($2::text[])
+      order by subject`,
+    [userId, [BETTER_AUTH_PROVIDER, "better_auth"]],
+  );
+  return result.rows
+    .map((row) => row.subject)
+    .filter((subject): subject is string => typeof subject === "string");
+}
+
+/** Delete Better Auth users only after their exact ids were resolved from the
+ * canonical account. Foreign-key cascades revoke all browser sessions, OAuth
+ * tokens/consents, wallet rows, and owned OAuth applications. */
+export async function deleteBetterAuthUsers(input: {
+  betterAuthUserIds: readonly string[];
+  db?: Db;
+}): Promise<number> {
+  if (input.betterAuthUserIds.length === 0) return 0;
+  const result = await (input.db ?? getPool()).query(
+    `delete from ba_users where id = any($1::text[])`,
+    [[...new Set(input.betterAuthUserIds)]],
+  );
+  return result.rowCount ?? 0;
+}
+
 export async function upsertWallet(input: {
   userId: AomiUserId;
   family: WalletFamily;

--- a/packages/account/src/service/account-service.ts
+++ b/packages/account/src/service/account-service.ts
@@ -10,6 +10,7 @@ import {
   deleteBetterAuthSiweWallet,
   deleteBetterAuthSiwsWallet,
   findAuthIdentityById,
+  findAuthIdentityForSubject,
   findAomiUserById,
   claimTelegramSessionOwner as claimTelegramSessionOwnerQuery,
   findSignalOwner,
@@ -18,6 +19,7 @@ import {
   listBetterAuthSiwsWallets,
   listBetterAuthUserIdsForAomiUser,
   listWalletsForUser,
+  lockBetterAuthUser,
   lockIdentityResolutionKeys,
   logAccountEvent,
   revokeAllAuthIdentitiesForUser,
@@ -74,6 +76,16 @@ let accountSchemaReady: Promise<void> | null = null;
 // provider-token expiry; this sentinel marks them non-expiring for the
 // resolver's freshness checks.
 const NON_EXPIRING_IDENTITY_EXPIRES_AT = Number.MAX_SAFE_INTEGER;
+
+export class AccountSessionInvalidError extends Error {
+  readonly code = "account_session_invalid";
+  readonly status = 401;
+
+  constructor() {
+    super("account_session_invalid");
+    this.name = "AccountSessionInvalidError";
+  }
+}
 
 export async function ensureAccountSchema(): Promise<void> {
   if (!accountSchemaReady) {
@@ -133,19 +145,19 @@ export async function getOrCreateAomiUserForBetterAuthSession(input: {
     // `identity_already_linked_to_another_account`; because that is a
     // non-recoverable error the whole transaction rolls back, so a failed email
     // link can never leave a freshly created user orphaned.
-    onResolved:
-      verifiedEmail || input.onResolved
-        ? async (result, db) => {
-            if (verifiedEmail) {
-              await upsertEmailIdentity({
-                userId: result.user.id,
-                email: verifiedEmail,
-                db,
-              });
-            }
-            await input.onResolved?.(result.user, db);
-          }
-        : undefined,
+    onResolved: async (result, db) => {
+      if (!(await lockBetterAuthUser(input.betterAuthUserId, db))) {
+        throw new AccountSessionInvalidError();
+      }
+      if (verifiedEmail) {
+        await upsertEmailIdentity({
+          userId: result.user.id,
+          email: verifiedEmail,
+          db,
+        });
+      }
+      await input.onResolved?.(result.user, db);
+    },
   });
   await logAccountEvent({
     userId: resolution.user.id,
@@ -871,7 +883,7 @@ function walletKeyString(family: WalletFamily, address: string): string {
 export async function unlinkAuthIdentity(input: {
   userId: AomiUserId;
   identityId: string;
-}): Promise<"revoked" | "not_found" | "last_factor" | "protected"> {
+}): Promise<"revoked" | "not_found" | "protected"> {
   const result = await withTransaction(async (db) => {
     await lockIdentityResolutionKeys(
       [`aomi-login-factors:${input.userId}`],
@@ -889,8 +901,6 @@ export async function unlinkAuthIdentity(input: {
     ) {
       return { status: "protected" as const };
     }
-    const factorCount = await countLoginFactors(input.userId, db);
-    if (factorCount <= 1) return { status: "last_factor" as const };
     const revoked = await revokeAuthIdentity({
       userId: input.userId,
       provider: identity.provider,
@@ -995,6 +1005,15 @@ export async function unlinkWallet(input: {
     const wallet = await findWalletById(input.walletId, db);
     if (!wallet || wallet.userId !== input.userId) return "not_found" as const;
     const walletSubject = walletIdentitySubject(wallet);
+    const walletIdentity = walletSubject
+      ? await findAuthIdentityForSubject({
+          userId: input.userId,
+          provider: walletSubject.provider,
+          ...IDENTITY_SCOPES[walletSubject.provider],
+          subject: walletSubject.subject,
+          db,
+        })
+      : null;
     if (walletSubject) {
       const factorCount = await countLoginFactors(input.userId, db);
       if (factorCount <= 1) return "last_factor" as const;
@@ -1033,6 +1052,16 @@ export async function unlinkWallet(input: {
       betterAuthUserIds: detached.betterAuthUserIds,
       db,
     });
+    await deleteBetterAuthUsers({
+      betterAuthUserIds: detached.betterAuthUserIds,
+      db,
+    });
+    if (walletIdentity) {
+      await deleteWidgetSessionsForProviderIdentity({
+        providerIdentityId: walletIdentity.id,
+        db,
+      });
+    }
     return "revoked" as const;
   });
   if (status !== "revoked") return status;

--- a/packages/account/src/service/account-service.ts
+++ b/packages/account/src/service/account-service.ts
@@ -6,6 +6,7 @@ import {
   clearAomiBetterAuthUserIds,
   countLoginFactors,
   deactivateAomiUser,
+  deleteBetterAuthUsers,
   deleteBetterAuthSiweWallet,
   deleteBetterAuthSiwsWallet,
   findAuthIdentityById,
@@ -15,6 +16,7 @@ import {
   findWalletById,
   listBetterAuthSiweWallets,
   listBetterAuthSiwsWallets,
+  listBetterAuthUserIdsForAomiUser,
   listWalletsForUser,
   lockIdentityResolutionKeys,
   logAccountEvent,
@@ -58,7 +60,10 @@ import {
   lockSignalRefs,
   resolveVerifiedProviderIdentity,
 } from "./identity-resolution";
-import { deleteWidgetSessionsForProviderIdentity } from "../widget-auth/store";
+import {
+  deleteWidgetSessionsForProviderIdentity,
+  deleteWidgetSessionsForUser,
+} from "../widget-auth/store";
 
 // Historically this applied the portal-owned `aomi_*` schema. AUTH-001 moves
 // durable account state to the shared backend canonical tables, so the hook now
@@ -894,14 +899,28 @@ export async function unlinkAuthIdentity(input: {
       subject: identity.subject,
       db,
     });
-    return revoked
-      ? { status: "revoked" as const, identity }
-      : { status: "not_found" as const };
+    if (!revoked) return { status: "not_found" as const };
+
+    // Provider sessions are carriers, not independent login factors. Removing
+    // a provider must also remove every carrier that could otherwise recover
+    // the canonical account from the provider's email or embedded wallets.
+    const betterAuthUserIds = await listBetterAuthUserIdsForAomiUser(
+      input.userId,
+      db,
+    );
+    await clearAomiBetterAuthUserIds({
+      userId: input.userId,
+      betterAuthUserIds,
+      db,
+    });
+    await deleteBetterAuthUsers({ betterAuthUserIds, db });
+    await deleteWidgetSessionsForProviderIdentity({
+      providerIdentityId: identity.id,
+      db,
+    });
+    return { status: "revoked" as const, identity };
   });
   if (result.status !== "revoked") return result.status;
-  await deleteWidgetSessionsForProviderIdentity({
-    providerIdentityId: result.identity.id,
-  });
   await logAccountEvent({
     userId: input.userId,
     eventType: "identity.revoked",
@@ -975,11 +994,13 @@ export async function unlinkWallet(input: {
     );
     const wallet = await findWalletById(input.walletId, db);
     if (!wallet || wallet.userId !== input.userId) return "not_found" as const;
-    const factorCount = await countLoginFactors(input.userId, db);
-    if (factorCount <= 1) return "last_factor" as const;
+    const walletSubject = walletIdentitySubject(wallet);
+    if (walletSubject) {
+      const factorCount = await countLoginFactors(input.userId, db);
+      if (factorCount <= 1) return "last_factor" as const;
+    }
     const revoked = await revokeWallet({ ...input, db });
     if (!revoked) return "not_found" as const;
-    const walletSubject = walletIdentitySubject(wallet);
     if (!walletSubject) return "revoked" as const;
 
     await revokeAuthIdentity({
@@ -1058,45 +1079,54 @@ export async function deactivateAomiAccount(input: {
   userId: AomiUserId;
 }): Promise<DeactivateAomiAccountResult> {
   await ensureAccountSchema();
-  return withTransaction(async (db) => {
-    const user = await findAomiUserById(input.userId, db);
-    if (!user) return { status: "not_found" };
-    // Last-factor protection guards *unlinking* an individual identity/wallet
-    // (see `unlinkAuthIdentity`/`unlinkWallet`), not full account deletion.
-    // Deleting an account is meant to revoke every remaining factor, so a
-    // Para-only/SIWE-only single-factor user must still be able to delete.
+  const result: DeactivateAomiAccountResult = await withTransaction(
+    async (db) => {
+      const user = await findAomiUserById(input.userId, db);
+      if (!user) return { status: "not_found" as const };
+      // Last-factor protection guards *unlinking* an individual identity/wallet
+      // (see `unlinkAuthIdentity`/`unlinkWallet`), not full account deletion.
+      // Deleting an account is meant to revoke every remaining factor, so a
+      // Para-only/SIWE-only single-factor user must still be able to delete.
 
-    const revokedIdentities = await revokeAllAuthIdentitiesForUser({
-      userId: input.userId,
-      db,
-    });
-    const revokedWallets = await revokeAllWalletsForUser({
-      userId: input.userId,
-      db,
-    });
-    const deactivated = await deactivateAomiUser({
-      userId: input.userId,
-      db,
-    });
-    if (!deactivated) return { status: "not_found" };
+      const betterAuthUserIds = await listBetterAuthUserIdsForAomiUser(
+        input.userId,
+        db,
+      );
+      const revokedIdentities = await revokeAllAuthIdentitiesForUser({
+        userId: input.userId,
+        db,
+      });
+      const revokedWallets = await revokeAllWalletsForUser({
+        userId: input.userId,
+        db,
+      });
+      await deleteBetterAuthUsers({ betterAuthUserIds, db });
+      await deleteWidgetSessionsForUser({ userId: input.userId, db });
+      const deactivated = await deactivateAomiUser({
+        userId: input.userId,
+        db,
+      });
+      if (!deactivated) return { status: "not_found" as const };
 
-    await logAccountEvent({
-      userId: input.userId,
-      actorUserId: input.userId,
-      eventType: "account.deactivated",
-      data: {
+      await logAccountEvent({
+        userId: input.userId,
+        actorUserId: input.userId,
+        eventType: "account.deactivated",
+        data: {
+          revokedIdentities,
+          revokedWallets,
+          hadBetterAuthUserId: Boolean(user.betterAuthUserId),
+        },
+        db,
+      });
+      return {
+        status: "deactivated" as const,
         revokedIdentities,
         revokedWallets,
-        hadBetterAuthUserId: Boolean(user.betterAuthUserId),
-      },
-      db,
-    });
-    return {
-      status: "deactivated",
-      revokedIdentities,
-      revokedWallets,
-    };
-  });
+      };
+    },
+  );
+  return result;
 }
 
 function signalEventType(signal: SignalRef, suffix: string): string {

--- a/packages/account/src/service/provider-exchange.ts
+++ b/packages/account/src/service/provider-exchange.ts
@@ -31,7 +31,6 @@ import type {
   WidgetProviderPolicy,
 } from "../providers/descriptor";
 import {
-  betterAuthWalletSignals,
   ensureAccountSchema,
   fetchAttestedProviderWallets,
   isIdentityAlreadyLinkedError,
@@ -87,21 +86,9 @@ export async function signInWithVerifiedProviderCredential(input: {
 }): Promise<ProviderLinkResult> {
   await ensureAccountSchema();
   const prepared = await prepareVerifiedCredential(input.verified);
-  const betterAuthSignals = await betterAuthWalletSignals(
-    input.betterAuthUserId,
-  );
-  const betterAuthIdentity: SignalRef = {
-    type: "identity",
-    provider: "better_auth",
-    issuerEnvironment: "aomi",
-    tenantId: "portal",
-    subject: input.betterAuthUserId,
-  };
-
   const resolution = await signInWithVerifiedProviderIdentity({
     identity: prepared.identity,
     policy: nativeProviderResolutionPolicy(prepared.identity.provider),
-    additionalRecoverySignals: [betterAuthIdentity, ...betterAuthSignals],
     wallets: prepared.wallets,
     displayName: input.name ?? input.email,
     onResolved: async (user, db) => {
@@ -131,7 +118,6 @@ export async function signInWithVerifiedProviderIdentity(input: {
   identity: VerifiedProviderIdentity;
   policy: Pick<WidgetProviderPolicy, "subjectIsEnvironmentGlobal">;
   wallets?: readonly AttestedWallet[];
-  additionalRecoverySignals?: readonly SignalRef[];
   displayName?: string | null;
   onResolved?: (user: DbAomiUser, db: import("pg").PoolClient) => Promise<void>;
 }): Promise<ProviderSignInResult> {
@@ -141,10 +127,11 @@ export async function signInWithVerifiedProviderIdentity(input: {
     const resolution = await resolveVerifiedProviderIdentity({
       identity: input.identity,
       policy: input.policy,
-      recoverySignals: [
-        ...(input.additionalRecoverySignals ?? []),
-        ...providerRecoverySignals(input.identity, wallets),
-      ],
+      // Login ownership comes only from the exact verified provider subject.
+      // Shared email and embedded-wallet claims are useful profile/capability
+      // data, but may attach a provider only through the authenticated link
+      // flow below; otherwise an unlinked provider can silently recover access.
+      recoverySignals: [],
       displayName: input.displayName ?? input.identity.email?.value,
       onResolved: async (result, db) => {
         await input.onResolved?.(result.user, db);

--- a/packages/account/src/widget-auth/store.ts
+++ b/packages/account/src/widget-auth/store.ts
@@ -187,6 +187,24 @@ export async function deleteWidgetSessionsForProviderIdentity(input: {
   return result.rowCount ?? 0;
 }
 
+/** Revoke every widget session for a deleted canonical account. The guarded
+ * JSON cast mirrors provider-identity revocation and cannot be tripped by an
+ * unrelated or malformed verification row. */
+export async function deleteWidgetSessionsForUser(input: {
+  userId: string;
+  db?: Db;
+}): Promise<number> {
+  const result = await (input.db ?? getPool()).query(
+    `delete from ba_verifications
+      where identifier like $1
+        and (case when value ~ '^\\s*\\{'
+                  then value::jsonb ->> 'userId'
+             end) = $2`,
+    [`${WIDGET_SESSION_NAMESPACE}%`, input.userId],
+  );
+  return result.rowCount ?? 0;
+}
+
 function parseTicket(value: string | undefined): WidgetAuthTicket | null {
   if (!value) return null;
   try {

--- a/packages/account/test/account-service-adoption.test.ts
+++ b/packages/account/test/account-service-adoption.test.ts
@@ -11,6 +11,7 @@ const queryMocks = vi.hoisted(() => ({
   deleteBetterAuthSiweWallet: vi.fn(),
   deleteBetterAuthSiwsWallet: vi.fn(),
   findAuthIdentityById: vi.fn(),
+  findAuthIdentityForSubject: vi.fn(),
   findAomiUserById: vi.fn(),
   findAomiUserByBetterAuthId: vi.fn(),
   findLegacyBackendUserIdByWallet: vi.fn(),
@@ -20,6 +21,7 @@ const queryMocks = vi.hoisted(() => ({
   listBetterAuthSiweWallets: vi.fn(),
   listBetterAuthSiwsWallets: vi.fn(),
   listWalletsForUser: vi.fn(),
+  lockBetterAuthUser: vi.fn(),
   lockIdentityResolutionKeys: vi.fn(),
   logAccountEvent: vi.fn(),
   revokeAllAuthIdentitiesForUser: vi.fn(),
@@ -81,6 +83,7 @@ describe("getOrCreateAomiUserForBetterAuthSession adoption", () => {
     queryMocks.runAomiAuthSchema.mockResolvedValue(undefined);
     queryMocks.withTransaction.mockImplementation(async (fn) => fn(db));
     queryMocks.findProviderSubjectOwners.mockResolvedValue([]);
+    queryMocks.lockBetterAuthUser.mockResolvedValue(true);
     queryMocks.findAomiUserByBetterAuthId.mockResolvedValue(null);
     queryMocks.listBetterAuthSiweWallets.mockResolvedValue([
       {
@@ -128,6 +131,7 @@ describe("getOrCreateAomiUserForBetterAuthSession adoption", () => {
     queryMocks.runAomiAuthSchema.mockResolvedValue(undefined);
     queryMocks.withTransaction.mockImplementation(async (fn) => fn(db));
     queryMocks.findProviderSubjectOwners.mockResolvedValue([]);
+    queryMocks.lockBetterAuthUser.mockResolvedValue(true);
     queryMocks.findAomiUserByBetterAuthId.mockResolvedValue(null);
     queryMocks.listBetterAuthSiweWallets.mockResolvedValue([]);
     queryMocks.listBetterAuthSiwsWallets.mockResolvedValue([

--- a/packages/account/test/account-service-review-fixes.test.ts
+++ b/packages/account/test/account-service-review-fixes.test.ts
@@ -12,6 +12,7 @@ const queryMocks = vi.hoisted(() => ({
   deleteBetterAuthSiweWallet: vi.fn(),
   deleteBetterAuthSiwsWallet: vi.fn(),
   findAuthIdentityById: vi.fn(),
+  findAuthIdentityForSubject: vi.fn(),
   findAomiUserById: vi.fn(),
   findProviderSubjectOwners: vi.fn(),
   findSignalOwner: vi.fn(),
@@ -20,6 +21,7 @@ const queryMocks = vi.hoisted(() => ({
   listBetterAuthSiwsWallets: vi.fn(),
   listBetterAuthUserIdsForAomiUser: vi.fn(),
   listWalletsForUser: vi.fn(),
+  lockBetterAuthUser: vi.fn(),
   lockIdentityResolutionKeys: vi.fn(),
   logAccountEvent: vi.fn(),
   revokeAllAuthIdentitiesForUser: vi.fn(),
@@ -55,6 +57,7 @@ function primeResolutionMocks() {
   queryMocks.listBetterAuthSiwsWallets.mockResolvedValue([]);
   queryMocks.findSignalOwner.mockResolvedValue(null);
   queryMocks.findProviderSubjectOwners.mockResolvedValue([]);
+  queryMocks.lockBetterAuthUser.mockResolvedValue(true);
   queryMocks.createAomiUser.mockResolvedValue({ id: "new-user" });
   queryMocks.upsertAuthIdentity.mockResolvedValue({ id: "ba-identity" });
 }
@@ -121,6 +124,24 @@ describe("getOrCreateAomiUserForBetterAuthSession email atomicity", () => {
         emailVerified: true,
       }),
     ).rejects.toThrow("identity_already_linked_to_another_account");
+  });
+
+  it("rejects a carrier deleted after its session was read", async () => {
+    primeResolutionMocks();
+    queryMocks.lockBetterAuthUser.mockResolvedValue(false);
+
+    const { getOrCreateAomiUserForBetterAuthSession } =
+      await import("../src/service/account-service");
+
+    await expect(
+      getOrCreateAomiUserForBetterAuthSession({
+        betterAuthUserId: "ba-deleted",
+      }),
+    ).rejects.toThrow("account_session_invalid");
+    expect(queryMocks.lockBetterAuthUser).toHaveBeenCalledWith(
+      "ba-deleted",
+      tx,
+    );
   });
 });
 
@@ -234,13 +255,13 @@ describe("deactivateAomiAccount last-factor handling", () => {
   });
 });
 
-describe("unlinkAuthIdentity last-factor handling", () => {
+describe("unlinkAuthIdentity revocation", () => {
   afterEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
   });
 
-  it("does not unlink the user's last usable provider login", async () => {
+  it("allows removing the last provider identity and invalidates its carriers", async () => {
     queryMocks.withTransaction.mockImplementation(async (fn) => fn(tx));
     queryMocks.lockIdentityResolutionKeys.mockResolvedValue(undefined);
     queryMocks.findAuthIdentityById.mockResolvedValue({
@@ -251,33 +272,6 @@ describe("unlinkAuthIdentity last-factor handling", () => {
       tenantId: "project-a",
       subject: "para-user",
     });
-    queryMocks.countLoginFactors.mockResolvedValue(1);
-
-    const { unlinkAuthIdentity } =
-      await import("../src/service/account-service");
-
-    await expect(
-      unlinkAuthIdentity({ userId: "user-a", identityId: "para-row" }),
-    ).resolves.toBe("last_factor");
-    expect(queryMocks.revokeAuthIdentity).not.toHaveBeenCalled();
-    expect(queryMocks.lockIdentityResolutionKeys).toHaveBeenCalledWith(
-      ["aomi-login-factors:user-a"],
-      tx,
-    );
-  });
-
-  it("allows unlinking after another usable login method is present", async () => {
-    queryMocks.withTransaction.mockImplementation(async (fn) => fn(tx));
-    queryMocks.lockIdentityResolutionKeys.mockResolvedValue(undefined);
-    queryMocks.findAuthIdentityById.mockResolvedValue({
-      id: "para-row",
-      userId: "user-a",
-      provider: "para",
-      issuerEnvironment: "para:beta",
-      tenantId: "project-a",
-      subject: "para-user",
-    });
-    queryMocks.countLoginFactors.mockResolvedValue(2);
     queryMocks.revokeAuthIdentity.mockResolvedValue(true);
     queryMocks.listBetterAuthUserIdsForAomiUser.mockResolvedValue([
       "ba-user-a",
@@ -290,7 +284,42 @@ describe("unlinkAuthIdentity last-factor handling", () => {
     await expect(
       unlinkAuthIdentity({ userId: "user-a", identityId: "para-row" }),
     ).resolves.toBe("revoked");
-    expect(queryMocks.countLoginFactors).toHaveBeenCalledWith("user-a", tx);
+    expect(queryMocks.countLoginFactors).not.toHaveBeenCalled();
+    expect(queryMocks.revokeAuthIdentity).toHaveBeenCalled();
+    expect(queryMocks.deleteBetterAuthUsers).toHaveBeenCalledWith({
+      betterAuthUserIds: ["ba-user-a"],
+      db: tx,
+    });
+    expect(queryMocks.lockIdentityResolutionKeys).toHaveBeenCalledWith(
+      ["aomi-login-factors:user-a"],
+      tx,
+    );
+  });
+
+  it("revokes a selected provider without consulting unrelated login factors", async () => {
+    queryMocks.withTransaction.mockImplementation(async (fn) => fn(tx));
+    queryMocks.lockIdentityResolutionKeys.mockResolvedValue(undefined);
+    queryMocks.findAuthIdentityById.mockResolvedValue({
+      id: "para-row",
+      userId: "user-a",
+      provider: "para",
+      issuerEnvironment: "para:beta",
+      tenantId: "project-a",
+      subject: "para-user",
+    });
+    queryMocks.revokeAuthIdentity.mockResolvedValue(true);
+    queryMocks.listBetterAuthUserIdsForAomiUser.mockResolvedValue([
+      "ba-user-a",
+    ]);
+    queryMocks.deleteBetterAuthUsers.mockResolvedValue(1);
+
+    const { unlinkAuthIdentity } =
+      await import("../src/service/account-service");
+
+    await expect(
+      unlinkAuthIdentity({ userId: "user-a", identityId: "para-row" }),
+    ).resolves.toBe("revoked");
+    expect(queryMocks.countLoginFactors).not.toHaveBeenCalled();
     expect(queryMocks.revokeAuthIdentity).toHaveBeenCalledWith(
       expect.objectContaining({ userId: "user-a", db: tx }),
     );
@@ -360,5 +389,41 @@ describe("unlinkWallet last-factor handling", () => {
     expect(queryMocks.revokeWallet).toHaveBeenCalledWith(
       expect.objectContaining({ walletId: "wallet-embedded", db: tx }),
     );
+  });
+
+  it("removes a SIWE wallet's Better Auth and widget sessions when another login remains", async () => {
+    queryMocks.withTransaction.mockImplementation(async (fn) => fn(tx));
+    queryMocks.lockIdentityResolutionKeys.mockResolvedValue(undefined);
+    queryMocks.findWalletById.mockResolvedValue({
+      id: "wallet-siwe",
+      userId: "user-a",
+      family: "evm",
+      address: "0x0000000000000000000000000000000000000003",
+      linkedVia: "siwe",
+    });
+    queryMocks.findAuthIdentityForSubject.mockResolvedValue({
+      id: "siwe-identity",
+    });
+    queryMocks.countLoginFactors.mockResolvedValue(2);
+    queryMocks.revokeWallet.mockResolvedValue(true);
+    queryMocks.revokeAuthIdentity.mockResolvedValue(true);
+    queryMocks.deleteBetterAuthSiweWallet.mockResolvedValue({
+      deleted: true,
+      betterAuthUserIds: ["ba-siwe-user"],
+    });
+    queryMocks.deleteBetterAuthUsers.mockResolvedValue(1);
+
+    const { unlinkWallet } = await import("../src/service/account-service");
+
+    await expect(
+      unlinkWallet({ userId: "user-a", walletId: "wallet-siwe" }),
+    ).resolves.toBe("revoked");
+    expect(queryMocks.deleteBetterAuthUsers).toHaveBeenCalledWith({
+      betterAuthUserIds: ["ba-siwe-user"],
+      db: tx,
+    });
+    expect(
+      widgetMocks.deleteWidgetSessionsForProviderIdentity,
+    ).toHaveBeenCalledWith({ providerIdentityId: "siwe-identity", db: tx });
   });
 });

--- a/packages/account/test/account-service-review-fixes.test.ts
+++ b/packages/account/test/account-service-review-fixes.test.ts
@@ -8,6 +8,7 @@ const queryMocks = vi.hoisted(() => ({
   countLoginFactors: vi.fn(),
   createAomiUser: vi.fn(),
   deactivateAomiUser: vi.fn(),
+  deleteBetterAuthUsers: vi.fn(),
   deleteBetterAuthSiweWallet: vi.fn(),
   deleteBetterAuthSiwsWallet: vi.fn(),
   findAuthIdentityById: vi.fn(),
@@ -17,6 +18,7 @@ const queryMocks = vi.hoisted(() => ({
   findWalletById: vi.fn(),
   listBetterAuthSiweWallets: vi.fn(),
   listBetterAuthSiwsWallets: vi.fn(),
+  listBetterAuthUserIdsForAomiUser: vi.fn(),
   listWalletsForUser: vi.fn(),
   lockIdentityResolutionKeys: vi.fn(),
   logAccountEvent: vi.fn(),
@@ -35,10 +37,13 @@ const queryMocks = vi.hoisted(() => ({
   withTransaction: vi.fn(),
 }));
 
-vi.mock("../src/db/queries", () => queryMocks);
-vi.mock("../src/widget-auth/store", () => ({
+const widgetMocks = vi.hoisted(() => ({
   deleteWidgetSessionsForProviderIdentity: vi.fn(async () => undefined),
+  deleteWidgetSessionsForUser: vi.fn(async () => undefined),
 }));
+
+vi.mock("../src/db/queries", () => queryMocks);
+vi.mock("../src/widget-auth/store", () => widgetMocks);
 
 const tx = { tag: "transaction-client" };
 
@@ -202,6 +207,10 @@ describe("deactivateAomiAccount last-factor handling", () => {
     queryMocks.revokeAllAuthIdentitiesForUser.mockResolvedValue(1);
     queryMocks.revokeAllWalletsForUser.mockResolvedValue(0);
     queryMocks.deactivateAomiUser.mockResolvedValue(true);
+    queryMocks.listBetterAuthUserIdsForAomiUser.mockResolvedValue([
+      "ba-solo-user",
+    ]);
+    queryMocks.deleteBetterAuthUsers.mockResolvedValue(1);
 
     const { deactivateAomiAccount } =
       await import("../src/service/account-service");
@@ -214,6 +223,14 @@ describe("deactivateAomiAccount last-factor handling", () => {
       revokedWallets: 0,
     });
     expect(queryMocks.deactivateAomiUser).toHaveBeenCalled();
+    expect(queryMocks.deleteBetterAuthUsers).toHaveBeenCalledWith({
+      betterAuthUserIds: ["ba-solo-user"],
+      db: tx,
+    });
+    expect(widgetMocks.deleteWidgetSessionsForUser).toHaveBeenCalledWith({
+      userId: "solo-user",
+      db: tx,
+    });
   });
 });
 
@@ -262,6 +279,10 @@ describe("unlinkAuthIdentity last-factor handling", () => {
     });
     queryMocks.countLoginFactors.mockResolvedValue(2);
     queryMocks.revokeAuthIdentity.mockResolvedValue(true);
+    queryMocks.listBetterAuthUserIdsForAomiUser.mockResolvedValue([
+      "ba-user-a",
+    ]);
+    queryMocks.deleteBetterAuthUsers.mockResolvedValue(1);
 
     const { unlinkAuthIdentity } =
       await import("../src/service/account-service");
@@ -273,6 +294,18 @@ describe("unlinkAuthIdentity last-factor handling", () => {
     expect(queryMocks.revokeAuthIdentity).toHaveBeenCalledWith(
       expect.objectContaining({ userId: "user-a", db: tx }),
     );
+    expect(queryMocks.clearAomiBetterAuthUserIds).toHaveBeenCalledWith({
+      userId: "user-a",
+      betterAuthUserIds: ["ba-user-a"],
+      db: tx,
+    });
+    expect(queryMocks.deleteBetterAuthUsers).toHaveBeenCalledWith({
+      betterAuthUserIds: ["ba-user-a"],
+      db: tx,
+    });
+    expect(
+      widgetMocks.deleteWidgetSessionsForProviderIdentity,
+    ).toHaveBeenCalledWith({ providerIdentityId: "para-row", db: tx });
   });
 });
 
@@ -303,6 +336,29 @@ describe("unlinkWallet last-factor handling", () => {
     expect(queryMocks.lockIdentityResolutionKeys).toHaveBeenCalledWith(
       ["aomi-login-factors:user-a"],
       tx,
+    );
+  });
+
+  it("allows removing an embedded provider wallet without treating it as a login factor", async () => {
+    queryMocks.withTransaction.mockImplementation(async (fn) => fn(tx));
+    queryMocks.lockIdentityResolutionKeys.mockResolvedValue(undefined);
+    queryMocks.findWalletById.mockResolvedValue({
+      id: "wallet-embedded",
+      userId: "user-a",
+      family: "evm",
+      address: "0x0000000000000000000000000000000000000002",
+      linkedVia: "para",
+    });
+    queryMocks.revokeWallet.mockResolvedValue(true);
+
+    const { unlinkWallet } = await import("../src/service/account-service");
+
+    await expect(
+      unlinkWallet({ userId: "user-a", walletId: "wallet-embedded" }),
+    ).resolves.toBe("revoked");
+    expect(queryMocks.countLoginFactors).not.toHaveBeenCalled();
+    expect(queryMocks.revokeWallet).toHaveBeenCalledWith(
+      expect.objectContaining({ walletId: "wallet-embedded", db: tx }),
     );
   });
 });

--- a/packages/account/test/canonical-queries.test.ts
+++ b/packages/account/test/canonical-queries.test.ts
@@ -4,6 +4,8 @@ import { describe, expect, it, vi } from "vitest";
 import {
   countLoginFactors,
   claimTelegramSessionOwner,
+  deleteBetterAuthUsers,
+  listBetterAuthUserIdsForAomiUser,
   revokeAuthIdentity,
   updateWalletLabel,
   upsertWallet,
@@ -31,6 +33,33 @@ function fakeDb(
 }
 
 describe("canonical account queries", () => {
+  it("lists and deletes only the Better Auth carriers attached to one canonical user", async () => {
+    const { db, calls } = fakeDb((call) =>
+      call.sql.includes("select distinct subject")
+        ? { rows: [{ subject: "ba-a" }, { subject: "ba-b" }] }
+        : { rows: [], rowCount: 2 },
+    );
+
+    const ids = await listBetterAuthUserIdsForAomiUser(
+      "canonical-user",
+      db as never,
+    );
+    await expect(
+      deleteBetterAuthUsers({
+        betterAuthUserIds: ids,
+        db: db as never,
+      }),
+    ).resolves.toBe(2);
+
+    expect(ids).toEqual(["ba-a", "ba-b"]);
+    expect(calls[0]?.params).toEqual([
+      "canonical-user",
+      ["betterauth", "better_auth"],
+    ]);
+    expect(calls[1]?.sql).toContain("delete from ba_users");
+    expect(calls[1]?.params).toEqual([["ba-a", "ba-b"]]);
+  });
+
   it("resolves a Telegram session only through the same canonical owner", async () => {
     const { db, calls } = fakeDb(() => ({
       rows: [{ user_id: "canonical-user" }],

--- a/packages/account/test/canonical-queries.test.ts
+++ b/packages/account/test/canonical-queries.test.ts
@@ -57,6 +57,7 @@ describe("canonical account queries", () => {
       ["betterauth", "better_auth"],
     ]);
     expect(calls[1]?.sql).toContain("delete from ba_users");
+    expect(calls[1]?.sql).toContain("delete from ba_oauth_device_codes");
     expect(calls[1]?.params).toEqual([["ba-a", "ba-b"]]);
   });
 
@@ -86,10 +87,22 @@ describe("canonical account queries", () => {
 
     await expect(countLoginFactors("user-1", db as never)).resolves.toBe(1);
     expect(calls[0]?.sql).not.toContain("public_keys");
-    expect(calls[0]?.sql).not.toContain("'email'");
+    expect(calls[0]?.sql).toContain("'email'");
     expect(calls[0]?.sql).not.toContain("'siwe'");
     expect(calls[0]?.sql).not.toContain("'siws'");
     expect(calls[0]?.sql).toContain("'betterauth'");
+  });
+
+  it("locks only a still-existing Better Auth carrier", async () => {
+    const { db, calls } = fakeDb(() => ({ rows: [{ exists: 1 }] }));
+    const { lockBetterAuthUser } = await import("../src/db/queries");
+
+    await expect(lockBetterAuthUser("ba-user-1", db as never)).resolves.toBe(
+      true,
+    );
+    expect(calls[0]?.sql).toContain("from ba_users");
+    expect(calls[0]?.sql).toContain("for key share");
+    expect(calls[0]?.params).toEqual(["ba-user-1"]);
   });
 
   it("links a SIWE wallet as an owned public key with SIWE provenance", async () => {

--- a/packages/account/test/identity-lifecycle.integration.test.ts
+++ b/packages/account/test/identity-lifecycle.integration.test.ts
@@ -1,0 +1,186 @@
+// @vitest-environment node
+
+import { randomUUID } from "node:crypto";
+import type { Pool } from "pg";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+const DATABASE_URL = process.env.AOMI_AUTH_TEST_DATABASE_URL;
+const describeWithDatabase = DATABASE_URL ? describe : describe.skip;
+
+describeWithDatabase("identity lifecycle persistence", () => {
+  let pool: Pool;
+  let ids: ReturnType<typeof testIds>;
+
+  beforeAll(async () => {
+    const { Pool: PgPool } = await import("pg");
+    pool = new PgPool({ connectionString: DATABASE_URL });
+    const schema = await pool.query(
+      `select to_regclass('public.ba_users') as users,
+              to_regclass('public.ba_sessions') as sessions,
+              to_regclass('public.ba_oauth_refresh_tokens') as refresh_tokens,
+              to_regclass('public.ba_oauth_access_tokens') as access_tokens,
+              to_regclass('public.ba_oauth_consents') as consents,
+              to_regclass('public.ba_oauth_device_codes') as device_codes,
+              to_regclass('public.ba_verifications') as verifications`,
+    );
+    if (Object.values(schema.rows[0] ?? {}).some((value) => value === null)) {
+      throw new Error(
+        "AOMI_AUTH_TEST_DATABASE_URL must target a disposable database with the current Better Auth migrations",
+      );
+    }
+  });
+
+  afterEach(async () => {
+    if (!pool || !ids) return;
+    await pool.query(`delete from ba_verifications where id = $1`, [ids.wst]);
+    await pool.query(`delete from ba_users where id = $1`, [ids.user]);
+    await pool.query(`delete from ba_oauth_clients where client_id = $1`, [
+      ids.client,
+    ]);
+  });
+
+  afterAll(async () => {
+    await pool?.end();
+  });
+
+  it("revokes two browser sessions, OAuth tokens, consent, and WST storage", async () => {
+    ids = testIds();
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + 60_000);
+    await pool.query(
+      `insert into ba_users
+         (id, name, email, email_verified, created_at, updated_at, is_anonymous)
+       values ($1, 'Lifecycle test', $2, true, $3, $3, false)`,
+      [ids.user, `${ids.user}@example.invalid`, now],
+    );
+    await pool.query(
+      `insert into ba_sessions
+         (id, expires_at, token, created_at, updated_at, user_id)
+       values ($1, $3, $2, $4, $4, $5),
+              ($6, $3, $7, $4, $4, $5)`,
+      [
+        ids.sessionA,
+        ids.sessionTokenA,
+        expiresAt,
+        now,
+        ids.user,
+        ids.sessionB,
+        ids.sessionTokenB,
+      ],
+    );
+    await pool.query(
+      `insert into ba_oauth_clients (id, client_id, redirect_uris)
+       values ($1, $2, '[]'::jsonb)`,
+      [ids.clientRow, ids.client],
+    );
+    await pool.query(
+      `insert into ba_oauth_refresh_tokens
+         (id, token, client_id, user_id, expires_at, created_at, scopes)
+       values ($1, $2, $3, $4, $5, $6, '["agent:read"]'::jsonb)`,
+      [ids.refresh, ids.refreshToken, ids.client, ids.user, expiresAt, now],
+    );
+    await pool.query(
+      `insert into ba_oauth_access_tokens
+         (id, token, client_id, user_id, refresh_id, expires_at, created_at, scopes)
+       values ($1, $2, $3, $4, $5, $6, $7, '["agent:read"]'::jsonb)`,
+      [
+        ids.access,
+        ids.accessToken,
+        ids.client,
+        ids.user,
+        ids.refresh,
+        expiresAt,
+        now,
+      ],
+    );
+    await pool.query(
+      `insert into ba_oauth_consents
+         (id, client_id, user_id, scopes, created_at, updated_at)
+       values ($1, $2, $3, '["agent:read"]'::jsonb, $4, $4)`,
+      [ids.consent, ids.client, ids.user, now],
+    );
+    await pool.query(
+      `insert into ba_oauth_device_codes
+         (id, device_code, user_code, user_id, expires_at, status, client_id,
+          scope, resources, oauth_client_id)
+       values ($1, $2, $3, $4, $5, 'approved', $6, 'agent:read',
+               '["https://portal.example/v1/agent"]'::jsonb, $6)`,
+      [
+        ids.device,
+        ids.deviceCode,
+        ids.userCode,
+        ids.user,
+        expiresAt,
+        ids.client,
+      ],
+    );
+    await pool.query(
+      `insert into ba_verifications
+         (id, identifier, value, expires_at, created_at, updated_at)
+       values ($1, $2, $3, $4, $5, $5)`,
+      [
+        ids.wst,
+        `aomi:widget:session:${ids.wst}`,
+        JSON.stringify({
+          kind: "widget_session",
+          userId: ids.user,
+          origin: "https://widget.example",
+          authMethod: "para",
+          issuedAt: now.toISOString(),
+          expiresAt: expiresAt.toISOString(),
+        }),
+        expiresAt,
+        now,
+      ],
+    );
+
+    const { deleteBetterAuthUsers } = await import("../src/db/queries");
+    const { deleteWidgetSessionsForUser } =
+      await import("../src/widget-auth/store");
+    await expect(
+      deleteBetterAuthUsers({ betterAuthUserIds: [ids.user], db: pool }),
+    ).resolves.toBe(1);
+    await expect(
+      deleteWidgetSessionsForUser({ userId: ids.user, db: pool }),
+    ).resolves.toBe(1);
+
+    for (const [table, id] of [
+      ["ba_users", ids.user],
+      ["ba_sessions", ids.sessionA],
+      ["ba_sessions", ids.sessionB],
+      ["ba_oauth_refresh_tokens", ids.refresh],
+      ["ba_oauth_access_tokens", ids.access],
+      ["ba_oauth_consents", ids.consent],
+      ["ba_oauth_device_codes", ids.device],
+      ["ba_verifications", ids.wst],
+    ] as const) {
+      const remaining = await pool.query(
+        `select 1 from ${table} where id = $1`,
+        [id],
+      );
+      expect(remaining.rowCount, `${table}:${id}`).toBe(0);
+    }
+  });
+});
+
+function testIds() {
+  const suffix = randomUUID();
+  return {
+    user: `lifecycle-user-${suffix}`,
+    sessionA: `lifecycle-session-a-${suffix}`,
+    sessionB: `lifecycle-session-b-${suffix}`,
+    sessionTokenA: `lifecycle-session-token-a-${suffix}`,
+    sessionTokenB: `lifecycle-session-token-b-${suffix}`,
+    clientRow: `lifecycle-client-row-${suffix}`,
+    client: `lifecycle-client-${suffix}`,
+    refresh: `lifecycle-refresh-${suffix}`,
+    refreshToken: `lifecycle-refresh-token-${suffix}`,
+    access: `lifecycle-access-${suffix}`,
+    accessToken: `lifecycle-access-token-${suffix}`,
+    consent: `lifecycle-consent-${suffix}`,
+    device: `lifecycle-device-${suffix}`,
+    deviceCode: `lifecycle-device-code-${suffix}`,
+    userCode: `LIFE-${suffix.slice(0, 8)}`,
+    wst: `lifecycle-wst-${suffix}`,
+  };
+}

--- a/packages/account/test/provider-exchange.test.ts
+++ b/packages/account/test/provider-exchange.test.ts
@@ -202,6 +202,49 @@ describe("provider sign-in and linking", () => {
     });
   });
 
+  it("cannot recover a removed provider through its former account email", async () => {
+    mockState.resolvedUserId = "new-user";
+    queryMocks.upsertEmailIdentity.mockRejectedValueOnce(
+      new Error("identity_already_linked_to_another_account"),
+    );
+
+    await expect(
+      signInWithVerifiedProviderCredential({
+        betterAuthUserId: "ba-recreated",
+        verified: verifiedCredential(),
+      }),
+    ).resolves.toEqual({
+      status: "conflict",
+      reason: "already_linked_to_another_account",
+      signalType: "identity",
+    });
+    expect(mockState.recoverySignals).toEqual([]);
+  });
+
+  it("lets an exact still-linked provider return to its canonical account", async () => {
+    mockState.resolvedUserId = "original-account";
+
+    await expect(
+      signInWithVerifiedProviderCredential({
+        betterAuthUserId: "ba-new-carrier",
+        verified: {
+          ...verifiedCredential(),
+          provider: "privy",
+          walletAttestationProvider: "privy",
+          token: {
+            ...verifiedCredential().token,
+            subject: "still-linked-privy-user",
+            walletAttestations: [],
+          },
+        },
+      }),
+    ).resolves.toMatchObject({
+      status: "linked",
+      user: { id: "original-account" },
+    });
+    expect(mockState.recoverySignals).toEqual([]);
+  });
+
   it("does not transfer a provider or wallet during authenticated linking", async () => {
     mockState.attachError = new IdentityConflictError(
       ["user-a", "user-b"],

--- a/packages/account/test/provider-exchange.test.ts
+++ b/packages/account/test/provider-exchange.test.ts
@@ -8,6 +8,7 @@ const mockState = vi.hoisted(() => ({
   attachError: null as Error | null,
   resolvedUserId: "user-a",
   ownerId: "user-a" as string | null,
+  recoverySignals: null as unknown[] | null,
 }));
 
 const serviceMocks = vi.hoisted(() => ({
@@ -75,6 +76,7 @@ vi.mock("../src/service/identity-resolution", async (importOriginal) => {
     ...actual,
     resolveVerifiedProviderIdentity: vi.fn(async (input) => {
       if (mockState.resolveError) throw mockState.resolveError;
+      mockState.recoverySignals = input.recoverySignals ?? null;
       const result = {
         user: { id: mockState.resolvedUserId },
         identity: { id: "provider-row" },
@@ -132,6 +134,7 @@ describe("provider sign-in and linking", () => {
     mockState.attachError = null;
     mockState.resolvedUserId = "user-a";
     mockState.ownerId = "user-a";
+    mockState.recoverySignals = null;
     serviceMocks.mergeProviderWalletAttestations.mockImplementation(
       (_primary, fallback) => fallback ?? [],
     );
@@ -181,6 +184,8 @@ describe("provider sign-in and linking", () => {
     expect(serviceMocks.syncProviderWallets).toHaveBeenCalledWith(
       expect.objectContaining({ userId: "user-a", db: { tx: true } }),
     );
+    expect(serviceMocks.betterAuthWalletSignals).not.toHaveBeenCalled();
+    expect(mockState.recoverySignals).toEqual([]);
   });
 
   it("creates a new account only when no signal has an owner", async () => {


### PR DESCRIPTION
## Summary
- resolve provider ownership only from the exact verified provider subject
- revoke Better Auth carrier users, sessions, OAuth grants/consents, device codes, and widget sessions with provider unlink/account deletion
- row-lock the Better Auth user during canonical resolution so a stale session cannot recreate a deleted binding
- apply last-factor protection only to real SIWE/SIWS login wallets; allow embedded-wallet and explicit provider unlink
- remove the consent UI's duplicate scope ceiling and reject unknown guest scopes server-side

## Verification
- account suite: 149 passed, plus disposable-PostgreSQL lifecycle integration
- Portal suite: 465 passed
- account and Portal typechecks
- scoped ESLint, Prettier, and diff checks
- real schema cascade proved deletion of two browser sessions, refresh/access token, consent, approved device code, and WST

## Stack
PR 4 of 5. Base: #562. Live two-browser provider unlink/deletion remains in the exact-head staging matrix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/563"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790949659&installation_model_id=12362&pr_number=563&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F563&signature=1465e1aa95952c864ba208bea1f1c62d8636c74a6d7686cb121e32fef4656f14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->