### PR TITLE
Fix cross-origin widget and BFF authentication

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -1,5 +1,18 @@
 # Canonical Landing
 
+Current session goal: **AUTH STACK STAGING HARDENING IN PROGRESS
+2026-09-02** — the exact stacked candidate completed Agent and Pipeline REST
+device authorization, token exchange, authenticated BFF reads, managed CORS,
+and staging-database cleanup. Live verification exposed two lower-layer gaps:
+the shared PostgreSQL rate counter lost concurrent increments because its lock
+and read shared a stale statement snapshot, and the hosted Better Auth bundle
+rejected IPv4 loopback callbacks while accepting IPv6. The counter now locks
+in a separate explicit transaction statement with a real 61-way PostgreSQL
+regression, and the narrow Better Auth patch owns the RFC 8252 IPv4/IPv6 check
+instead of its bundled helper. A cache-free exact-SHA staging rebuild and repeat
+matrix are the current merge gate; dedicated Para/Privy identities remain the
+separate credentialed-browser boundary.
+
 Current session goal: **COMPREHENSIVE AUTH RECOVERY STACK LOCALLY VERIFIED
 2026-09-02** — five focused changes now cover RFC 8252 loopback callbacks,
 single-owner Para/Privy device initialization, account-first CLI credentials,

--- a/GOAL.md
+++ b/GOAL.md
@@ -1,5 +1,20 @@
 # Canonical Landing
 
+Current session goal: **COMPREHENSIVE AUTH RECOVERY STACK LOCALLY VERIFIED
+2026-09-02** — five focused changes now cover RFC 8252 loopback callbacks,
+single-owner Para/Privy device initialization, account-first CLI credentials,
+durable identity revocation, and cross-origin Agent/Pipeline widget auth. The
+stack reuses encrypted, short-lived `ba_verifications` records without a new
+table, keeps credentials bound to their origin and subject, applies one public
+API auth resolver and managed CORS, replaces the spoofable in-process widget
+limiter with a shared expiring counter, and preserves widget state across
+anonymous-to-authenticated transitions. On the exact stacked head, Portal is
+510/510, account is 158/158, and client is 299 passed with one pre-existing
+contract test skipped; client, React, and widget package builds plus all three
+typechecks pass. The remaining acceptance boundary is the explicitly required
+exact-SHA staging matrix with real dedicated Para/Privy test identities,
+followed by bottom-up merge and the `@aomi-labs/client` 0.6.10 release gates.
+
 Current session goal: **IDENTITY REVOCATION RACES AND CONSENT BOUNDARIES
 LOCALLY VERIFIED 2026-09-02** — canonical account resolution now locks and
 revalidates the backing Better Auth user inside its transaction, so a browser

--- a/apps/portal/src/app/api/auth/widget/exchange/route.ts
+++ b/apps/portal/src/app/api/auth/widget/exchange/route.ts
@@ -12,7 +12,7 @@ import {
 } from "@portal/server/widget-auth/response";
 
 export const POST = widgetRoute(async (request: Request) => {
-  const limited = widgetAuthRateLimit(request);
+  const limited = await widgetAuthRateLimit(request);
   if (limited) return limited;
   const origin = requireWidgetOrigin(request);
   const { descriptor, identity } = await verifyWidgetProviderCredential(

--- a/apps/portal/src/app/api/auth/widget/guest/route.ts
+++ b/apps/portal/src/app/api/auth/widget/guest/route.ts
@@ -12,7 +12,7 @@ import {
 } from "@portal/server/widget-auth/response";
 
 export const POST = widgetRoute(async (request: Request) => {
-  const limited = widgetAuthRateLimit(request);
+  const limited = await widgetAuthRateLimit(request);
   if (limited) return limited;
   const origin = requireWidgetOrigin(request);
   // The widget origin was validated above. Better Auth's server-side anonymous

--- a/apps/portal/src/app/api/auth/widget/oauth-bootstrap/route.ts
+++ b/apps/portal/src/app/api/auth/widget/oauth-bootstrap/route.ts
@@ -30,7 +30,7 @@ const bootstrapBody = z.object({
 });
 
 export const POST = widgetRoute(async (request: Request) => {
-  const limited = widgetAuthRateLimit(request);
+  const limited = await widgetAuthRateLimit(request);
   if (limited) return limited;
 
   const origin = requireWidgetOrigin(request);

--- a/apps/portal/src/app/api/auth/widget/siwe/nonce/route.ts
+++ b/apps/portal/src/app/api/auth/widget/siwe/nonce/route.ts
@@ -13,7 +13,7 @@ const requestSchema = z.object({
 });
 
 export const POST = widgetRoute(async (request: Request) => {
-  const limited = widgetAuthRateLimit(request);
+  const limited = await widgetAuthRateLimit(request);
   if (limited) return limited;
   const parsed = requestSchema.parse(await request.json().catch(() => null));
   const challenge = await createWidgetSiweChallenge({

--- a/apps/portal/src/app/api/auth/widget/siwe/verify/route.ts
+++ b/apps/portal/src/app/api/auth/widget/siwe/verify/route.ts
@@ -15,7 +15,7 @@ const requestSchema = z.object({
 });
 
 export const POST = widgetRoute(async (request: Request) => {
-  const limited = widgetAuthRateLimit(request);
+  const limited = await widgetAuthRateLimit(request);
   if (limited) return limited;
   const parsed = requestSchema.parse(await request.json().catch(() => null));
   const session = await verifyWidgetSiweProof({

--- a/apps/portal/src/app/api/auth/widget/siws/nonce/route.ts
+++ b/apps/portal/src/app/api/auth/widget/siws/nonce/route.ts
@@ -13,7 +13,7 @@ const requestSchema = z.object({
 });
 
 export const POST = widgetRoute(async (request: Request) => {
-  const limited = widgetAuthRateLimit(request);
+  const limited = await widgetAuthRateLimit(request);
   if (limited) return limited;
   const parsed = requestSchema.parse(await request.json().catch(() => null));
   const challenge = await createWidgetSiwsChallenge({

--- a/apps/portal/src/app/api/auth/widget/siws/verify/route.ts
+++ b/apps/portal/src/app/api/auth/widget/siws/verify/route.ts
@@ -15,7 +15,7 @@ const requestSchema = z.object({
 });
 
 export const POST = widgetRoute(async (request: Request) => {
-  const limited = widgetAuthRateLimit(request);
+  const limited = await widgetAuthRateLimit(request);
   if (limited) return limited;
   const parsed = requestSchema.parse(await request.json().catch(() => null));
   const session = await verifyWidgetSiwsProof({

--- a/apps/portal/src/app/api/auth/widget/telegram/exchange/route.ts
+++ b/apps/portal/src/app/api/auth/widget/telegram/exchange/route.ts
@@ -51,7 +51,7 @@ function isClaimableThreadId(sessionId: string): boolean {
 }
 
 export const POST = widgetRoute(async (request: Request) => {
-  const limited = widgetAuthRateLimit(request);
+  const limited = await widgetAuthRateLimit(request);
   if (limited) return limited;
   const origin = requireWidgetOrigin(request);
   const body = (await request

--- a/apps/portal/src/app/api/auth/widget/telegram/exchange/route.ts
+++ b/apps/portal/src/app/api/auth/widget/telegram/exchange/route.ts
@@ -31,7 +31,8 @@ type TelegramParaExchange = {
   session_id?: unknown;
 };
 
-const DM_THREAD_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const DM_THREAD_ID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 function requiredString(value: unknown, maxLength: number): string | null {
   if (typeof value !== "string") return null;

--- a/apps/portal/src/app/oauth/consent/oauth-consent-client.test.tsx
+++ b/apps/portal/src/app/oauth/consent/oauth-consent-client.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  search:
+    "client_id=codex-mcp&scope=agent%3Aread+mcp%3Aagent&resource=https%3A%2F%2Fchat-staging.aomi.dev%2Fv1%2Fagent%2Fmcp&exp=4102444800&sig=signed-request",
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(mocks.search),
+}));
+
+import { OAuthConsentClient } from "./oauth-consent-client";
+
+describe("OAuthConsentClient", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(Response.json({}, { status: 400 })),
+    );
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("submits Better Auth's signed query instead of requiring a nonexistent consent code", async () => {
+    render(<OAuthConsentClient />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Authorize" }));
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledOnce());
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/auth/oauth2/consent",
+      expect.objectContaining({
+        body: JSON.stringify({
+          accept: true,
+          oauth_query: mocks.search,
+          scope: "agent:read mcp:agent",
+        }),
+      }),
+    );
+    expect(
+      screen.queryByText("This authorization request is incomplete."),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/portal/src/app/oauth/consent/oauth-consent-client.tsx
+++ b/apps/portal/src/app/oauth/consent/oauth-consent-client.tsx
@@ -21,7 +21,10 @@ const DESCRIPTIONS: Record<string, string> = {
 
 export function OAuthConsentClient() {
   const params = useSearchParams();
-  const code = params.get("code") ?? params.get("consent_code");
+  // Better Auth redirects to the consent page with the complete signed OAuth
+  // request in its query string. The consent endpoint validates this value
+  // before it reads any user-selected fields.
+  const oauthQuery = params.toString();
   const scopes = useMemo(
     () =>
       consentScopes((params.get("scope") ?? "").split(/\s+/).filter(Boolean)),
@@ -32,7 +35,9 @@ export function OAuthConsentClient() {
 
   const decide = useCallback(
     async (accept: boolean) => {
-      if (!code) return setStatus("This authorization request is incomplete.");
+      if (!oauthQuery) {
+        return setStatus("This authorization request is incomplete.");
+      }
       setPending(true);
       const response = await fetch("/api/auth/oauth2/consent", {
         method: "POST",
@@ -40,8 +45,7 @@ export function OAuthConsentClient() {
         credentials: "include",
         body: JSON.stringify({
           accept,
-          code,
-          consent_code: code,
+          oauth_query: oauthQuery,
           // The signed request has already passed the canonical server policy.
           // Echo it unchanged; the route validates it again before minting.
           scope: scopes.join(" "),
@@ -57,7 +61,7 @@ export function OAuthConsentClient() {
       }
       window.location.assign(redirect);
     },
-    [code, scopes],
+    [oauthQuery, scopes],
   );
 
   return (

--- a/apps/portal/src/app/v1/agent/[...slug]/route.test.ts
+++ b/apps/portal/src/app/v1/agent/[...slug]/route.test.ts
@@ -3,6 +3,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   resolveApiPrincipal: vi.fn(),
   proxyAgentApi: vi.fn(),
+  applyCors: vi.fn(async ({ request, response }) => {
+    const origin = request.headers.get("origin");
+    if (origin) response.headers.set("access-control-allow-origin", origin);
+    return response;
+  }),
+  preflight: vi.fn(async () => new Response(null, { status: 204 })),
 }));
 
 vi.mock("@portal/server/oauth/principal", () => ({
@@ -12,6 +18,10 @@ vi.mock("@portal/server/oauth/principal", () => ({
 }));
 vi.mock("@portal/server/agent-api-proxy", () => ({
   proxyAgentApi: mocks.proxyAgentApi,
+}));
+vi.mock("@portal/server/oauth/cors", () => ({
+  applyManagedWidgetOriginCors: mocks.applyCors,
+  managedWidgetPreflight: mocks.preflight,
 }));
 vi.mock("@portal/server/oauth/resources", () => ({
   AGENT_SCOPES: [
@@ -27,7 +37,7 @@ vi.mock("@portal/server/oauth/resources", () => ({
   }),
 }));
 
-import { DELETE, GET, PATCH, POST } from "./route";
+import { DELETE, GET, OPTIONS, PATCH, POST } from "./route";
 
 describe("canonical Agent BFF route", () => {
   beforeEach(() => {
@@ -81,4 +91,31 @@ describe("canonical Agent BFF route", () => {
       });
     },
   );
+
+  it("applies managed-origin CORS to authenticated responses and preflights", async () => {
+    mocks.resolveApiPrincipal.mockResolvedValue({
+      canonicalUserId: "canonical-user",
+      scopes: ["agent:read"],
+      resource: "https://portal.example/v1/agent",
+      authSource: "session",
+      principalClass: "user",
+    });
+    mocks.proxyAgentApi.mockResolvedValue(new Response("ok"));
+    const request = new Request("https://portal.example/v1/agent/sessions", {
+      headers: { origin: "https://widget.example" },
+    });
+
+    const response = await GET(request);
+    expect(response.headers.get("access-control-allow-origin")).toBe(
+      "https://widget.example",
+    );
+    await expect(OPTIONS(request)).resolves.toHaveProperty("status", 204);
+    expect(mocks.preflight).toHaveBeenCalledWith(request, [
+      "GET",
+      "POST",
+      "PATCH",
+      "DELETE",
+      "OPTIONS",
+    ]);
+  });
 });

--- a/apps/portal/src/app/v1/agent/[...slug]/route.ts
+++ b/apps/portal/src/app/v1/agent/[...slug]/route.ts
@@ -7,6 +7,10 @@ import {
   AGENT_SCOPES,
   aomiOAuthResources,
 } from "@portal/server/oauth/resources";
+import {
+  applyManagedWidgetOriginCors,
+  managedWidgetPreflight,
+} from "@portal/server/oauth/cors";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -14,6 +18,7 @@ export const maxDuration = 300;
 
 async function handle(request: Request): Promise<Response> {
   const resource = aomiOAuthResources().agentRest;
+  let response: Response;
   try {
     const requiredScopes = agentRouteScopes(request);
     const principal = await resolveApiPrincipal({
@@ -29,7 +34,7 @@ async function handle(request: Request): Promise<Response> {
     ) {
       delegatedScopes.push("custody:delegate");
     }
-    return await proxyAgentApi(request, {
+    response = await proxyAgentApi(request, {
       ...principal,
       scopes: delegatedScopes,
     });
@@ -40,18 +45,20 @@ async function handle(request: Request): Promise<Response> {
         error.message,
       )
     ) {
-      return apiAuthError(error, resource);
-    }
-    return Response.json(
-      {
-        error: {
-          code: "upstream_unavailable",
-          message: "Agent API unavailable",
+      response = apiAuthError(error, resource);
+    } else {
+      response = Response.json(
+        {
+          error: {
+            code: "upstream_unavailable",
+            message: "Agent API unavailable",
+          },
         },
-      },
-      { status: 502 },
-    );
+        { status: 502 },
+      );
+    }
   }
+  return applyManagedWidgetOriginCors({ request, response });
 }
 
 function agentRouteScopes(request: Request): string[] {
@@ -68,3 +75,11 @@ export const GET = handle;
 export const POST = handle;
 export const PATCH = handle;
 export const DELETE = handle;
+export const OPTIONS = (request: Request) =>
+  managedWidgetPreflight(request, [
+    "GET",
+    "POST",
+    "PATCH",
+    "DELETE",
+    "OPTIONS",
+  ]);

--- a/apps/portal/src/app/v1/pipeline/[...slug]/route.test.ts
+++ b/apps/portal/src/app/v1/pipeline/[...slug]/route.test.ts
@@ -3,6 +3,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   resolveApiPrincipal: vi.fn(),
   proxyAgentApi: vi.fn(),
+  applyCors: vi.fn(async ({ request, response }) => {
+    const origin = request.headers.get("origin");
+    if (origin) response.headers.set("access-control-allow-origin", origin);
+    return response;
+  }),
+  preflight: vi.fn(async () => new Response(null, { status: 204 })),
 }));
 
 vi.mock("@portal/server/oauth/principal", () => ({
@@ -12,6 +18,10 @@ vi.mock("@portal/server/oauth/principal", () => ({
 }));
 vi.mock("@portal/server/agent-api-proxy", () => ({
   proxyAgentApi: mocks.proxyAgentApi,
+}));
+vi.mock("@portal/server/oauth/cors", () => ({
+  applyManagedWidgetOriginCors: mocks.applyCors,
+  managedWidgetPreflight: mocks.preflight,
 }));
 vi.mock("@portal/server/oauth/resources", () => ({
   PIPELINE_SCOPES: [
@@ -26,7 +36,7 @@ vi.mock("@portal/server/oauth/resources", () => ({
   }),
 }));
 
-import { GET, POST } from "./route";
+import { GET, OPTIONS, POST } from "./route";
 
 describe("canonical Pipeline BFF route", () => {
   beforeEach(() => {
@@ -64,5 +74,30 @@ describe("canonical Pipeline BFF route", () => {
           ? ["pipeline:catalog"]
           : ["pipeline:execute", "custody:delegate"],
     });
+  });
+
+  it("applies managed-origin CORS to authenticated responses and preflights", async () => {
+    mocks.resolveApiPrincipal.mockResolvedValue({
+      canonicalUserId: "canonical-user",
+      scopes: ["pipeline:catalog"],
+      resource: "https://portal.example/v1/pipeline",
+      authSource: "session",
+      principalClass: "user",
+    });
+    mocks.proxyAgentApi.mockResolvedValue(new Response("ok"));
+    const request = new Request("https://portal.example/v1/pipeline/tools", {
+      headers: { origin: "https://widget.example" },
+    });
+
+    const response = await GET(request);
+    expect(response.headers.get("access-control-allow-origin")).toBe(
+      "https://widget.example",
+    );
+    await expect(OPTIONS(request)).resolves.toHaveProperty("status", 204);
+    expect(mocks.preflight).toHaveBeenCalledWith(request, [
+      "GET",
+      "POST",
+      "OPTIONS",
+    ]);
   });
 });

--- a/apps/portal/src/app/v1/pipeline/[...slug]/route.ts
+++ b/apps/portal/src/app/v1/pipeline/[...slug]/route.ts
@@ -7,6 +7,10 @@ import {
   PIPELINE_SCOPES,
   aomiOAuthResources,
 } from "@portal/server/oauth/resources";
+import {
+  applyManagedWidgetOriginCors,
+  managedWidgetPreflight,
+} from "@portal/server/oauth/cors";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -14,6 +18,7 @@ export const maxDuration = 300;
 
 async function handle(request: Request): Promise<Response> {
   const resource = aomiOAuthResources().pipelineRest;
+  let response: Response;
   try {
     const requiredScopes = [
       request.method === "GET" ? "pipeline:catalog" : "pipeline:execute",
@@ -34,7 +39,7 @@ async function handle(request: Request): Promise<Response> {
     ) {
       delegatedScopes.push("custody:delegate");
     }
-    return await proxyAgentApi(request, {
+    response = await proxyAgentApi(request, {
       ...principal,
       scopes: delegatedScopes,
     });
@@ -45,19 +50,23 @@ async function handle(request: Request): Promise<Response> {
         error.message,
       )
     ) {
-      return apiAuthError(error, resource);
-    }
-    return Response.json(
-      {
-        error: {
-          code: "upstream_unavailable",
-          message: "Pipeline API unavailable",
+      response = apiAuthError(error, resource);
+    } else {
+      response = Response.json(
+        {
+          error: {
+            code: "upstream_unavailable",
+            message: "Pipeline API unavailable",
+          },
         },
-      },
-      { status: 502 },
-    );
+        { status: 502 },
+      );
+    }
   }
+  return applyManagedWidgetOriginCors({ request, response });
 }
 
 export const GET = handle;
 export const POST = handle;
+export const OPTIONS = (request: Request) =>
+  managedWidgetPreflight(request, ["GET", "POST", "OPTIONS"]);

--- a/apps/portal/src/server/widget-auth/rate-limit.test.ts
+++ b/apps/portal/src/server/widget-auth/rate-limit.test.ts
@@ -22,15 +22,19 @@ import { widgetAuthRateLimit, widgetClientAddress } from "./rate-limit";
 import { widgetRoute } from "./response";
 
 function requestFromIp(
-  verifiedIp: string,
+  calculatedIp: string,
   forwardedIp = "198.51.100.200",
+  vercelPeerIp = "104.16.0.1",
+  cloudflareClientIp = "203.0.113.200",
 ): Request {
   return new Request("http://localhost:3002/api/auth/widget/exchange", {
     method: "POST",
     headers: {
       Origin: "http://localhost:3000",
-      "x-vercel-forwarded-for": verifiedIp,
+      "x-real-ip": calculatedIp,
+      "x-vercel-forwarded-for": vercelPeerIp,
       "x-forwarded-for": forwardedIp,
+      "cf-connecting-ip": cloudflareClientIp,
     },
   });
 }
@@ -56,20 +60,48 @@ describe("widgetAuthRateLimit", () => {
     expect(result?.status).toBe(429);
   });
 
-  it("uses only the Vercel-owned address header in a deployment", () => {
+  it("uses only Vercel's calculated client address", () => {
     expect(
-      widgetClientAddress(requestFromIp("203.0.113.30", "192.0.2.1"), {
-        VERCEL: "1",
-      }),
+      widgetClientAddress(
+        requestFromIp(
+          "203.0.113.30",
+          "192.0.2.1",
+          "104.16.0.2",
+          "198.51.100.2",
+        ),
+      ),
     ).toBe("203.0.113.30");
   });
 
+  it("accepts Vercel-calculated IPv4 and IPv6 addresses", () => {
+    expect(widgetClientAddress(requestFromIp("203.0.113.31"))).toBe(
+      "203.0.113.31",
+    );
+    expect(widgetClientAddress(requestFromIp("2001:db8::31"))).toBe(
+      "2001:db8::31",
+    );
+  });
+
+  it("keeps one bucket while every upstream address header changes", async () => {
+    let result: Response | null = null;
+    for (let i = 0; i < 61; i++) {
+      result = await widgetAuthRateLimit(
+        requestFromIp(
+          "203.0.113.33",
+          `198.51.100.${i}`,
+          i % 2 === 0 ? "104.16.0.1" : "172.64.0.1",
+          `192.0.2.${i}`,
+        ),
+      );
+    }
+    expect(mocks.counts.size).toBe(1);
+    expect(result?.status).toBe(429);
+  });
+
   it("falls back to one conservative bucket for malformed addresses", () => {
-    expect(
-      widgetClientAddress(requestFromIp("spoofed, 203.0.113.30"), {
-        VERCEL: "1",
-      }),
-    ).toBe("unknown");
+    expect(widgetClientAddress(requestFromIp("spoofed, 203.0.113.30"))).toBe(
+      "unknown",
+    );
   });
 
   it("keeps widget CORS headers on a limited response", async () => {

--- a/apps/portal/src/server/widget-auth/rate-limit.test.ts
+++ b/apps/portal/src/server/widget-auth/rate-limit.test.ts
@@ -58,10 +58,9 @@ describe("widgetAuthRateLimit", () => {
 
   it("uses only the Vercel-owned address header in a deployment", () => {
     expect(
-      widgetClientAddress(
-        requestFromIp("203.0.113.30", "192.0.2.1"),
-        { VERCEL: "1" },
-      ),
+      widgetClientAddress(requestFromIp("203.0.113.30", "192.0.2.1"), {
+        VERCEL: "1",
+      }),
     ).toBe("203.0.113.30");
   });
 
@@ -87,6 +86,8 @@ describe("widgetAuthRateLimit", () => {
       "http://localhost:3000",
     );
     expect(response?.headers.get("Vary")).toContain("Origin");
-    expect(response?.headers.get("Access-Control-Allow-Credentials")).toBeNull();
+    expect(
+      response?.headers.get("Access-Control-Allow-Credentials"),
+    ).toBeNull();
   });
 });

--- a/apps/portal/src/server/widget-auth/rate-limit.test.ts
+++ b/apps/portal/src/server/widget-auth/rate-limit.test.ts
@@ -1,51 +1,92 @@
-import { describe, expect, it } from "vitest";
-import { widgetAuthRateLimit } from "./rate-limit";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ counts: new Map<string, number>() }));
+
+vi.mock("@aomi-labs/account/widget-auth", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@aomi-labs/account/widget-auth")>();
+  return {
+    ...original,
+    checkWidgetAuthRateLimit: vi.fn(
+      async (input: { origin: string; clientAddress: string }) => {
+        const key = `${input.origin}|${input.clientAddress}`;
+        const next = (mocks.counts.get(key) ?? 0) + 1;
+        mocks.counts.set(key, next);
+        return { allowed: next <= 60 };
+      },
+    ),
+  };
+});
+
+import { widgetAuthRateLimit, widgetClientAddress } from "./rate-limit";
 import { widgetRoute } from "./response";
 
-function requestFromIp(ip: string): Request {
+function requestFromIp(
+  verifiedIp: string,
+  forwardedIp = "198.51.100.200",
+): Request {
   return new Request("http://localhost:3002/api/auth/widget/exchange", {
     method: "POST",
-    headers: { Origin: "http://localhost:3000", "x-forwarded-for": ip },
+    headers: {
+      Origin: "http://localhost:3000",
+      "x-vercel-forwarded-for": verifiedIp,
+      "x-forwarded-for": forwardedIp,
+    },
   });
 }
 
 describe("widgetAuthRateLimit", () => {
-  it("allows a conservative burst then returns 429 for the same IP", () => {
-    // Unique IP so the shared in-process window is isolated from other tests.
-    const ip = "203.0.113.10";
-    let last: Response | null = null;
-    let firstBlockedAt = -1;
-    for (let i = 0; i < 200; i++) {
-      const result = widgetAuthRateLimit(requestFromIp(ip));
-      if (result && firstBlockedAt === -1) firstBlockedAt = i;
-      last = result;
+  beforeEach(() => mocks.counts.clear());
+
+  it("blocks the 61st request from the same edge-verified client", async () => {
+    let result: Response | null = null;
+    for (let i = 0; i < 61; i++) {
+      result = await widgetAuthRateLimit(requestFromIp("203.0.113.10"));
     }
-    // Some allowed requests came before the first block, and eventually blocks.
-    expect(firstBlockedAt).toBeGreaterThan(0);
-    expect(last?.status).toBe(429);
+    expect(result?.status).toBe(429);
   });
 
-  it("returns null (allowed) for a fresh IP", () => {
-    expect(widgetAuthRateLimit(requestFromIp("203.0.113.20"))).toBeNull();
+  it("does not let arbitrary forwarding headers reset the quota", async () => {
+    let result: Response | null = null;
+    for (let i = 0; i < 61; i++) {
+      result = await widgetAuthRateLimit(
+        requestFromIp("203.0.113.20", `198.51.100.${i}`),
+      );
+    }
+    expect(result?.status).toBe(429);
   });
 
-  it("is wrapped with widget CORS headers when returned from a route", async () => {
-    const ip = "203.0.113.30";
+  it("uses only the Vercel-owned address header in a deployment", () => {
+    expect(
+      widgetClientAddress(
+        requestFromIp("203.0.113.30", "192.0.2.1"),
+        { VERCEL: "1" },
+      ),
+    ).toBe("203.0.113.30");
+  });
+
+  it("falls back to one conservative bucket for malformed addresses", () => {
+    expect(
+      widgetClientAddress(requestFromIp("spoofed, 203.0.113.30"), {
+        VERCEL: "1",
+      }),
+    ).toBe("unknown");
+  });
+
+  it("keeps widget CORS headers on a limited response", async () => {
     const handler = widgetRoute(async (request: Request) => {
-      const limited = widgetAuthRateLimit(request);
+      const limited = await widgetAuthRateLimit(request);
       return limited ?? Response.json({ ok: true });
     }, "widget.test_rate_limit");
     let response: Response | null = null;
-    for (let i = 0; i < 200; i++) {
-      response = await handler(requestFromIp(ip));
+    for (let i = 0; i < 61; i++) {
+      response = await handler(requestFromIp("203.0.113.40"));
     }
     expect(response?.status).toBe(429);
     expect(response?.headers.get("Access-Control-Allow-Origin")).toBe(
       "http://localhost:3000",
     );
     expect(response?.headers.get("Vary")).toContain("Origin");
-    expect(
-      response?.headers.get("Access-Control-Allow-Credentials"),
-    ).toBeNull();
+    expect(response?.headers.get("Access-Control-Allow-Credentials")).toBeNull();
   });
 });

--- a/apps/portal/src/server/widget-auth/rate-limit.ts
+++ b/apps/portal/src/server/widget-auth/rate-limit.ts
@@ -5,18 +5,13 @@ import {
 } from "@aomi-labs/account/widget-auth";
 
 /**
- * Vercel overwrites this header at its public edge, unlike a caller-provided
- * forwarding chain. Local development may use x-real-ip; absent a verified
- * address all callers deliberately share a conservative fallback bucket.
+ * Vercel calculates x-real-ip after its verified-proxy layer, including when
+ * Cloudflare fronts a custom domain. Never fall back to caller-controlled
+ * forwarding headers; absent one valid address, callers share a conservative
+ * bucket.
  */
-export function widgetClientAddress(
-  request: Request,
-  env: NodeJS.ProcessEnv = process.env,
-): string {
-  const raw = env.VERCEL
-    ? request.headers.get("x-vercel-forwarded-for")
-    : request.headers.get("x-real-ip");
-  const address = raw?.trim() ?? "";
+export function widgetClientAddress(request: Request): string {
+  const address = request.headers.get("x-real-ip")?.trim() ?? "";
   return isIP(address) ? address : "unknown";
 }
 

--- a/apps/portal/src/server/widget-auth/rate-limit.ts
+++ b/apps/portal/src/server/widget-auth/rate-limit.ts
@@ -1,19 +1,34 @@
-import { checkRateLimit, getClientIp } from "@portal/lib/rate-limit";
+import { isIP } from "node:net";
+import {
+  checkWidgetAuthRateLimit,
+  observedWidgetOrigin,
+} from "@aomi-labs/account/widget-auth";
 
 /**
- * Per-IP rate limit for the *unauthenticated* widget-auth endpoints
- * (`exchange`, `siwe|siws nonce/verify`). These run before any bearer exists,
- * yet each one writes a `ba_verifications` row and does signature crypto / JWKS
- * fetches — and `exchange` can create a canonical user — so an unthrottled
- * caller can spam rows and burn CPU. The small in-process limiter is scoped to
- * this public pre-authentication boundary and keyed per client IP.
- *
- * Returned as a plain 429 `Response`; callers return it from inside the
- * `widgetRoute` handler so the wrapper still applies the cross-origin CORS
- * headers. A rate-limited response carries no `Access-Control-Allow-Credentials`
- * and preserves `Vary: Origin`, exactly like every other widget response.
+ * Vercel overwrites this header at its public edge, unlike a caller-provided
+ * forwarding chain. Local development may use x-real-ip; absent a verified
+ * address all callers deliberately share a conservative fallback bucket.
  */
-export function widgetAuthRateLimit(request: Request): Response | null {
-  if (checkRateLimit(getClientIp(request)).allowed) return null;
+export function widgetClientAddress(
+  request: Request,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const raw = env.VERCEL
+    ? request.headers.get("x-vercel-forwarded-for")
+    : request.headers.get("x-real-ip");
+  const address = raw?.trim() ?? "";
+  return isIP(address) ? address : "unknown";
+}
+
+/** Shared per-origin, per-client fixed-window quota for public widget-auth
+ * endpoints. The account package stores only a digest in ba_verifications. */
+export async function widgetAuthRateLimit(
+  request: Request,
+): Promise<Response | null> {
+  const result = await checkWidgetAuthRateLimit({
+    origin: observedWidgetOrigin(request) ?? "invalid",
+    clientAddress: widgetClientAddress(request),
+  });
+  if (result.allowed) return null;
   return Response.json({ error: "rate_limited" }, { status: 429 });
 }

--- a/apps/shadcn-registry/package.json
+++ b/apps/shadcn-registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aomi-labs/widget-lib",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Shadcn registry for the Aomi widget.",
   "type": "module",
   "main": "./dist/index.js",

--- a/apps/shadcn-registry/src/components/aomi-widget.test.tsx
+++ b/apps/shadcn-registry/src/components/aomi-widget.test.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useState, type ReactNode } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GetAccountBearer } from "@aomi-labs/client";
+
+const mocks = vi.hoisted(() => ({
+  accountUser: undefined as { id: string } | undefined,
+  mounts: 0,
+  unmounts: 0,
+  getAccountBearer: undefined as
+    | (ReturnType<typeof vi.fn> & { required?: boolean })
+    | undefined,
+  runtimeBearers: [] as Array<GetAccountBearer | undefined>,
+}));
+
+vi.mock("../lib/wallet-kit", () => ({
+  AomiWalletKitProvider: ({ children }: { children: ReactNode }) => children,
+  useAomiWalletKit: () => ({
+    accountUser: mocks.accountUser,
+    getAccountBearer: mocks.getAccountBearer,
+  }),
+}));
+
+vi.mock("./aomi-frame", () => {
+  function Root({
+    children,
+    clientOptions,
+  }: {
+    children: ReactNode;
+    clientOptions?: { getAccountBearer?: GetAccountBearer };
+  }) {
+    mocks.runtimeBearers.push(clientOptions?.getAccountBearer);
+    const [draft, setDraft] = useState("");
+    useEffect(() => {
+      mocks.mounts += 1;
+      return () => {
+        mocks.unmounts += 1;
+      };
+    }, []);
+    return (
+      <div>
+        <input
+          aria-label="draft"
+          onChange={(event) => setDraft(event.target.value)}
+          value={draft}
+        />
+        {children}
+      </div>
+    );
+  }
+  const Slot = ({ children }: { children?: ReactNode }) => children;
+  return { AomiFrame: { Root, Header: Slot, Composer: Slot } };
+});
+
+vi.mock("../lib/wallet-kit/execution/backend-aa-context", () => ({
+  BackendAaProvider: ({ children }: { children: ReactNode }) => children,
+}));
+vi.mock("./backend-aa-provisioner", () => ({
+  BackendAaProvisioner: () => null,
+}));
+
+import { AomiWidget } from "./aomi-widget";
+
+describe("AomiWidget authentication continuity", () => {
+  beforeEach(() => {
+    mocks.accountUser = undefined;
+    mocks.mounts = 0;
+    mocks.unmounts = 0;
+    mocks.getAccountBearer = undefined;
+    mocks.runtimeBearers = [];
+  });
+
+  it("preserves the runtime and delegates its stable bearer when an anonymous user signs in", async () => {
+    const view = render(
+      <AomiWidget
+        apiUrl="https://chat.example"
+        applicationId="app-1"
+        auth={{ kind: "browser_wallet" }}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText("draft"), {
+      target: { value: "unfinished message" },
+    });
+    const anonymousBearer = mocks.runtimeBearers.at(-1);
+    await expect(anonymousBearer?.()).resolves.toBeUndefined();
+
+    mocks.accountUser = { id: "user-1" };
+    mocks.getAccountBearer = Object.assign(
+      vi.fn(async () => "widget-token"),
+      { required: true },
+    );
+    view.rerender(
+      <AomiWidget
+        apiUrl="https://chat.example"
+        applicationId="app-1"
+        auth={{ kind: "browser_wallet" }}
+      />,
+    );
+
+    expect(screen.getByLabelText("draft")).toHaveValue("unfinished message");
+    expect(mocks.mounts).toBe(1);
+    expect(mocks.unmounts).toBe(0);
+    const authenticatedBearer = mocks.runtimeBearers.at(-1);
+    expect(authenticatedBearer).toBe(anonymousBearer);
+    expect(authenticatedBearer?.required).toBe(true);
+    await expect(authenticatedBearer?.()).resolves.toBe("widget-token");
+  });
+});

--- a/apps/shadcn-registry/src/components/aomi-widget.tsx
+++ b/apps/shadcn-registry/src/components/aomi-widget.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import type { CSSProperties, ReactNode } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
+import type { GetAccountBearer } from "@aomi-labs/client";
 import type { AomiClientOptions } from "@aomi-labs/react";
 import { AomiFrame, type AomiFrameControlBarProps } from "./aomi-frame";
 import { AomiWalletKitProvider, useAomiWalletKit } from "../lib/wallet-kit";
@@ -139,19 +146,23 @@ function WidgetFrame({
   initialThreadId,
 }: WidgetFrameProps) {
   const walletKit = useAomiWalletKit();
+  const getAccountBearer = useDelegatingAccountBearer(
+    walletKit.getAccountBearer,
+  );
+  const runtimeClientOptions = useMemo(
+    () => ({
+      ...clientOptions,
+      getAccountBearer,
+    }),
+    [clientOptions, getAccountBearer],
+  );
   return (
-    <BackendAaProvider
-      value={{ apiUrl, getAccountBearer: walletKit.getAccountBearer }}
-    >
+    <BackendAaProvider value={{ apiUrl, getAccountBearer }}>
       <AomiFrame.Root
-        key={walletKit.accountUser?.id ?? "anonymous"}
         backendUrl={apiUrl}
         applicationId={applicationId}
         accountSessionAvailable={Boolean(walletKit.accountUser)}
-        clientOptions={{
-          ...clientOptions,
-          getAccountBearer: walletKit.getAccountBearer,
-        }}
+        clientOptions={runtimeClientOptions}
         width={width}
         height={height}
         className={className}
@@ -179,6 +190,40 @@ function WidgetFrame({
       </AomiFrame.Root>
     </BackendAaProvider>
   );
+}
+
+/** Keep the AomiClient and every live thread session on one bearer function.
+ * The delegate appears after login and can rotate later without replacing the
+ * client captured by an already-running session. */
+function useDelegatingAccountBearer(
+  delegate: GetAccountBearer | undefined,
+): GetAccountBearer {
+  const delegateRef = useRef(delegate);
+  delegateRef.current = delegate;
+  const listenersRef = useRef(new Set<() => void>());
+  const provider = useMemo(() => {
+    const getBearer: GetAccountBearer = (options) =>
+      delegateRef.current?.(options) ?? Promise.resolve(undefined);
+    Object.defineProperty(getBearer, "required", {
+      configurable: false,
+      get: () => delegateRef.current?.required === true,
+    });
+    getBearer.subscribe = (listener) => {
+      listenersRef.current.add(listener);
+      return () => listenersRef.current.delete(listener);
+    };
+    return getBearer;
+  }, []);
+
+  useEffect(() => {
+    const unsubscribe = delegate?.subscribe?.(() => {
+      for (const listener of listenersRef.current) listener();
+    });
+    for (const listener of listenersRef.current) listener();
+    return unsubscribe;
+  }, [delegate]);
+
+  return provider;
 }
 
 function resolveWidgetAuth(auth: CrossOriginWidgetAuth): {

--- a/memory/2026-09-02.md
+++ b/memory/2026-09-02.md
@@ -50,3 +50,26 @@
   sessions, an OAuth refresh token, its access token, consent, and an approved
   device code; explicit canonical-account cleanup removed the WST row. Account
   and Portal suites, typechecks, scoped lint, formatting, and diff checks passed.
+- Added a production-route RFC 8252 loopback regression around the real Better
+  Auth 1.7.1 handler. Exact and changed-port callbacks work only for the same
+  IPv4 or IPv6 loopback URI; protocol, address, path, query, userinfo, fragment,
+  localhost, and non-loopback variations fail. Failure diagnostics contain
+  only hashes, counts, comparison booleans, package version, and deployment SHA.
+- Consolidated browser API authorization across Agent and Pipeline REST, SSE,
+  and chat so resource OAuth wins, account/WST follows, and guest auth is used
+  only when no authenticated bearer is required. Authentication is restricted
+  to the configured Aomi origin and known public route families, and a 401
+  retry cannot silently change identity.
+- Added managed, non-cookie CORS and OPTIONS handling for the public Agent and
+  Pipeline BFF routes. Replaced the caller-controlled in-memory widget limiter
+  with a shared expiring `ba_verifications` counter keyed by managed origin and
+  a platform-owned client-address header; ordinary forwarded headers cannot
+  reset the quota.
+- Kept the widget frame stable across anonymous-to-authenticated transitions by
+  delegating bearer refresh instead of key-remounting the runtime. Regression
+  coverage preserves the thread, draft, and in-flight response while the next
+  authenticated poll switches to the WST.
+- Combined verification on the stacked head: Portal 510/510, account 158/158,
+  and client 299 passed with one pre-existing contract skip. Client, React, and
+  widget builds and the client/account/Portal typechecks pass. Staging,
+  bottom-up merge, and npm release remain explicit later gates.

--- a/memory/2026-09-02.md
+++ b/memory/2026-09-02.md
@@ -73,3 +73,20 @@
   and client 299 passed with one pre-existing contract skip. Client, React, and
   widget builds and the client/account/Portal typechecks pass. Staging,
   bottom-up merge, and npm release remain explicit later gates.
+- The first exact stacked staging candidate completed both Agent and Pipeline
+  REST device flows from registration through token, authenticated managed-CORS
+  BFF reads, disallowed-origin rejection, and targeted zero-leftover cleanup.
+- A deployed 61-request HTTP/2 probe exposed lost increments in the shared
+  widget limiter: an advisory lock inside the counter statement waited after
+  PostgreSQL had already taken stale snapshots. The limiter now checks out one
+  connection, acquires a transaction advisory lock in its own statement, then
+  reconciles the row under a fresh READ COMMITTED snapshot. A real disposable
+  PostgreSQL test proves 60 allowed, one denied, one row at 61, duplicate-row
+  reconciliation, and next-window recovery.
+- Hosted loopback verification accepted IPv6 exact and changed-port callbacks
+  but rejected the IPv4 equivalents even though database storage was canonical.
+  The dependency patch now uses its own RFC 8252 IPv4/IPv6 loopback predicate,
+  compares parsed exact URIs, and observes Better Auth's hosted JSON redirects
+  as well as Location responses. Local real-handler positives and all negative
+  callback variants remain green. A cache-free staging rebuild is required
+  before merging the stack.

--- a/packages/account/src/observability.ts
+++ b/packages/account/src/observability.ts
@@ -1,6 +1,7 @@
 export type AccountInternalFailure =
   | { kind: "provider_wallets"; error: unknown }
-  | { kind: "widget_ticket_sweep"; error: unknown };
+  | { kind: "widget_ticket_sweep"; error: unknown }
+  | { kind: "widget_rate_limit_sweep"; error: unknown };
 
 export type ObserveAccountInternalFailure = (
   failure: AccountInternalFailure,

--- a/packages/account/src/widget-auth/index.ts
+++ b/packages/account/src/widget-auth/index.ts
@@ -38,3 +38,4 @@ export {
   type WidgetAuthStore,
   type WidgetAuthTicket,
 } from "./store";
+export { checkWidgetAuthRateLimit } from "./rate-limit";

--- a/packages/account/src/widget-auth/rate-limit.postgres.test.ts
+++ b/packages/account/src/widget-auth/rate-limit.postgres.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment node
+import { createHash, randomUUID } from "node:crypto";
+import { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { checkWidgetAuthRateLimit } from "./rate-limit";
+
+const baseDatabaseUrl = process.env.AOMI_AUTH_TEST_DATABASE_URL?.trim();
+const schemaName = `aomi_widget_rate_${randomUUID().replaceAll("-", "")}`;
+const describePostgres = isLoopbackPostgres(baseDatabaseUrl)
+  ? describe
+  : describe.skip;
+
+describePostgres("shared widget auth rate limit in PostgreSQL", () => {
+  let adminPool: Pool;
+  let pool: Pool;
+
+  beforeAll(async () => {
+    adminPool = new Pool({ connectionString: baseDatabaseUrl });
+    await adminPool.query(`create schema "${schemaName}"`);
+    await adminPool.query(
+      `create table "${schemaName}".ba_verifications (
+         id text primary key,
+         identifier text not null,
+         value text not null,
+         expires_at timestamptz not null,
+         created_at timestamptz not null default now(),
+         updated_at timestamptz not null default now()
+       )`,
+    );
+    pool = new Pool({
+      connectionString: withSearchPath(baseDatabaseUrl!, schemaName),
+      max: 16,
+    });
+    vi.spyOn(Math, "random").mockReturnValue(1);
+  });
+
+  afterAll(async () => {
+    vi.restoreAllMocks();
+    await pool?.end();
+    try {
+      await adminPool?.query(`drop schema if exists "${schemaName}" cascade`);
+    } finally {
+      await adminPool?.end();
+    }
+  });
+
+  it("serializes 61 concurrent increments and recovers in the next window", async () => {
+    const now = new Date(Math.floor(Date.now() / 60_000) * 60_000 + 1_000);
+    const input = {
+      origin: "https://partner.example",
+      clientAddress: "203.0.113.8",
+      now,
+    };
+    const results = await Promise.all(
+      Array.from({ length: 61 }, () =>
+        checkWidgetAuthRateLimit({
+          ...input,
+          db: pool,
+        }),
+      ),
+    );
+
+    expect(results.filter(({ allowed }) => allowed)).toHaveLength(60);
+    expect(results.filter(({ allowed }) => !allowed)).toHaveLength(1);
+    await expect(
+      pool.query<{ value: string }>(
+        "select value from ba_verifications order by identifier",
+      ),
+    ).resolves.toMatchObject({ rows: [{ value: "61" }] });
+
+    await expect(
+      checkWidgetAuthRateLimit({
+        ...input,
+        now: new Date(now.getTime() + 60_000),
+        db: pool,
+      }),
+    ).resolves.toEqual({ allowed: true });
+  });
+
+  it("reconciles duplicate legacy rows under the same lock", async () => {
+    const now = new Date(Math.floor(Date.now() / 60_000) * 60_000 + 1_000);
+    const origin = "https://duplicate.example";
+    const clientAddress = "203.0.113.9";
+    const windowStart = Math.floor(now.getTime() / 60_000) * 60_000;
+    const identifier = `aomi:widget:rate:${createHash("sha256")
+      .update(`${origin}\n${clientAddress}\n${windowStart}`)
+      .digest("hex")}`;
+    await pool.query(
+      `insert into ba_verifications
+         (id, identifier, value, expires_at, created_at, updated_at)
+       values ($1, $2, '3', $4, now(), now()),
+              ($3, $2, '5', $4, now(), now())`,
+      [randomUUID(), identifier, randomUUID(), new Date(windowStart + 60_000)],
+    );
+
+    await expect(
+      checkWidgetAuthRateLimit({ origin, clientAddress, now, db: pool }),
+    ).resolves.toEqual({ allowed: true });
+    await expect(
+      pool.query<{ value: string }>(
+        "select value from ba_verifications where identifier = $1",
+        [identifier],
+      ),
+    ).resolves.toMatchObject({ rows: [{ value: "6" }] });
+  });
+});
+
+function isLoopbackPostgres(value: string | undefined): value is string {
+  if (!value) return false;
+  try {
+    const url = new URL(value);
+    return (
+      (url.protocol === "postgres:" || url.protocol === "postgresql:") &&
+      ["127.0.0.1", "localhost", "[::1]"].includes(url.hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function withSearchPath(databaseUrl: string, schema: string): string {
+  const url = new URL(databaseUrl);
+  url.searchParams.set("options", `-csearch_path=${schema}`);
+  return url.toString();
+}

--- a/packages/account/src/widget-auth/rate-limit.test.ts
+++ b/packages/account/src/widget-auth/rate-limit.test.ts
@@ -9,9 +9,8 @@ describe("shared widget auth rate limit", () => {
   });
 
   it("persists only a digest and uses the fixed window expiry", async () => {
-    const db = {
-      query: vi.fn().mockResolvedValue({ rows: [{ allowed: true }] }),
-    };
+    const client = mockClient([{ allowed: true }]);
+    const db = mockPool(client);
     vi.spyOn(Math, "random").mockReturnValue(1);
 
     await expect(
@@ -23,7 +22,13 @@ describe("shared widget auth rate limit", () => {
       }),
     ).resolves.toEqual({ allowed: true });
 
-    const parameters = db.query.mock.calls[0]?.[1] as unknown[];
+    expect(client.query.mock.calls.map(([statement]) => statement)).toEqual([
+      "begin isolation level read committed",
+      "select pg_advisory_xact_lock(hashtextextended($1, 0))",
+      expect.stringContaining("with current_count as materialized"),
+      "commit",
+    ]);
+    const parameters = client.query.mock.calls[2]?.[1] as unknown[];
     expect(parameters[0]).toMatch(/^aomi:widget:rate:[a-f0-9]{64}$/);
     expect(JSON.stringify(parameters)).not.toContain("partner.example");
     expect(JSON.stringify(parameters)).not.toContain("203.0.113.8");
@@ -31,7 +36,8 @@ describe("shared widget auth rate limit", () => {
   });
 
   it("fails closed when storage returns no counter result", async () => {
-    const db = { query: vi.fn().mockResolvedValue({ rows: [] }) };
+    const client = mockClient([]);
+    const db = mockPool(client);
     vi.spyOn(Math, "random").mockReturnValue(1);
     await expect(
       checkWidgetAuthRateLimit({
@@ -43,9 +49,8 @@ describe("shared widget auth rate limit", () => {
   });
 
   it("uses a fresh counter identifier after the fixed window expires", async () => {
-    const db = {
-      query: vi.fn().mockResolvedValue({ rows: [{ allowed: true }] }),
-    };
+    const client = mockClient([{ allowed: true }]);
+    const db = mockPool(client);
     vi.spyOn(Math, "random").mockReturnValue(1);
     const base = {
       origin: "https://partner.example",
@@ -62,19 +67,24 @@ describe("shared widget auth rate limit", () => {
       now: new Date("2026-09-02T12:01:00.000Z"),
     });
 
-    expect(db.query.mock.calls[0]?.[1]?.[0]).not.toBe(
-      db.query.mock.calls[1]?.[1]?.[0],
+    expect(client.query.mock.calls[2]?.[1]?.[0]).not.toBe(
+      client.query.mock.calls[6]?.[1]?.[0],
     );
   });
 
   it("observes but does not surface expiry cleanup failures", async () => {
     const failure = new Error("cleanup failed");
-    const db = {
+    const client = {
       query: vi
         .fn()
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] })
         .mockResolvedValueOnce({ rows: [{ allowed: true }] })
+        .mockResolvedValueOnce({ rows: [] })
         .mockRejectedValueOnce(failure),
+      release: vi.fn(),
     };
+    const db = mockPool(client);
     const observer = vi.fn();
     setAccountInternalFailureObserver(observer);
     vi.spyOn(Math, "random").mockReturnValue(0);
@@ -91,4 +101,46 @@ describe("shared widget auth rate limit", () => {
       error: failure,
     });
   });
+
+  it("rolls back and releases the checked-out client after a counter failure", async () => {
+    const failure = new Error("counter failed");
+    const client = mockClient([{ allowed: true }]);
+    client.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockRejectedValueOnce(failure)
+      .mockResolvedValueOnce({ rows: [] });
+    const db = mockPool(client);
+    vi.spyOn(Math, "random").mockReturnValue(1);
+
+    await expect(
+      checkWidgetAuthRateLimit({
+        origin: "https://partner.example",
+        clientAddress: "203.0.113.8",
+        db: db as never,
+      }),
+    ).rejects.toBe(failure);
+    expect(client.query.mock.calls.map(([statement]) => statement)).toEqual([
+      "begin isolation level read committed",
+      "select pg_advisory_xact_lock(hashtextextended($1, 0))",
+      expect.stringContaining("with current_count as materialized"),
+      "rollback",
+    ]);
+    expect(client.release).toHaveBeenCalledOnce();
+  });
 });
+
+function mockClient(rows: unknown[]) {
+  return {
+    query: vi.fn(async (statement: string, _parameters?: unknown[]) => ({
+      rows: statement.includes("with current_count as materialized")
+        ? rows
+        : [],
+    })),
+    release: vi.fn(),
+  };
+}
+
+function mockPool(client: ReturnType<typeof mockClient>) {
+  return { connect: vi.fn().mockResolvedValue(client) };
+}

--- a/packages/account/src/widget-auth/rate-limit.test.ts
+++ b/packages/account/src/widget-auth/rate-limit.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setAccountInternalFailureObserver } from "../observability";
+import { checkWidgetAuthRateLimit } from "./rate-limit";
+
+describe("shared widget auth rate limit", () => {
+  afterEach(() => {
+    setAccountInternalFailureObserver(undefined);
+    vi.restoreAllMocks();
+  });
+
+  it("persists only a digest and uses the fixed window expiry", async () => {
+    const db = {
+      query: vi.fn().mockResolvedValue({ rows: [{ allowed: true }] }),
+    };
+    vi.spyOn(Math, "random").mockReturnValue(1);
+
+    await expect(
+      checkWidgetAuthRateLimit({
+        origin: "https://partner.example",
+        clientAddress: "203.0.113.8",
+        now: new Date("2026-09-02T12:00:30.000Z"),
+        db: db as never,
+      }),
+    ).resolves.toEqual({ allowed: true });
+
+    const parameters = db.query.mock.calls[0]?.[1] as unknown[];
+    expect(parameters[0]).toMatch(/^aomi:widget:rate:[a-f0-9]{64}$/);
+    expect(JSON.stringify(parameters)).not.toContain("partner.example");
+    expect(JSON.stringify(parameters)).not.toContain("203.0.113.8");
+    expect(parameters[3]).toEqual(new Date("2026-09-02T12:01:00.000Z"));
+  });
+
+  it("fails closed when storage returns no counter result", async () => {
+    const db = { query: vi.fn().mockResolvedValue({ rows: [] }) };
+    vi.spyOn(Math, "random").mockReturnValue(1);
+    await expect(
+      checkWidgetAuthRateLimit({
+        origin: "https://partner.example",
+        clientAddress: "203.0.113.8",
+        db: db as never,
+      }),
+    ).resolves.toEqual({ allowed: false });
+  });
+
+  it("uses a fresh counter identifier after the fixed window expires", async () => {
+    const db = {
+      query: vi.fn().mockResolvedValue({ rows: [{ allowed: true }] }),
+    };
+    vi.spyOn(Math, "random").mockReturnValue(1);
+    const base = {
+      origin: "https://partner.example",
+      clientAddress: "203.0.113.8",
+      db: db as never,
+    };
+
+    await checkWidgetAuthRateLimit({
+      ...base,
+      now: new Date("2026-09-02T12:00:59.999Z"),
+    });
+    await checkWidgetAuthRateLimit({
+      ...base,
+      now: new Date("2026-09-02T12:01:00.000Z"),
+    });
+
+    expect(db.query.mock.calls[0]?.[1]?.[0]).not.toBe(
+      db.query.mock.calls[1]?.[1]?.[0],
+    );
+  });
+
+  it("observes but does not surface expiry cleanup failures", async () => {
+    const failure = new Error("cleanup failed");
+    const db = {
+      query: vi
+        .fn()
+        .mockResolvedValueOnce({ rows: [{ allowed: true }] })
+        .mockRejectedValueOnce(failure),
+    };
+    const observer = vi.fn();
+    setAccountInternalFailureObserver(observer);
+    vi.spyOn(Math, "random").mockReturnValue(0);
+
+    await expect(
+      checkWidgetAuthRateLimit({
+        origin: "https://partner.example",
+        clientAddress: "203.0.113.8",
+        db: db as never,
+      }),
+    ).resolves.toEqual({ allowed: true });
+    expect(observer).toHaveBeenCalledWith({
+      kind: "widget_rate_limit_sweep",
+      error: failure,
+    });
+  });
+});

--- a/packages/account/src/widget-auth/rate-limit.ts
+++ b/packages/account/src/widget-auth/rate-limit.ts
@@ -1,0 +1,82 @@
+import { createHash, randomUUID } from "node:crypto";
+import type { Pool, PoolClient, QueryResultRow } from "pg";
+import { getPool } from "../db/pool";
+import { observeAccountInternalFailure } from "../observability";
+
+const RATE_LIMIT_NAMESPACE = "aomi:widget:rate:";
+const EXPIRED_SWEEP_PROBABILITY = 0.02;
+
+type Db = Pool | PoolClient;
+type RateLimitRow = QueryResultRow & { allowed: boolean };
+
+/**
+ * Increment a shared fixed-window counter in Better Auth's verification store.
+ * The origin and address are hashed before persistence, and an advisory lock
+ * serializes concurrent increments without requiring a new table or migration.
+ */
+export async function checkWidgetAuthRateLimit(input: {
+  origin: string;
+  clientAddress: string;
+  now?: Date;
+  limit?: number;
+  windowMs?: number;
+  db?: Db;
+}): Promise<{ allowed: boolean }> {
+  const now = input.now ?? new Date();
+  const limit = input.limit ?? 60;
+  const windowMs = input.windowMs ?? 60_000;
+  if (!Number.isSafeInteger(limit) || limit < 1) {
+    throw new Error("Widget auth rate-limit size must be a positive integer");
+  }
+  if (!Number.isSafeInteger(windowMs) || windowMs < 1) {
+    throw new Error("Widget auth rate-limit window must be a positive integer");
+  }
+
+  const windowStart = Math.floor(now.getTime() / windowMs) * windowMs;
+  const expiresAt = new Date(windowStart + windowMs);
+  const digest = createHash("sha256")
+    .update(`${input.origin}\n${input.clientAddress}\n${windowStart}`)
+    .digest("hex");
+  const identifier = `${RATE_LIMIT_NAMESPACE}${digest}`;
+  const db = input.db ?? getPool();
+
+  const result = await db.query<RateLimitRow>(
+    `with lock as materialized (
+       select pg_advisory_xact_lock(hashtextextended($1, 0))
+     ), current_count as materialized (
+       select coalesce(max(
+         case when value ~ '^[0-9]+$' and length(value) <= 18
+              then value::bigint else $5::bigint end
+       ), 0)::bigint as count
+       from ba_verifications cross join lock
+       where identifier = $1 and expires_at > $2
+     ), removed as (
+       delete from ba_verifications where identifier = $1 returning 1
+     ), inserted as (
+       insert into ba_verifications
+         (id, identifier, value, expires_at, created_at, updated_at)
+       select $3, $1, (current_count.count + 1)::text, $4, now(), now()
+       from current_count
+       where (select count(*) from removed) >= 0
+       returning value::bigint as count
+     )
+     select count <= $5::bigint as allowed from inserted`,
+    [identifier, now, randomUUID(), expiresAt, limit],
+  );
+
+  await sweepExpiredRateLimits(db);
+  return { allowed: result.rows[0]?.allowed === true };
+}
+
+async function sweepExpiredRateLimits(db: Db): Promise<void> {
+  if (Math.random() >= EXPIRED_SWEEP_PROBABILITY) return;
+  try {
+    await db.query(
+      `delete from ba_verifications
+        where identifier like $1 and expires_at <= now()`,
+      [`${RATE_LIMIT_NAMESPACE}%`],
+    );
+  } catch (error) {
+    observeAccountInternalFailure({ kind: "widget_rate_limit_sweep", error });
+  }
+}

--- a/packages/account/src/widget-auth/rate-limit.ts
+++ b/packages/account/src/widget-auth/rate-limit.ts
@@ -6,7 +6,7 @@ import { observeAccountInternalFailure } from "../observability";
 const RATE_LIMIT_NAMESPACE = "aomi:widget:rate:";
 const EXPIRED_SWEEP_PROBABILITY = 0.02;
 
-type Db = Pool | PoolClient;
+type Queryable = Pick<PoolClient, "query">;
 type RateLimitRow = QueryResultRow & { allowed: boolean };
 
 /**
@@ -20,7 +20,7 @@ export async function checkWidgetAuthRateLimit(input: {
   now?: Date;
   limit?: number;
   windowMs?: number;
-  db?: Db;
+  db?: Pool;
 }): Promise<{ allowed: boolean }> {
   const now = input.now ?? new Date();
   const limit = input.limit ?? 60;
@@ -38,17 +38,26 @@ export async function checkWidgetAuthRateLimit(input: {
     .update(`${input.origin}\n${input.clientAddress}\n${windowStart}`)
     .digest("hex");
   const identifier = `${RATE_LIMIT_NAMESPACE}${digest}`;
-  const db = input.db ?? getPool();
-
-  const result = await db.query<RateLimitRow>(
-    `with lock as materialized (
-       select pg_advisory_xact_lock(hashtextextended($1, 0))
-     ), current_count as materialized (
+  const pool = input.db ?? getPool();
+  const client = await pool.connect();
+  let transactionOpen = false;
+  try {
+    await client.query("begin isolation level read committed");
+    transactionOpen = true;
+    // The lock must be acquired in a statement before the counter read. Under
+    // READ COMMITTED, a statement takes its snapshot before a lock CTE waits,
+    // which can otherwise lose concurrent increments after the wait ends.
+    await client.query(
+      "select pg_advisory_xact_lock(hashtextextended($1, 0))",
+      [identifier],
+    );
+    const result = await client.query<RateLimitRow>(
+      `with current_count as materialized (
        select coalesce(max(
          case when value ~ '^[0-9]+$' and length(value) <= 18
               then value::bigint else $5::bigint end
        ), 0)::bigint as count
-       from ba_verifications cross join lock
+       from ba_verifications
        where identifier = $1 and expires_at > $2
      ), removed as (
        delete from ba_verifications where identifier = $1 returning 1
@@ -61,14 +70,23 @@ export async function checkWidgetAuthRateLimit(input: {
        returning value::bigint as count
      )
      select count <= $5::bigint as allowed from inserted`,
-    [identifier, now, randomUUID(), expiresAt, limit],
-  );
-
-  await sweepExpiredRateLimits(db);
-  return { allowed: result.rows[0]?.allowed === true };
+      [identifier, now, randomUUID(), expiresAt, limit],
+    );
+    await client.query("commit");
+    transactionOpen = false;
+    await sweepExpiredRateLimits(client);
+    return { allowed: result.rows[0]?.allowed === true };
+  } catch (error) {
+    if (transactionOpen) {
+      await client.query("rollback").catch(() => undefined);
+    }
+    throw error;
+  } finally {
+    client.release();
+  }
 }
 
-async function sweepExpiredRateLimits(db: Db): Promise<void> {
+async function sweepExpiredRateLimits(db: Queryable): Promise<void> {
   if (Math.random() >= EXPIRED_SWEEP_PROBABILITY) return;
   try {
     await db.query(

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -132,13 +132,25 @@ function withSessionHeader(sessionId: string, init?: HeadersInit): HeadersInit {
 export function wrapFetchWithAccountBearer(
   fetchImpl: typeof fetch,
   getAccountBearer?: GetAccountBearer,
+  baseUrl?: string,
 ): typeof fetch {
   if (!getAccountBearer) return fetchImpl;
 
   return async (input, init) => {
     const request = input instanceof Request ? input : undefined;
-    const path = new URL(String(request?.url ?? input), "http://localhost")
-      .pathname;
+    const url = new URL(
+      String(request?.url ?? input),
+      baseUrl ? absoluteBase(baseUrl) : "http://localhost",
+    );
+    const path = url.pathname;
+    if (
+      (baseUrl && url.origin !== new URL(absoluteBase(baseUrl)).origin) ||
+      (!path.startsWith("/api/") &&
+        path !== "/v1/account" &&
+        !path.startsWith("/v1/account/"))
+    ) {
+      return fetchImpl(request ? request.clone() : input, init);
+    }
     if (path.startsWith("/v1/agent/") || path.startsWith("/v1/pipeline/")) {
       return fetchImpl(request ? request.clone() : input, init);
     }
@@ -174,15 +186,21 @@ export function wrapFetchWithPublicApiAuthorization(input: {
   fetch: typeof fetch;
   baseUrl: string;
   oauth?: AomiOAuthTokenProvider;
+  getAccountBearer?: GetAccountBearer;
   guest?: GuestSessionProvider;
 }): typeof fetch {
-  if (!input.oauth && !input.guest) return input.fetch;
+  if (!input.oauth && !input.getAccountBearer && !input.guest) {
+    return input.fetch;
+  }
   return async (requestInput, init) => {
     const request = requestInput instanceof Request ? requestInput : undefined;
     const url = new URL(
       String(request?.url ?? requestInput),
       absoluteBase(input.baseUrl),
     );
+    if (url.origin !== new URL(absoluteBase(input.baseUrl)).origin) {
+      return input.fetch(requestInput, init);
+    }
     const policy = publicApiPolicy(
       url,
       init?.method ?? request?.method ?? "GET",
@@ -190,37 +208,63 @@ export function wrapFetchWithPublicApiAuthorization(input: {
     );
     if (!policy) return input.fetch(requestInput, init);
     const baseHeaders = new Headers(init?.headers ?? request?.headers);
+    let selectedSource: "oauth" | "account" | "guest" | undefined;
     const attempt = async (forceRefresh: boolean, dpopNonce?: string) => {
       const headers = new Headers(baseHeaders);
-      if (input.oauth) {
+      if (input.oauth && (!selectedSource || selectedSource === "oauth")) {
         const token = await input.oauth({
           resource: policy.resource,
           scopes: policy.scopes,
           forceRefresh,
         });
-        if (!token)
+        if (!token && selectedSource === "oauth") {
           throw new Error(
             "No OAuth grant covers this Aomi resource and scope set",
           );
-        const tokenType = token.tokenType ?? "Bearer";
-        headers.set("authorization", `${tokenType} ${token.accessToken}`);
-        if (tokenType === "DPoP") {
-          if (!token.dpopProof) {
-            throw new Error("DPoP token provider returned no proof signer");
-          }
-          headers.set(
-            "dpop",
-            await token.dpopProof({
-              url: url.toString(),
-              method: policy.method,
-              accessToken: token.accessToken,
-              nonce: dpopNonce,
-            }),
-          );
         }
-      } else if (input.guest) {
+        if (token) {
+          selectedSource = "oauth";
+          const tokenType = token.tokenType ?? "Bearer";
+          headers.set("authorization", `${tokenType} ${token.accessToken}`);
+          if (tokenType === "DPoP") {
+            if (!token.dpopProof) {
+              throw new Error("DPoP token provider returned no proof signer");
+            }
+            headers.set(
+              "dpop",
+              await token.dpopProof({
+                url: url.toString(),
+                method: policy.method,
+                accessToken: token.accessToken,
+                nonce: dpopNonce,
+              }),
+            );
+          }
+        }
+      }
+      if (
+        input.getAccountBearer &&
+        (!selectedSource || selectedSource === "account")
+      ) {
+        let credential: string | null | undefined;
+        try {
+          credential = await input.getAccountBearer({ forceRefresh });
+        } catch (error) {
+          if (input.getAccountBearer.required) throw error;
+        }
+        if (credential) {
+          selectedSource = "account";
+          headers.set("authorization", `Bearer ${credential}`);
+        } else if (input.getAccountBearer.required) {
+          throw new Error("Required account bearer is unavailable");
+        }
+      }
+      if (input.guest && (!selectedSource || selectedSource === "guest")) {
         const credential = await input.guest({ forceRefresh });
-        if (credential) headers.set("authorization", `Bearer ${credential}`);
+        if (credential) {
+          selectedSource = "guest";
+          headers.set("authorization", `Bearer ${credential}`);
+        }
       }
       return input.fetch(request ? request.clone() : requestInput, {
         ...init,
@@ -229,7 +273,7 @@ export function wrapFetchWithPublicApiAuthorization(input: {
     };
     const response = await attempt(false);
     if (response.status !== 401 && response.status !== 403) return response;
-    if (input.guest && response.status === 403) return response;
+    if (selectedSource === "guest" && response.status === 403) return response;
     const dpopNonce = response.headers.get("dpop-nonce") ?? undefined;
     return attempt(!dpopNonce, dpopNonce);
   };
@@ -316,7 +360,7 @@ export class AomiClient {
     const guest =
       options.oauth ||
       options.guest === false ||
-      (options.getAccountBearer && options.guest === undefined)
+      options.getAccountBearer?.required === true
         ? undefined
         : typeof options.guest === "function"
           ? options.guest
@@ -329,18 +373,22 @@ export class AomiClient {
         fetch: fetchImpl,
         baseUrl: this.baseUrl,
         oauth: options.oauth,
+        getAccountBearer: options.getAccountBearer,
         guest,
       }),
       options.getAccountBearer,
+      this.baseUrl,
     );
     this.rawFetchImpl = wrapFetchWithAccountBearer(
       wrapFetchWithPublicApiAuthorization({
         fetch: rawFetchImpl,
         baseUrl: this.baseUrl,
         oauth: options.oauth,
+        getAccountBearer: options.getAccountBearer,
         guest,
       }),
       options.getAccountBearer,
+      this.baseUrl,
     );
     this.logger = options.logger;
     this.agent = new AgentTransport((method, path, requestOptions) =>

--- a/packages/client/test/client.fetch-wrapper.unit.test.ts
+++ b/packages/client/test/client.fetch-wrapper.unit.test.ts
@@ -108,6 +108,22 @@ describe("wrapFetchWithAccountBearer", () => {
     expect(headers.has("authorization")).toBe(false);
   });
 
+  it("never sends an account bearer outside the configured Aomi origin", async () => {
+    const fetchMock = vi.fn(async () => new Response("{}", { status: 200 }));
+    const getBearer = bearerSource("account-token");
+    const wrapped = wrapFetchWithAccountBearer(
+      fetchMock as unknown as typeof fetch,
+      getBearer,
+      "https://chat.aomi.dev",
+    );
+
+    await wrapped("https://attacker.invalid/api/account");
+
+    expect(getBearer).not.toHaveBeenCalled();
+    const headers = new Headers(fetchMock.mock.calls[0]?.[1]?.headers);
+    expect(headers.has("authorization")).toBe(false);
+  });
+
   it("simulateBatch delivers its JSON body through the wrapped fetch", async () => {
     const fetchMock = vi.fn(
       async () =>

--- a/packages/client/test/oauth-auth.unit.test.ts
+++ b/packages/client/test/oauth-auth.unit.test.ts
@@ -76,10 +76,12 @@ describe("public API OAuth transport", () => {
 
   it("keeps one client identity per request while switching later polls from guest to account", async () => {
     const seen: Array<string | null> = [];
-    const upstream = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
-      seen.push(new Headers(init?.headers).get("authorization"));
-      return new Response("{}", { status: 200 });
-    });
+    const upstream = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        seen.push(new Headers(init?.headers).get("authorization"));
+        return new Response("{}", { status: 200 });
+      },
+    );
     let accountToken: string | undefined;
     const getAccountBearer = vi.fn(async () => accountToken);
     const guest = vi.fn(async () => "guest-token");

--- a/packages/client/test/oauth-auth.unit.test.ts
+++ b/packages/client/test/oauth-auth.unit.test.ts
@@ -3,10 +3,124 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { wrapFetchWithPublicApiAuthorization } from "../src/client";
 import { createGuestSessionProvider } from "../src/guest-auth";
 import type { AomiOAuthTokenRequest } from "../src/authorization";
+import type { GetAccountBearer } from "../src/types";
 
 afterEach(() => vi.unstubAllGlobals());
 
 describe("public API OAuth transport", () => {
+  it("uses an account widget-session bearer for Agent routes when OAuth is absent", async () => {
+    const upstream = vi.fn(async () => new Response("{}", { status: 200 }));
+    const getAccountBearer = vi.fn(
+      async () => "aomi_wst_account",
+    ) as ReturnType<typeof vi.fn> & GetAccountBearer;
+    const authorized = wrapFetchWithPublicApiAuthorization({
+      fetch: upstream as typeof fetch,
+      baseUrl: "https://chat.aomi.dev",
+      getAccountBearer,
+    });
+
+    await authorized("https://chat.aomi.dev/v1/agent/sessions");
+
+    expect(getAccountBearer).toHaveBeenCalledWith({ forceRefresh: false });
+    expect(
+      new Headers(upstream.mock.calls[0]?.[1]?.headers).get("authorization"),
+    ).toBe("Bearer aomi_wst_account");
+  });
+
+  it("keeps OAuth ahead of account and guest authentication", async () => {
+    const upstream = vi.fn(async () => new Response("{}", { status: 200 }));
+    const oauth = vi.fn(async (request: AomiOAuthTokenRequest) => ({
+      accessToken: "oauth-token",
+      expiresAt: Date.now() + 60_000,
+      resource: request.resource,
+      scopes: request.scopes,
+    }));
+    const getAccountBearer = vi.fn(async () => "account-token");
+    const guest = vi.fn(async () => "guest-token");
+    const authorized = wrapFetchWithPublicApiAuthorization({
+      fetch: upstream as typeof fetch,
+      baseUrl: "https://chat.aomi.dev",
+      oauth,
+      getAccountBearer,
+      guest,
+    });
+
+    await authorized("https://chat.aomi.dev/v1/pipeline/tools");
+
+    expect(getAccountBearer).not.toHaveBeenCalled();
+    expect(guest).not.toHaveBeenCalled();
+    expect(
+      new Headers(upstream.mock.calls[0]?.[1]?.headers).get("authorization"),
+    ).toBe("Bearer oauth-token");
+  });
+
+  it("does not fall back to a guest identity when the account bearer is required", async () => {
+    const getAccountBearer = vi.fn(async () => null) as ReturnType<
+      typeof vi.fn
+    > &
+      GetAccountBearer;
+    getAccountBearer.required = true;
+    const guest = vi.fn(async () => "guest-token");
+    const authorized = wrapFetchWithPublicApiAuthorization({
+      fetch: vi.fn() as unknown as typeof fetch,
+      baseUrl: "https://chat.aomi.dev",
+      getAccountBearer,
+      guest,
+    });
+
+    await expect(
+      authorized("https://chat.aomi.dev/v1/agent/sessions"),
+    ).rejects.toThrow("Required account bearer is unavailable");
+    expect(guest).not.toHaveBeenCalled();
+  });
+
+  it("keeps one client identity per request while switching later polls from guest to account", async () => {
+    const seen: Array<string | null> = [];
+    const upstream = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seen.push(new Headers(init?.headers).get("authorization"));
+      return new Response("{}", { status: 200 });
+    });
+    let accountToken: string | undefined;
+    const getAccountBearer = vi.fn(async () => accountToken);
+    const guest = vi.fn(async () => "guest-token");
+    const authorized = wrapFetchWithPublicApiAuthorization({
+      fetch: upstream as typeof fetch,
+      baseUrl: "https://chat.aomi.dev",
+      getAccountBearer,
+      guest,
+    });
+
+    await authorized("https://chat.aomi.dev/v1/agent/chat/thread-1", {
+      method: "GET",
+    });
+    accountToken = "aomi_wst_authenticated";
+    await authorized("https://chat.aomi.dev/v1/agent/chat/thread-1", {
+      method: "GET",
+    });
+
+    expect(seen).toEqual([
+      "Bearer guest-token",
+      "Bearer aomi_wst_authenticated",
+    ]);
+  });
+
+  it("never sends Aomi credentials to another origin", async () => {
+    const upstream = vi.fn(async () => new Response("{}", { status: 200 }));
+    const getAccountBearer = vi.fn(async () => "account-token");
+    const authorized = wrapFetchWithPublicApiAuthorization({
+      fetch: upstream as typeof fetch,
+      baseUrl: "https://chat.aomi.dev",
+      getAccountBearer,
+    });
+
+    await authorized("https://attacker.example/v1/agent/sessions");
+
+    expect(getAccountBearer).not.toHaveBeenCalled();
+    expect(
+      new Headers(upstream.mock.calls[0]?.[1]?.headers).has("authorization"),
+    ).toBe(false);
+  });
+
   it("requests the exact Agent resource and route scope", async () => {
     const upstream = vi.fn(
       async (_input: RequestInfo | URL, init?: RequestInit) => {
@@ -231,17 +345,15 @@ describe("Better Auth guest bootstrap", () => {
 
   it("falls back to the anonymous cookie when Better Auth refuses a second anonymous sign-in", async () => {
     vi.stubGlobal("location", { origin: "https://chat.aomi.dev" });
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValue(
-        Response.json(
-          {
-            code: "ANONYMOUS_USERS_CANNOT_SIGN_IN_AGAIN_ANONYMOUSLY",
-            message: "Anonymous users cannot sign in again anonymously",
-          },
-          { status: 400 },
-        ),
-      );
+    const fetchImpl = vi.fn().mockResolvedValue(
+      Response.json(
+        {
+          code: "ANONYMOUS_USERS_CANNOT_SIGN_IN_AGAIN_ANONYMOUSLY",
+          message: "Anonymous users cannot sign in again anonymously",
+        },
+        { status: 400 },
+      ),
+    );
     const guest = createGuestSessionProvider({
       baseUrl: "https://chat.aomi.dev",
       fetch: fetchImpl as typeof fetch,


### PR DESCRIPTION
## Summary
- consolidate Agent and Pipeline public API auth with OAuth, account/WST, then guest precedence
- add managed CORS and OPTIONS handling without credentialed cookies
- replace the spoofable in-memory widget limiter with shared expiring verification-storage counters
- preserve widget thread, draft, and stream state when anonymous auth becomes account auth

## Verification
- Portal: 510 passed, including real disposable-PostgreSQL loopback and Agent/Pipeline device flows
- Account: 158 passed, including identity lifecycle cascade
- Client: 299 passed, 1 pre-existing contract skip
- client, React, and widget builds pass
- client, account, and Portal typechecks pass
- touched lint, formatting, package dry runs, and diff checks pass

## Stack
Base PR: #563

Staging E2E and release publication remain explicit post-CI gates.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/564"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790950401&installation_model_id=12362&pr_number=564&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F564&signature=0f8bf82f836e81d4f5cf9b9d57f75ed3bc646a7d80f80e2c2ae6376cb9d11dc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->