### PR TITLE
Route agent requests by thread headers

### DIFF
--- a/apps/portal/src/server/agent-api-proxy.test.ts
+++ b/apps/portal/src/server/agent-api-proxy.test.ts
@@ -55,6 +55,8 @@ describe("Agent API proxy", () => {
           "mcp-protocol-version": "2025-06-18",
           "payment-signature": "payment",
           "x-request-id": "request-1",
+          "x-session-id": "session-1",
+          "x-thread-id": "thread-1",
         },
         body: "{}",
       }),
@@ -80,6 +82,8 @@ describe("Agent API proxy", () => {
     expect(headers.get("idempotency-key")).toBe("idem-1");
     expect(headers.get("mcp-protocol-version")).toBe("2025-06-18");
     expect(headers.get("payment-signature")).toBe("payment");
+    expect(headers.get("x-session-id")).toBe("session-1");
+    expect(headers.get("x-thread-id")).toBe("thread-1");
     expect(response.headers.get("payment-response")).toBe("paid");
     expect(response.headers.get("payment-receipt")).toBe("receipt");
     expect(response.headers.get("mcp-protocol-version")).toBe("2025-06-18");

--- a/apps/portal/src/server/agent-api-proxy.ts
+++ b/apps/portal/src/server/agent-api-proxy.ts
@@ -12,6 +12,8 @@ const REQUEST_HEADERS = new Set([
   "payment-signature",
   "x-request-id",
   "x-aomi-inference-funding",
+  "x-session-id",
+  "x-thread-id",
 ]);
 
 const RESPONSE_HEADERS = new Set([

--- a/packages/client/src/agent/transport.ts
+++ b/packages/client/src/agent/transport.ts
@@ -48,12 +48,16 @@ export class AgentTransport {
       inferenceFunding?: AomiInferenceFundingSource;
     } = {},
   ): Promise<EventPage> {
+    const sessionId = intent.sessionId;
     return this.json("POST", "/v1/agent/chat", {
-      headers: mutationHeaders({
-        ...options,
-        inferenceFunding:
-          options.inferenceFunding ?? this.defaultInferenceFunding,
-      }),
+      headers: {
+        ...mutationHeaders({
+          ...options,
+          inferenceFunding:
+            options.inferenceFunding ?? this.defaultInferenceFunding,
+        }),
+        ...threadHeaders(sessionId),
+      },
       body: intent,
     });
   }
@@ -63,6 +67,7 @@ export class AgentTransport {
     options: { cursor?: string; waitMs?: number } = {},
   ): Promise<EventPage> {
     return this.json("GET", `/v1/agent/chat/${encodeURIComponent(sessionId)}`, {
+      headers: threadHeaders(sessionId),
       query: {
         cursor: options.cursor,
         wait: Math.min(Math.max(options.waitMs ?? 0, 0), 30_000),
@@ -79,7 +84,10 @@ export class AgentTransport {
       "POST",
       `/v1/agent/chat/${encodeURIComponent(sessionId)}/interrupt`,
       {
-        headers: { "idempotency-key": idempotencyKey },
+        headers: {
+          "idempotency-key": idempotencyKey,
+          ...threadHeaders(sessionId),
+        },
         body: { turnId },
       },
     );
@@ -96,7 +104,10 @@ export class AgentTransport {
       "POST",
       `/v1/agent/chat/${encodeURIComponent(sessionId)}/actions/${encodeURIComponent(actionId)}/result`,
       {
-        headers: { "idempotency-key": idempotencyKey },
+        headers: {
+          "idempotency-key": idempotencyKey,
+          ...threadHeaders(sessionId),
+        },
         body: { revision, result },
       },
     );
@@ -183,6 +194,14 @@ function mutationHeaders(
       ? { "x-aomi-inference-funding": options.inferenceFunding }
       : {}),
   };
+}
+
+function threadHeaders(
+  sessionId: string | null | undefined,
+): Record<string, string> {
+  return sessionId
+    ? { "x-session-id": sessionId, "x-thread-id": sessionId }
+    : {};
 }
 
 function randomIdempotencyKey(): string {

--- a/packages/client/test/agent-transport.unit.test.ts
+++ b/packages/client/test/agent-transport.unit.test.ts
@@ -33,9 +33,14 @@ describe("AgentTransport", () => {
     expect(startHeaders.get("idempotency-key")).toBe("idem-fixed");
     expect(startHeaders.get("payment-signature")).toBe("payment");
     expect(startHeaders.get("x-aomi-inference-funding")).toBe("user_byok");
+    expect(startHeaders.get("x-session-id")).toBe("session-1");
+    expect(startHeaders.get("x-thread-id")).toBe("session-1");
     expect(fetch.mock.calls[1][0]).toBe(
       "https://portal.example/v1/agent/chat/session-1?cursor=cursor-1&wait=30000",
     );
+    const pollHeaders = new Headers(fetch.mock.calls[1][1].headers);
+    expect(pollHeaders.get("x-session-id")).toBe("session-1");
+    expect(pollHeaders.get("x-thread-id")).toBe("session-1");
   });
 
   it("applies the client funding default to Agent turns", async () => {


### PR DESCRIPTION
Older chats intermittently return 502 when an Agent v1 request lands on a backend host that does not own the thread. Forward the session/thread routing headers through the SDK and Portal proxy for start, poll, interrupt, and action-result requests.

Validation:
- Agent transport unit tests: 4 passed
- Portal proxy tests: 7 passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/578"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791379932&installation_model_id=12362&pr_number=578&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F578&signature=910b516bb2ffc366952acfe30e8243f621d2277e467c48dea14a59714779b5de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->