### PR TITLE
feat(control-bar): add Cambrian, vaults.fyi, and Morpho Vaults app metadata

### DIFF
--- a/apps/shadcn-registry/src/components/control-bar/app-metadata.ts
+++ b/apps/shadcn-registry/src/components/control-bar/app-metadata.ts
@@ -65,6 +65,11 @@ const APP_DISPLAY_NAMES: Record<string, Omit<AppInfo, "id">> = {
     abbr: "B",
     category: APP_CATEGORIES.cex,
   },
+  cambrian: {
+    displayName: "Cambrian",
+    abbr: "Ca",
+    category: APP_CATEGORIES.analytics,
+  },
   cow: {
     displayName: "CoW Protocol",
     abbr: "CoW",
@@ -135,6 +140,11 @@ const APP_DISPLAY_NAMES: Record<string, Omit<AppInfo, "id">> = {
     abbr: "M",
     category: APP_CATEGORIES.yield,
   },
+  "morpho-vaults": {
+    displayName: "Morpho Vaults",
+    abbr: "MV",
+    category: APP_CATEGORIES.yield,
+  },
   neynar: {
     displayName: "Neynar",
     abbr: "N",
@@ -180,6 +190,11 @@ const APP_DISPLAY_NAMES: Record<string, Omit<AppInfo, "id">> = {
     abbr: "PR",
     category: APP_CATEGORIES.prediction,
   },
+  vaultsfyi: {
+    displayName: "vaults.fyi",
+    abbr: "VF",
+    category: APP_CATEGORIES.yield,
+  },
   x: {
     displayName: "X",
     abbr: "X",
@@ -212,6 +227,9 @@ const APP_ALIASES: Record<string, string> = {
   "para-customer": "para",
   para_consumer: "para-consumer",
   polymarket_rewards: "polymarket-rewards",
+  morpho_vaults: "morpho-vaults",
+  "vaults.fyi": "vaultsfyi",
+  "vaults-fyi": "vaultsfyi",
   twitter: "x",
 };
 


### PR DESCRIPTION
Three official apps shipped in aomi-sdk `apps-v0.1.40` (backend lock: aomi-labs/product-mono#1042). Without metadata the picker shows them under **Other** as titleized ids.

- `cambrian` → Analytics, "Cambrian"
- `vaultsfyi` → Lending & Yield, "vaults.fyi" (aliases `vaults.fyi`, `vaults-fyi`)
- `morpho-vaults` → Lending & Yield, "Morpho Vaults" (alias `morpho_vaults`)

`app-metadata.test.ts` passes (5/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791275117&installation_model_id=12362&pr_number=574&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F574&signature=67eab515e847f6cd5416acc888cb99a3e14aded4742527846e2e60cf59a2318a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->