### PR TITLE
Keep restored legacy tool steps in one working trace

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -1,5 +1,9 @@
 # Canonical Landing
 
+Current session goal: **LEGACY AGENT TRACE GROUPING VERIFIED 2026-09-07** —
+group null-turn historical Agent tool steps and final answers by their preceding
+user message while preserving canonical turn identities and stable pagination.
+
 Current session goal: **LEAN PAYMENT REVIEW FRONTEND CONSUMER FIXES VERIFIED
 2026-09-06** — SDK BYOK routes and response shapes use `/api/account/model-keys`,
 Agent and CLI calls can explicitly select `user_byok`, Portal credit top-ups

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aomi-labs/react",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Runtime, state, and utilities for the Aomi widget.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/react/src/runtime/__tests__/event-projection.test.ts
+++ b/packages/react/src/runtime/__tests__/event-projection.test.ts
@@ -123,6 +123,162 @@ describe("projectAssistantMessages", () => {
     ]);
   });
 
+  it("groups legacy null-turn tools and answers by their preceding user message", () => {
+    const events: Event[] = [
+      {
+        ...meta(1, "message", null),
+        type: "message",
+        sender: "user",
+        content: "first",
+      },
+      {
+        ...meta(2, "message", null),
+        type: "message",
+        sender: "agent",
+        content: "",
+        message_key: "first-tool-1",
+        tool_name: "search",
+        tool_result: ["Search", '{"matches":2}'],
+      },
+      {
+        ...meta(3, "message", null),
+        type: "message",
+        sender: "agent",
+        content: "",
+        message_key: "first-tool-2",
+        tool_name: "inspect",
+        tool_result: ["Inspect", '{"valid":true}'],
+      },
+      {
+        ...meta(4, "message", null),
+        type: "message",
+        sender: "agent",
+        content: "First answer",
+      },
+      {
+        ...meta(5, "message", null),
+        type: "message",
+        sender: "user",
+        content: "second",
+      },
+      {
+        ...meta(6, "message", null),
+        type: "message",
+        sender: "agent",
+        content: "",
+        message_key: "second-tool",
+        tool_name: "quote",
+        tool_result: ["Quote", '{"price":"1"}'],
+      },
+      {
+        ...meta(7, "message", null),
+        type: "message",
+        sender: "agent",
+        content: "Second answer",
+      },
+    ];
+
+    const firstPage = projectAssistantMessages(events.slice(0, 4));
+    const projected = projectAssistantMessages(events);
+
+    expect(projected).toHaveLength(4);
+    expect(projected[1]).toMatchObject({
+      id: firstPage[1]?.id,
+      role: "assistant",
+      content: [
+        { type: "tool-call", toolName: "search", result: { matches: 2 } },
+        { type: "tool-call", toolName: "inspect", result: { valid: true } },
+        { type: "text", text: "First answer" },
+      ],
+    });
+    expect(projected[3]).toMatchObject({
+      role: "assistant",
+      content: [
+        { type: "tool-call", toolName: "quote", result: { price: "1" } },
+        { type: "text", text: "Second answer" },
+      ],
+    });
+  });
+
+  it("keeps explicit turn ids authoritative and deduplicates null-turn typed completions", () => {
+    const events: Event[] = [
+      {
+        ...meta(1, "message", "canonical-turn"),
+        type: "message",
+        sender: "agent",
+        content: "Canonical",
+      },
+      {
+        ...meta(2, "message", null),
+        type: "message",
+        sender: "user",
+        content: "legacy",
+      },
+      {
+        ...meta(3, "message", null),
+        type: "message",
+        sender: "agent",
+        content: "",
+        message_key: "inline-quote",
+        tool_name: "quote",
+        tool_result: ["Quote", '{"price":"old"}'],
+      },
+      {
+        ...meta(4, "tool_complete", null),
+        type: "tool_complete",
+        id: "quote",
+        call_id: "typed-quote",
+        tool_name: "quote",
+        result: { price: "new" },
+      },
+    ];
+
+    const projected = projectAssistantMessages(events);
+    expect(projected[0]?.id).toBe("turn:canonical-turn");
+    expect(projected[2]?.content).toEqual([
+      {
+        type: "tool-call",
+        toolCallId: "typed-quote",
+        toolName: "quote",
+        args: undefined,
+        result: { price: "new" },
+      },
+    ]);
+  });
+
+  it("starts a new legacy group after a user message with an explicit turn id", () => {
+    const projected = projectAssistantMessages([
+      {
+        ...meta(1, "message", null),
+        type: "message",
+        sender: "user",
+        content: "legacy",
+      },
+      {
+        ...meta(2, "message", null),
+        type: "message",
+        sender: "agent",
+        content: "Legacy answer",
+      },
+      {
+        ...meta(3, "message", "canonical-turn"),
+        type: "message",
+        sender: "user",
+        content: "canonical request",
+      },
+      {
+        ...meta(4, "message", null),
+        type: "message",
+        sender: "agent",
+        content: "Imported answer after canonical user",
+      },
+    ]);
+
+    expect(projected).toHaveLength(4);
+    expect(projected[1]?.id).toBe("turn:legacy:event-1");
+    expect(projected[3]?.id).toBe("turn:legacy:event-3");
+  });
+
   it("keeps an inline tool's trace when a different tool completed typed in the same turn", () => {
     const events: Event[] = [
       {

--- a/packages/react/src/runtime/utils.ts
+++ b/packages/react/src/runtime/utils.ts
@@ -210,7 +210,13 @@ export function projectAssistantMessages(
   const assistantTurns = new Map<string, AssistantProjection>();
   const standaloneMessages = new Map<string, number>();
   let userMessageOrdinal = 0;
-  const turnKey = (event: Event) => event.turn_id ?? `event:${event.event_id}`;
+  let legacyTurnKey = `legacy:${events[0]?.event_id ?? "empty"}`;
+  const turnKeys = events.map((event) => {
+    if (event.type === "message" && event.sender === "user") {
+      legacyTurnKey = `legacy:${event.event_id}`;
+    }
+    return event.turn_id ?? legacyTurnKey;
+  });
   // Inline results only ever arrive as `tool_result` message events, so an
   // inline part may be suppressed only when the SAME tool also produced a
   // typed completion in the turn — suppressing per turn would drop a sync
@@ -218,15 +224,15 @@ export function projectAssistantMessages(
   const typedToolKey = (turn: string, toolName: string) =>
     `${turn}::${toolName}`;
   const typedToolCompletions = new Set(
-    events.flatMap((event) =>
+    events.flatMap((event, index) =>
       event.type === "tool_complete" && event.tool_name !== "task"
-        ? [typedToolKey(turnKey(event), event.tool_name)]
+        ? [typedToolKey(turnKeys[index]!, event.tool_name)]
         : [],
     ),
   );
 
-  const assistantTurn = (event: Event): AssistantProjection => {
-    const key = turnKey(event);
+  const assistantTurn = (event: Event, index: number): AssistantProjection => {
+    const key = turnKeys[index]!;
     const existing = assistantTurns.get(key);
     if (existing) return existing;
     const projection: AssistantProjection = {
@@ -245,17 +251,17 @@ export function projectAssistantMessages(
     return projection;
   };
 
-  for (const event of events) {
+  for (const [index, event] of events.entries()) {
     if (event.type === "message") {
       if (event.sender === "system") continue;
       if (event.sender === "agent") {
-        const projection = assistantTurn(event);
+        const projection = assistantTurn(event, index);
         const key = event.message_key ?? event.event_id;
         const toolResult = inlineToolResult(event);
         if (toolResult) {
           if (
             !typedToolCompletions.has(
-              typedToolKey(turnKey(event), toolResult.toolName),
+              typedToolKey(turnKeys[index]!, toolResult.toolName),
             )
           ) {
             upsertPart(
@@ -277,16 +283,16 @@ export function projectAssistantMessages(
       let projected = toInboundMessage(event, output.length);
       if (!projected) continue;
       const key = event.message_key ?? event.event_id;
-      const index = standaloneMessages.get(key);
-      if (index === undefined) {
+      const existingIndex = standaloneMessages.get(key);
+      if (existingIndex === undefined) {
         if (projected.role === "user") {
           projected = { ...projected, id: userMessageId(userMessageOrdinal++) };
         }
         standaloneMessages.set(key, output.length);
         output.push(projected);
       } else {
-        const previous = output[index];
-        output[index] =
+        const previous = output[existingIndex];
+        output[existingIndex] =
           projected.role === "user" && previous && !("parts" in previous)
             ? { ...projected, id: previous.id }
             : projected;
@@ -298,7 +304,7 @@ export function projectAssistantMessages(
       (event.type === "tool_update" || event.type === "tool_complete") &&
       event.tool_name !== "task"
     ) {
-      const projection = assistantTurn(event);
+      const projection = assistantTurn(event, index);
       upsertPart(
         projection,
         projection.toolParts,


### PR DESCRIPTION
Restored older conversations render each tool result as a separate one-step “Worked it out” block because their events have no turn ID. Group those legacy events by the preceding user message so their tools and final answer form one assistant response.

Explicit backend turn IDs remain authoritative. Every user message starts a new fallback group, including mixed old/new history, and typed tool-result deduplication uses the same grouping. React is patch-bumped to 0.6.9.

Validation: all nine projection tests pass, including multi-tool answers, separate user requests, mixed canonical/legacy boundaries, stable IDs as history grows, and typed completion deduplication. Scoped lint and formatting pass. Render-level verification through AssistantTurnParts passed (one trace, ordered steps, visible final answer). React build and package audit passed. Full PR CI passed.

Deployed on Chat staging as dpl_AjrtEajvutUha1R4DqFrhUrrqPgj from merged commit 8bd2e771e63869fc7328d2b8a1327c79cbccfffd. An isolated authenticated browser verified two restored transfer conversations each render exactly one Working trace containing five steps and the final answer. No messages or wallet actions were submitted.
