### PR TITLE
Keep Credit Bank gateway errors readable and balances honest

### DIFF
--- a/apps/portal/src/features/usage/credit-bank.test.tsx
+++ b/apps/portal/src/features/usage/credit-bank.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AomiCreditApiError } from "@aomi-labs/client";
 
@@ -238,36 +238,5 @@ describe("Credit Bank", () => {
       "idempotencyKey",
     );
     expect(screen.queryByText(/Confirm the top-up again/)).toBeNull();
-  });
-
-  it("does not let a late balance failure overwrite a successful top-up", async () => {
-    let rejectInitialLoad!: (cause: unknown) => void;
-    mocks.accountCredits.get.mockImplementationOnce(
-      () =>
-        new Promise((_, reject) => {
-          rejectInitialLoad = reject;
-        }),
-    );
-    mocks.accountCredits.topUp.mockResolvedValue({
-      ...position(),
-      bank: { balance_microusd: 10_000, outstanding_debt_microusd: 0 },
-    });
-
-    render(<CreditBank />);
-    fireEvent.click(screen.getByRole("button", { name: /Credit bank/ }));
-    fireEvent.click(screen.getByRole("button", { name: "Add credits" }));
-    fireEvent.change(screen.getByLabelText("Top-up credits"), {
-      target: { value: "1" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Pay 0.01 USDC" }));
-
-    expect(
-      await screen.findByText("1 credit added. Your bank now has 1 credit."),
-    ).toBeTruthy();
-    await act(async () => {
-      rejectInitialLoad(new AomiCreditApiError(502, "fetch account credits"));
-    });
-    expect(screen.queryByText(/Failed to fetch account credits/)).toBeNull();
-    expect(screen.getByText("1 credit")).toBeTruthy();
   });
 });

--- a/apps/portal/src/features/usage/credit-bank.test.tsx
+++ b/apps/portal/src/features/usage/credit-bank.test.tsx
@@ -136,6 +136,7 @@ describe("Credit Bank", () => {
     view.unmount();
     render(<CreditBank />);
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(screen.getByText("Unavailable")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: /Credit bank/ }));
     expect(await screen.findByText(/account unavailable/)).toBeTruthy();
   });
@@ -237,5 +238,36 @@ describe("Credit Bank", () => {
       "idempotencyKey",
     );
     expect(screen.queryByText(/Confirm the top-up again/)).toBeNull();
+  });
+
+  it("does not let a late balance failure overwrite a successful top-up", async () => {
+    let rejectInitialLoad!: (cause: unknown) => void;
+    mocks.accountCredits.get.mockImplementationOnce(
+      () =>
+        new Promise((_, reject) => {
+          rejectInitialLoad = reject;
+        }),
+    );
+    mocks.accountCredits.topUp.mockResolvedValue({
+      ...position(),
+      bank: { balance_microusd: 10_000, outstanding_debt_microusd: 0 },
+    });
+
+    render(<CreditBank />);
+    fireEvent.click(screen.getByRole("button", { name: /Credit bank/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Add credits" }));
+    fireEvent.change(screen.getByLabelText("Top-up credits"), {
+      target: { value: "1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Pay 0.01 USDC" }));
+
+    expect(
+      await screen.findByText("1 credit added. Your bank now has 1 credit."),
+    ).toBeTruthy();
+    rejectInitialLoad(new AomiCreditApiError(502, "fetch account credits"));
+    await waitFor(() =>
+      expect(screen.queryByText(/Failed to fetch account credits/)).toBeNull(),
+    );
+    expect(screen.getByText("1 credit")).toBeTruthy();
   });
 });

--- a/apps/portal/src/features/usage/credit-bank.test.tsx
+++ b/apps/portal/src/features/usage/credit-bank.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AomiCreditApiError } from "@aomi-labs/client";
 
@@ -264,10 +264,10 @@ describe("Credit Bank", () => {
     expect(
       await screen.findByText("1 credit added. Your bank now has 1 credit."),
     ).toBeTruthy();
-    rejectInitialLoad(new AomiCreditApiError(502, "fetch account credits"));
-    await waitFor(() =>
-      expect(screen.queryByText(/Failed to fetch account credits/)).toBeNull(),
-    );
+    await act(async () => {
+      rejectInitialLoad(new AomiCreditApiError(502, "fetch account credits"));
+    });
+    expect(screen.queryByText(/Failed to fetch account credits/)).toBeNull();
     expect(screen.getByText("1 credit")).toBeTruthy();
   });
 });

--- a/apps/portal/src/features/usage/credit-bank.test.tsx
+++ b/apps/portal/src/features/usage/credit-bank.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AomiCreditApiError } from "@aomi-labs/client";
 
 const mocks = vi.hoisted(() => ({
   connected: true,
@@ -211,5 +212,30 @@ describe("Credit Bank", () => {
       idempotencyKey: "topup-recovery",
       recover: true,
     });
+  });
+
+  it("keeps an uncertain payment pending instead of asking for a new payment", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Response.json(position())),
+    );
+    mocks.accountCredits.topUp.mockRejectedValue(
+      new AomiCreditApiError(502, "top up account credits"),
+    );
+
+    render(<CreditBank />);
+    await screen.findByText("-25 credits");
+    fireEvent.click(screen.getByRole("button", { name: /Credit bank/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Add credits" }));
+    fireEvent.click(screen.getByRole("button", { name: "Pay 10.00 USDC" }));
+
+    expect(
+      await screen.findByText("Failed to top up account credits: HTTP 502"),
+    ).toBeTruthy();
+    expect(screen.getByText("Confirming previous payment")).toBeTruthy();
+    expect(window.localStorage.getItem("aomi_credit_topup:user-1")).toContain(
+      "idempotencyKey",
+    );
+    expect(screen.queryByText(/Confirm the top-up again/)).toBeNull();
   });
 });

--- a/apps/portal/src/features/usage/credit-bank/credit-bank.tsx
+++ b/apps/portal/src/features/usage/credit-bank/credit-bank.tsx
@@ -224,11 +224,7 @@ export function CreditBank() {
         <span className="flex shrink-0 items-center gap-2">
           <span className="text-right">
             <span className="text-aomi-fg block text-[13px] font-medium tabular-nums">
-              {loading && !position
-                ? "—"
-                : balance === null
-                  ? "—"
-                  : formatCreditAmount(balance)}
+              {balance === null ? "—" : formatCreditAmount(balance)}
             </span>
             <span className="text-aomi-muted block text-[11px] tabular-nums">
               {loading && !position

--- a/apps/portal/src/features/usage/credit-bank/credit-bank.tsx
+++ b/apps/portal/src/features/usage/credit-bank/credit-bank.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   AomiCreditApiError,
   type AomiCreditActivity,
@@ -87,6 +87,7 @@ export function CreditBank() {
   const [pendingTopUp, setPendingTopUp] = useState<PendingTopUp | null>(
     initialPendingTopUp,
   );
+  const loadAttempt = useRef(0);
 
   useEffect(() => {
     const next = readPendingTopUp(pendingStorageKey);
@@ -95,16 +96,20 @@ export function CreditBank() {
   }, [pendingStorageKey]);
 
   const load = useCallback(async () => {
+    const attempt = ++loadAttempt.current;
     setLoading(true);
     try {
-      setPosition(await account.credits.get({ limit: ACTIVITY_PAGE_SIZE }));
+      const next = await account.credits.get({ limit: ACTIVITY_PAGE_SIZE });
+      if (attempt !== loadAttempt.current) return;
+      setPosition(next);
       setError(null);
     } catch (cause) {
+      if (attempt !== loadAttempt.current) return;
       setError(
         cause instanceof Error ? cause.message : "Could not load Credit Bank",
       );
     } finally {
-      setLoading(false);
+      if (attempt === loadAttempt.current) setLoading(false);
     }
   }, [account.credits]);
 
@@ -149,6 +154,10 @@ export function CreditBank() {
       setPendingTopUp(pending);
     }
     setPaying(true);
+    // A balance refresh may still be in flight. Its late failure must not
+    // overwrite the result of this payment attempt or its recovery state.
+    ++loadAttempt.current;
+    setLoading(false);
     setError(null);
     setSuccess(null);
     try {

--- a/apps/portal/src/features/usage/credit-bank/credit-bank.tsx
+++ b/apps/portal/src/features/usage/credit-bank/credit-bank.tsx
@@ -198,7 +198,7 @@ export function CreditBank() {
     }
   }
 
-  const balance = toCredits(position?.bank.balance_microusd ?? 0);
+  const balance = position ? toCredits(position.bank.balance_microusd) : null;
 
   return (
     <div className="border-aomi-border border-t">
@@ -224,12 +224,18 @@ export function CreditBank() {
         <span className="flex shrink-0 items-center gap-2">
           <span className="text-right">
             <span className="text-aomi-fg block text-[13px] font-medium tabular-nums">
-              {loading && !position ? "—" : formatCreditAmount(balance)}
+              {loading && !position
+                ? "—"
+                : balance === null
+                  ? "—"
+                  : formatCreditAmount(balance)}
             </span>
             <span className="text-aomi-muted block text-[11px] tabular-nums">
               {loading && !position
                 ? "Loading…"
-                : `${formatUsdc(balance / 100)} value`}
+                : balance === null
+                  ? "Unavailable"
+                  : `${formatUsdc(balance / 100)} value`}
             </span>
           </span>
           <ChevronDown

--- a/apps/portal/src/features/usage/credit-bank/credit-bank.tsx
+++ b/apps/portal/src/features/usage/credit-bank/credit-bank.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   AomiCreditApiError,
   type AomiCreditActivity,
@@ -87,7 +87,6 @@ export function CreditBank() {
   const [pendingTopUp, setPendingTopUp] = useState<PendingTopUp | null>(
     initialPendingTopUp,
   );
-  const loadAttempt = useRef(0);
 
   useEffect(() => {
     const next = readPendingTopUp(pendingStorageKey);
@@ -96,20 +95,16 @@ export function CreditBank() {
   }, [pendingStorageKey]);
 
   const load = useCallback(async () => {
-    const attempt = ++loadAttempt.current;
     setLoading(true);
     try {
-      const next = await account.credits.get({ limit: ACTIVITY_PAGE_SIZE });
-      if (attempt !== loadAttempt.current) return;
-      setPosition(next);
+      setPosition(await account.credits.get({ limit: ACTIVITY_PAGE_SIZE }));
       setError(null);
     } catch (cause) {
-      if (attempt !== loadAttempt.current) return;
       setError(
         cause instanceof Error ? cause.message : "Could not load Credit Bank",
       );
     } finally {
-      if (attempt === loadAttempt.current) setLoading(false);
+      setLoading(false);
     }
   }, [account.credits]);
 
@@ -154,10 +149,6 @@ export function CreditBank() {
       setPendingTopUp(pending);
     }
     setPaying(true);
-    // A balance refresh may still be in flight. Its late failure must not
-    // overwrite the result of this payment attempt or its recovery state.
-    ++loadAttempt.current;
-    setLoading(false);
     setError(null);
     setSuccess(null);
     try {

--- a/packages/client/src/account/credits.ts
+++ b/packages/client/src/account/credits.ts
@@ -169,10 +169,45 @@ async function responseJson<T>(
   operation: string,
 ): Promise<T> {
   if (!response.ok) {
-    const detail = await response.text().catch(() => "");
+    const detail = await responseErrorDetail(response);
     throw new AomiCreditApiError(response.status, operation, detail);
   }
   return (await response.json()) as T;
+}
+
+async function responseErrorDetail(
+  response: Response,
+): Promise<string | undefined> {
+  const body = await response.text().catch(() => "");
+  if (!body.trim()) return undefined;
+
+  try {
+    const payload = JSON.parse(body) as unknown;
+    const detail = jsonErrorDetail(payload);
+    return detail ? detail.slice(0, 500) : undefined;
+  } catch {
+    // Gateways and proxies sometimes return an HTML error page. Keep the
+    // status in the API error while hiding that page from users.
+    return undefined;
+  }
+}
+
+function jsonErrorDetail(value: unknown): string | undefined {
+  if (typeof value === "string") return value.trim() || undefined;
+  if (!value || typeof value !== "object") return undefined;
+
+  const record = value as Record<string, unknown>;
+  for (const key of ["message", "detail", "error"]) {
+    const candidate = record[key];
+    if (typeof candidate === "string" && candidate.trim()) {
+      return candidate.trim();
+    }
+    if (candidate && typeof candidate === "object") {
+      const nested = jsonErrorDetail(candidate);
+      if (nested) return nested;
+    }
+  }
+  return undefined;
 }
 
 function paymentReceiptFrom(

--- a/packages/client/test/account-credits.unit.test.ts
+++ b/packages/client/test/account-credits.unit.test.ts
@@ -178,4 +178,50 @@ describe("account credits", () => {
     expect(first.headers.get("idempotency-key")).toBe("topup-recovery");
     expect(second.headers.get("idempotency-key")).toBe("topup-recovery");
   });
+
+  it("does not expose an HTML gateway page in credit errors", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          "<!DOCTYPE html><html><body>502 Bad Gateway</body></html>",
+          {
+            status: 502,
+            headers: { "content-type": "text/html" },
+          },
+        ),
+    );
+    const client = new AomiClient({
+      baseUrl: "https://api.test",
+      fetch: fetchImpl as typeof fetch,
+      guest: false,
+    });
+
+    const error = await client.account.credits.get().catch((cause) => cause);
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBe("Failed to fetch account credits: HTTP 502");
+    expect(error.message).not.toContain("<!DOCTYPE html>");
+  });
+
+  it("retains a structured JSON error detail", async () => {
+    const fetchImpl = vi.fn(async () =>
+      Response.json(
+        {
+          error: {
+            code: "payment_pending",
+            message: "Payment is still confirming",
+          },
+        },
+        { status: 503 },
+      ),
+    );
+    const client = new AomiClient({
+      baseUrl: "https://api.test",
+      fetch: fetchImpl as typeof fetch,
+      guest: false,
+    });
+
+    await expect(client.account.credits.get()).rejects.toThrow(
+      "HTTP 503\nPayment is still confirming",
+    );
+  });
 });


### PR DESCRIPTION
Credit Bank displayed an entire Cloudflare HTML error page when staging returned HTTP 502 while reading the balance. The shared credit transport now reports the HTTP status with useful structured JSON error details, and an unavailable initial balance displays “Unavailable” instead of zero.

Pending top-ups continue to retain the same purchase identity after an uncertain gateway response, so retrying recovers the existing purchase.

Validation: 7 client credit transport tests passed, including HTML error handling and structured error messages. All 5 focused Portal Credit Bank tests passed, including unavailable balances and preserving pending payments after HTTP 502.
