### PR TITLE
fix(oauth): allow resource-bound token refresh

### DIFF
--- a/apps/portal/src/server/oauth/request-policy.test.ts
+++ b/apps/portal/src/server/oauth/request-policy.test.ts
@@ -78,6 +78,18 @@ describe("OAuth request policy", () => {
     );
   });
 
+  it("allows a resource-bound refresh without repeating resource", async () => {
+    await expectContinue(
+      enforceAomiOAuthRequestPolicy(
+        new Request("https://portal.example/api/auth/oauth2/token", {
+          method: "POST",
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+          body: "grant_type=refresh_token&refresh_token=opaque-refresh-token",
+        }),
+      ),
+    );
+  });
+
   it("limits unauthenticated DCR to an exact MCP resource", async () => {
     const register = (resource: string) =>
       enforceAomiOAuthRequestPolicy(

--- a/apps/portal/src/server/oauth/request-policy.ts
+++ b/apps/portal/src/server/oauth/request-policy.ts
@@ -74,6 +74,17 @@ export async function enforceAomiOAuthRequestPolicy(
       ["openid", "profile", "email", "offline_access"].includes(scope),
     );
 
+  // A refresh grant inherits the resource that was bound when it was issued.
+  // Codex follows RFC 8707 and does not repeat `resource` on refresh, so let
+  // Better Auth resolve that stored binding instead of rejecting the request.
+  if (
+    isToken &&
+    values.get("grant_type") === "refresh_token" &&
+    resources.length === 0
+  ) {
+    return proceed(request);
+  }
+
   // OIDC-only authorization is a separate use case. Token callers make that
   // intent explicit with scope so an omitted Aomi resource cannot be confused
   // with an identity-only exchange.


### PR DESCRIPTION
Codex completes the authorization-code flow, then refreshes its MCP token without repeating RFC 8707 `resource`. The request policy currently rejects that standards-compliant refresh before Better Auth can resolve the refresh grant's stored resource binding.

Allow only a `refresh_token` grant with no resource indicator; all initial Aomi grants remain exact-resource-bound.

Verification:
- `pnpm exec vitest run apps/portal/src/server/oauth/request-policy.test.ts` (21 passed)
- `pnpm exec prettier --check apps/portal/src/server/oauth/request-policy.ts apps/portal/src/server/oauth/request-policy.test.ts`

After merge, stage this exact commit and prove Codex `tools/list` succeeds.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/567"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790975952&installation_model_id=12362&pr_number=567&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F567&signature=6aea290e424130e857cbf91e7ac78def594eed7fc6e9aaad0bdb90494e4b1909"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->