### PR TITLE
fix(oauth): submit signed consent request

### DIFF
--- a/apps/portal/src/app/oauth/consent/oauth-consent-client.test.tsx
+++ b/apps/portal/src/app/oauth/consent/oauth-consent-client.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  search:
+    "client_id=codex-mcp&scope=agent%3Aread+mcp%3Aagent&resource=https%3A%2F%2Fchat-staging.aomi.dev%2Fv1%2Fagent%2Fmcp&exp=4102444800&sig=signed-request",
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(mocks.search),
+}));
+
+import { OAuthConsentClient } from "./oauth-consent-client";
+
+describe("OAuthConsentClient", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(Response.json({}, { status: 400 })),
+    );
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("submits Better Auth's signed query instead of requiring a nonexistent consent code", async () => {
+    render(<OAuthConsentClient />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Authorize" }));
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledOnce());
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/auth/oauth2/consent",
+      expect.objectContaining({
+        body: JSON.stringify({
+          accept: true,
+          oauth_query: mocks.search,
+          scope: "agent:read mcp:agent",
+        }),
+      }),
+    );
+    expect(
+      screen.queryByText("This authorization request is incomplete."),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/portal/src/app/oauth/consent/oauth-consent-client.tsx
+++ b/apps/portal/src/app/oauth/consent/oauth-consent-client.tsx
@@ -21,7 +21,10 @@ const DESCRIPTIONS: Record<string, string> = {
 
 export function OAuthConsentClient() {
   const params = useSearchParams();
-  const code = params.get("code") ?? params.get("consent_code");
+  // Better Auth redirects to the consent page with the complete signed OAuth
+  // request in its query string. The consent endpoint validates this value
+  // before it reads any user-selected fields.
+  const oauthQuery = params.toString();
   const scopes = useMemo(
     () =>
       consentScopes((params.get("scope") ?? "").split(/\s+/).filter(Boolean)),
@@ -32,7 +35,9 @@ export function OAuthConsentClient() {
 
   const decide = useCallback(
     async (accept: boolean) => {
-      if (!code) return setStatus("This authorization request is incomplete.");
+      if (!oauthQuery) {
+        return setStatus("This authorization request is incomplete.");
+      }
       setPending(true);
       const response = await fetch("/api/auth/oauth2/consent", {
         method: "POST",
@@ -40,8 +45,7 @@ export function OAuthConsentClient() {
         credentials: "include",
         body: JSON.stringify({
           accept,
-          code,
-          consent_code: code,
+          oauth_query: oauthQuery,
           // The signed request has already passed the canonical server policy.
           // Echo it unchanged; the route validates it again before minting.
           scope: scopes.join(" "),
@@ -57,7 +61,7 @@ export function OAuthConsentClient() {
       }
       window.location.assign(redirect);
     },
-    [code, scopes],
+    [oauthQuery, scopes],
   );
 
   return (


### PR DESCRIPTION
Fixes the consent page handoff used by Better Auth OAuth provider.

Better Auth redirects to the configured consent page with the full signed authorization query in the URL; it does not issue a `code` or `consent_code` query parameter. The page therefore rejected every real MCP request before calling the consent endpoint.

This sends that signed query unchanged as `oauth_query`, which Better Auth verifies server-side, and adds a UI regression test.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/565"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790971762&installation_model_id=12362&pr_number=565&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F565&signature=44bb3a25db3f983b550eedefe5ee9a38c22a4a9d5159ef342c948ae3a94e4aed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->