### PR TITLE
fix(oauth): complete the Codex consent flow

### DIFF
--- a/apps/portal/src/app/.well-known/oauth-authorization-server/api/auth/route.test.ts
+++ b/apps/portal/src/app/.well-known/oauth-authorization-server/api/auth/route.test.ts
@@ -17,7 +17,10 @@ import { GET } from "./route";
 describe("path-scoped OAuth authorization-server discovery", () => {
   it("serves metadata for the /api/auth issuer", async () => {
     mocks.metadata.mockResolvedValue(
-      Response.json({ issuer: "https://chat.aomi.dev/api/auth" }),
+      Response.json({
+        issuer: "https://chat.aomi.dev/api/auth",
+        authorization_response_iss_parameter_supported: true,
+      }),
     );
     const request = new Request(
       "https://chat.aomi.dev/.well-known/oauth-authorization-server/api/auth",
@@ -28,6 +31,7 @@ describe("path-scoped OAuth authorization-server discovery", () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({
       issuer: "https://chat.aomi.dev/api/auth",
+      authorization_response_iss_parameter_supported: false,
     });
     expect(mocks.metadata).toHaveBeenCalledWith(request);
   });

--- a/apps/portal/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/apps/portal/src/app/.well-known/oauth-authorization-server/route.ts
@@ -11,7 +11,9 @@ const metadata = oauthProviderAuthServerMetadata(
 );
 
 export async function GET(request: Request) {
-  return publicDiscoveryResponse(await metadata(request));
+  return publicDiscoveryResponse(
+    await codexCompatibleMetadata(await metadata(request)),
+  );
 }
 
 export async function HEAD(request: Request) {
@@ -24,4 +26,26 @@ export async function HEAD(request: Request) {
 
 export function OPTIONS() {
   return publicDiscoveryResponse(new Response(null, { status: 204 }));
+}
+
+async function codexCompatibleMetadata(response: Response): Promise<Response> {
+  const body = (await response
+    .clone()
+    .json()
+    .catch(() => null)) as Record<string, unknown> | null;
+  if (body?.authorization_response_iss_parameter_supported !== true) {
+    return response;
+  }
+
+  // Codex CLI 0.144 discards the RFC 9207 `iss` callback parameter but then
+  // requires it when this capability is advertised. Keep emitting `iss` on
+  // authorization responses; temporarily advertise it as optional so Codex
+  // can finish the PKCE flow. Remove this compatibility path once Codex
+  // forwards the callback issuer to its OAuth client.
+  const headers = new Headers(response.headers);
+  headers.delete("content-length");
+  return Response.json(
+    { ...body, authorization_response_iss_parameter_supported: false },
+    { status: response.status, statusText: response.statusText, headers },
+  );
 }

--- a/apps/portal/src/app/oauth/consent/oauth-consent-client.test.tsx
+++ b/apps/portal/src/app/oauth/consent/oauth-consent-client.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  search:
+    "client_id=codex-mcp&scope=agent%3Aread+mcp%3Aagent&resource=https%3A%2F%2Fchat-staging.aomi.dev%2Fv1%2Fagent%2Fmcp&exp=4102444800&sig=signed-request",
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(mocks.search),
+}));
+
+import { OAuthConsentClient } from "./oauth-consent-client";
+
+describe("OAuthConsentClient", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(Response.json({}, { status: 400 })),
+    );
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("submits Better Auth's signed query instead of requiring a nonexistent consent code", async () => {
+    render(<OAuthConsentClient />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Authorize" }));
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledOnce());
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/auth/oauth2/consent",
+      expect.objectContaining({
+        body: JSON.stringify({
+          accept: true,
+          oauth_query: mocks.search,
+          scope: "agent:read mcp:agent",
+        }),
+      }),
+    );
+    expect(
+      screen.queryByText("This authorization request is incomplete."),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/portal/src/app/oauth/consent/oauth-consent-client.tsx
+++ b/apps/portal/src/app/oauth/consent/oauth-consent-client.tsx
@@ -22,7 +22,10 @@ const DESCRIPTIONS: Record<string, string> = {
 export function OAuthConsentClient() {
   const params = useSearchParams();
   const { data: session } = authClient.useSession();
-  const code = params.get("code") ?? params.get("consent_code");
+  // Better Auth redirects to the consent page with the complete signed OAuth
+  // request in its query string. The consent endpoint validates this value
+  // before it reads any user-selected fields.
+  const oauthQuery = params.toString();
   const scopes = useMemo(
     () => (params.get("scope") ?? "").split(/\s+/).filter(Boolean),
     [params],
@@ -44,7 +47,9 @@ export function OAuthConsentClient() {
 
   const decide = useCallback(
     async (accept: boolean) => {
-      if (!code) return setStatus("This authorization request is incomplete.");
+      if (!oauthQuery) {
+        return setStatus("This authorization request is incomplete.");
+      }
       setPending(true);
       const response = await fetch("/api/auth/oauth2/consent", {
         method: "POST",
@@ -52,8 +57,9 @@ export function OAuthConsentClient() {
         credentials: "include",
         body: JSON.stringify({
           accept,
-          code,
-          consent_code: code,
+          oauth_query: oauthQuery,
+          // The signed request has already passed the canonical server policy.
+          // Echo it unchanged; the route validates it again before minting.
           scope: acceptedScopes.join(" "),
         }),
       });
@@ -67,7 +73,7 @@ export function OAuthConsentClient() {
       }
       window.location.assign(redirect);
     },
-    [acceptedScopes, code],
+    [acceptedScopes, oauthQuery],
   );
 
   return (


### PR DESCRIPTION
Completes the minimum Codex MCP OAuth path on top of #561.

- Submit Better Auth's signed OAuth query from the consent page rather than requiring a nonexistent code field.
- Temporarily advertise RFC 9207 issuer handling as optional: Codex CLI 0.144 drops `iss` from its local callback before passing it to its OAuth library, despite requiring it when the server advertises the capability. The authorization response continues to carry `iss`; remove this compatibility declaration once Codex forwards it.

Verification:
- OAuth consent component test
- authorization-server metadata route test
- Prettier and git diff checks