### PR TITLE
Allow audited frozen npm candidate publishing

### DIFF
--- a/.github/scripts/verify-main-ci.sh
+++ b/.github/scripts/verify-main-ci.sh
@@ -4,6 +4,15 @@ set -euo pipefail
 : "${GH_TOKEN:?GH_TOKEN is required}"
 : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
 : "${CANDIDATE_SHA:?CANDIDATE_SHA is required}"
+: "${ALLOW_PUBLISHABLE_PACKAGE_DRIFT:=false}"
+
+case "$ALLOW_PUBLISHABLE_PACKAGE_DRIFT" in
+  true | false) ;;
+  *)
+    echo "ALLOW_PUBLISHABLE_PACKAGE_DRIFT must be true or false" >&2
+    exit 1
+    ;;
+esac
 
 [[ "$CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ]] || {
   echo "candidate_sha must be a full lowercase commit SHA" >&2
@@ -28,8 +37,9 @@ git merge-base --is-ancestor "$CANDIDATE_SHA" origin/main || {
 # main says these packages are: a commit that main later reverted stays an
 # ancestor forever, so ancestry alone would happily publish reverted code.
 # Nothing structural distinguishes "reverted" from "superseded", so this fails
-# closed on both — if the published code itself moved on main since the
-# candidate, a human decides whether to re-cut the candidate or proceed.
+# closed on both by default. A release captain may explicitly acknowledge the
+# drift for an already-soaked immutable candidate; the workflow-dispatch input
+# is retained in the Actions audit trail rather than silently publishing it.
 # Deliberately scoped to the publishable package paths rather than the whole
 # tree: unrelated churn is exactly what the freeze is supposed to tolerate.
 PUBLISHABLE_PATHS=(
@@ -42,9 +52,12 @@ if ! git diff --quiet "$CANDIDATE_SHA" origin/main -- "${PUBLISHABLE_PATHS[@]}";
   echo "Publishable packages changed on main since $CANDIDATE_SHA:" >&2
   git diff --name-only "$CANDIDATE_SHA" origin/main -- "${PUBLISHABLE_PATHS[@]}" \
     | cut -d/ -f1-2 | sort -u | sed 's/^/  /' >&2
-  echo "Refusing to publish: main may have reverted or superseded this code." >&2
-  echo "Re-cut the candidate, or publish from a SHA whose packages match main." >&2
-  exit 1
+  if [[ "$ALLOW_PUBLISHABLE_PACKAGE_DRIFT" != true ]]; then
+    echo "Refusing to publish: main may have reverted or superseded this code." >&2
+    echo "Re-cut the candidate, or explicitly acknowledge package drift for an already-soaked candidate." >&2
+    exit 1
+  fi
+  echo "Continuing with explicitly acknowledged publishable-package drift." >&2
 fi
 # Filter server-side on head_sha as well as branch: a candidate that has soaked
 # for a while can otherwise fall outside the newest page of main's CI runs.

--- a/.github/workflows/publish-npm-token.yml
+++ b/.github/workflows/publish-npm-token.yml
@@ -4,9 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       candidate_sha:
-        description: Full current main SHA
+        description: Full immutable candidate SHA merged into main
         required: true
         type: string
+      allow_package_drift:
+        description: Publish this already-soaked candidate even though publishable package paths changed on main
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -30,6 +35,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+          ALLOW_PUBLISHABLE_PACKAGE_DRIFT: ${{ inputs.allow_package_drift }}
         run: .github/scripts/verify-main-ci.sh
 
       - name: Enable corepack


### PR DESCRIPTION
Adds an explicit `allow_package_drift` workflow-dispatch acknowledgement for an already-soaked immutable candidate whose publishable package paths changed on main.

The default remains fail-closed. The override preserves candidate ancestry and same-SHA CI checks, and its acknowledgement is retained in the Actions run.

Validation:
- `bash -n .github/scripts/verify-main-ci.sh`
- `git diff --check`
- workflow policy check
- `actionlint .github/workflows/publish-npm-token.yml`
- verified the production candidate passes ancestry + same-SHA CI with the explicit acknowledgement

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791574113&installation_model_id=12362&pr_number=585&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F585&signature=aa2471e8f7438298e9c37436e0016e8809e8b26851bc625401f54b4d0029de9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->