### PR TITLE
docs: explain Builder Console environments and platforms

### DIFF
--- a/apps/landing/content/guides/build/console.mdx
+++ b/apps/landing/content/guides/build/console.mdx
@@ -1,0 +1,90 @@
+---
+title: Builder Console
+description: Manage Aomi projects, platforms, deployments, and environments in Aomi Build.
+---
+
+# Builder Console
+
+[Aomi Build](https://build.aomi.dev) is the control plane for builders. Use it
+to connect a GitHub repository, deploy its Aomi Apps, configure runtime
+environment values, and monitor deployments.
+
+## Choose the right environment
+
+Use staging while testing a repository or a deployment workflow, and use
+production for the live application:
+
+| Environment | Builder console                                          | Backend API                    | Purpose                      |
+| ----------- | -------------------------------------------------------- | ------------------------------ | ---------------------------- |
+| Staging     | [build-staging.aomi.dev](https://build-staging.aomi.dev) | `https://api-staging.aomi.dev` | Test changes and deployments |
+| Production  | [build.aomi.dev](https://build.aomi.dev)                 | `https://api.aomi.dev`         | Live applications            |
+
+Staging and production use separate project registries, applications,
+deployments, credentials, and runtime data. A repository can therefore have a
+separate Project in each environment. A Project created in staging does not
+make an application available in production; deploy the intended commit to
+the intended environment separately.
+
+## Projects and platforms
+
+A **Project** is a GitHub repository connected to Aomi. Each Project is owned
+by one builder and is bound to one deployment platform within that environment.
+The platform determines the platform repository and deployment destination for
+the Project.
+
+**Community** is the default platform for projects that are not associated
+with a partner deployment. Partner platforms use their exact platform name,
+such as `world-market-apps`.
+
+The platform switcher changes which platform's Projects page you are viewing.
+It does not move, copy, or rebind a Project. Once a repository has been
+connected, project-scoped deployment and detail requests use the platform
+stored on that Project.
+
+## Import a repository
+
+1. Sign in to Build with the GitHub account that owns or administers the
+   repository.
+2. Select the exact platform you want to use in the platform switcher. If you
+   are building an unscoped application, use `community`.
+3. Open **New app** and connect the repository.
+4. Complete the deploy flow and configure any required values in the
+   Project's **Environment** tab before activation.
+
+The platform is selected when the Project is created. Changing the platform
+selector later only changes the page filter; it does not change the Project's
+binding.
+
+## When a repository is already connected
+
+If Build says that a repository is already connected but the current Projects
+page is empty, check the selected platform first. This usually means:
+
+```text
+Current page: community
+Existing Project: world-market-apps
+Result: the community list is empty, but importing the same repository reports
+        that it is already connected
+```
+
+Switch to the exact platform named by the existing Project and open that
+Project. Do not create a duplicate Project or assume that changing
+`.aomi/config.json` alone will rebind it. If the repository must move to a
+different platform, ask the platform operator to perform the supported
+rebind/ownership procedure after checking its existing applications and
+deployment history.
+
+## Deployment model
+
+Project creation and deployment are separate steps:
+
+1. Build validates the repository's `.aomi/config.json` and application
+   manifests.
+2. A preflight resolves an immutable source commit.
+3. Deployment builds the listed applications in the selected platform's
+   pipeline.
+4. Activation loads the resulting release into the runtime for that
+   environment.
+
+For a deployment troubleshooting checklist, see [How It Works](/docs/build/how-it-works).
+For the SDK and application structure, see [Getting Started](/docs/build/getting-started).

--- a/apps/landing/content/guides/build/meta.json
+++ b/apps/landing/content/guides/build/meta.json
@@ -2,6 +2,7 @@
   "title": "Build with Aomi",
   "pages": [
     "overview",
+    "console",
     "cli",
     "frontend-setup",
     "widget-installation",

--- a/apps/landing/content/guides/build/overview.mdx
+++ b/apps/landing/content/guides/build/overview.mdx
@@ -91,6 +91,7 @@ The widget is built on top of the headless library. Installing the widget pulls 
 
 ## Next Steps
 
+- [Builder Console](/docs/build/console) — choose an environment, switch platforms, and manage connected Projects.
 - [Getting Started](/docs/build/getting-started) — set up your first Aomi App.
 - [How It Works](/docs/build/how-it-works) — technical deep dive into the platform pipeline.
 - [Widget Installation](/docs/build/ui/widget/aomi-frame) — install the full UI.


### PR DESCRIPTION
## Summary

- add a public Builder Console guide under `/docs/build/console`
- document staging vs production URLs and isolated project/deployment state
- explain platform switching, Community vs partner platforms, and already-connected repository troubleshooting
- link the guide from the Build docs navigation and overview

## Verification

- `pnpm exec prettier --check apps/landing/content/guides/build/console.mdx apps/landing/content/guides/build/meta.json apps/landing/content/guides/build/overview.mdx`
- `pnpm --filter landing build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791128589&installation_model_id=12362&pr_number=572&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F572&signature=857c79c759642238e42882264c363ebadcdcd317fafa2d73987dd107b2b952a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->