### PR TITLE
Run frozen npm releases under main policy

### DIFF
--- a/.github/workflows/publish-npm-token.yml
+++ b/.github/workflows/publish-npm-token.yml
@@ -31,12 +31,19 @@ jobs:
           ref: ${{ inputs.candidate_sha }}
           fetch-depth: 0
 
-      - name: Verify the candidate is on main with successful same-SHA CI
+      - name: Verify the candidate under main's release policy
         env:
           GH_TOKEN: ${{ github.token }}
           CANDIDATE_SHA: ${{ inputs.candidate_sha }}
           ALLOW_PUBLISHABLE_PACKAGE_DRIFT: ${{ inputs.allow_package_drift }}
-        run: .github/scripts/verify-main-ci.sh
+        run: |
+          # The candidate is intentionally frozen, so its checkout can contain
+          # an older verifier. Load the policy from main while retaining the
+          # candidate checkout for the ancestry and package-diff checks below.
+          git fetch origin main --quiet
+          git show origin/main:.github/scripts/verify-main-ci.sh > "$RUNNER_TEMP/verify-main-ci.sh"
+          chmod +x "$RUNNER_TEMP/verify-main-ci.sh"
+          "$RUNNER_TEMP/verify-main-ci.sh"
 
       - name: Enable corepack
         run: corepack enable


### PR DESCRIPTION
The publish job checks out the frozen candidate before verification, so invoking `.github/scripts/verify-main-ci.sh` read the old candidate copy and ignored policy updates on `main`.

Load that verifier from `origin/main` while retaining the frozen-candidate checkout for all git comparisons and the subsequent build/publish.

Validated with `actionlint`, the workflow policy checker, and a real read-only verifier run against `8bd2e771e63869fc7328d2b8a1327c79cbccfffd` using explicit drift acknowledgement.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/586"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791574740&installation_model_id=12362&pr_number=586&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F586&signature=da44a1544171ea0ba6319cb65c374dc80cfdafb566dced8670cd77c113ac02dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->