### PR TITLE
test(client): record handover revoke as activation-or-wallet

### DIFF
--- a/packages/client/test/fixtures/backend-openapi.json
+++ b/packages/client/test/fixtures/backend-openapi.json
@@ -3319,7 +3319,7 @@
         },
         "security": [],
         "x-aomi-auth": [
-          "activation"
+          "activation-or-wallet"
         ]
       }
     },

--- a/packages/client/test/fixtures/manager-openapi.json
+++ b/packages/client/test/fixtures/manager-openapi.json
@@ -807,7 +807,7 @@
         },
         "security": [],
         "x-aomi-auth": [
-          "activation"
+          "activation-or-wallet"
         ]
       }
     },

--- a/packages/client/test/generated/backend-routes.ts
+++ b/packages/client/test/generated/backend-routes.ts
@@ -831,7 +831,7 @@ export const AOMI_BACKEND_ENDPOINTS = [
   {
     method: "POST",
     path: "/api/platforms/{name}/telegram/handover/{bot}/{id}/revoke",
-    auth: ["activation"],
+    auth: ["activation-or-wallet"],
   },
   {
     method: "POST",


### PR DESCRIPTION
## Why

Companion to [aomi-labs/product-mono#1049](https://github.com/aomi-labs/product-mono/pull/1049), which lets a wallet owner revoke its own handover. `revoke` joins issue and activate on the dual-credential route set, so the route contract has to say so.

Test-only, so there is no runtime ordering constraint between the two — this can merge before or after.

## What

One label, three files: the manager fixture, the merged fixture that mirrors it, and the generated route list.

**Deliberately not regenerated.** Running `npm run update:backend-openapi` against current main also rewrites every path from `{name}` to `:name` and churns ~900 lines of unrelated backend routes — main's checked-in fixture and main's own generator disagree on path style. Paying that down is worth doing, but not buried under a one-route change. Opened as a follow-up rather than bundled here.

The auth-class union already carries `activation-or-wallet`, `wallet`, and `wallet-session` (landed separately), so no source change is needed and the manager route count stays at 68.

## Test plan

- `npm run test:openapi` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)