### PR TITLE
Match app chips to skill styling and show both in sent messages

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -1,5 +1,7 @@
 # Current work
 
+**INLINE APP CHIPS 2026-09-10** — apps match skill icon/text styling in the composer and are visible in submitted messages. Apps persist; skill mentions remain draft-scoped. App deletion retains one-turn guidance. Isolated follow-up; no deployment.
+
 **PERSISTENT APP CHIPS 2026-09-10** — selected app chips remain in the composer
 after sends and restore per conversation from browser storage. New conversations
 start empty. Deleting a chip queues one-turn removal guidance; reselection

--- a/apps/shadcn-registry/package.json
+++ b/apps/shadcn-registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aomi-labs/widget-lib",
-  "version": "2.0.45",
+  "version": "2.0.46",
   "description": "Shadcn registry for the Aomi widget.",
   "type": "module",
   "main": "./dist/index.js",

--- a/apps/shadcn-registry/src/components/assistant-ui/capability-composer/input.tsx
+++ b/apps/shadcn-registry/src/components/assistant-ui/capability-composer/input.tsx
@@ -11,6 +11,7 @@ import {
   type KeyboardEvent,
 } from "react";
 import { createPortal } from "react-dom";
+import { AppWindowIcon } from "lucide-react";
 import { useCapabilityComposer } from "./provider";
 import { useCapabilityCatalog } from "./catalog";
 import { CapabilityPicker } from "./picker";
@@ -461,68 +462,72 @@ export const CapabilityMentionInput: FC<{
 
   return (
     <>
-      {hintsEnabled && mentions.some((item) => item.kind === "app") && (
-        <div
-          className="flex flex-wrap gap-1 px-4 pb-1"
-          aria-label="Selected apps"
-        >
-          {mentions
-            .filter((item) => item.kind === "app")
-            .map((item) => (
-              <button
-                key={item.key}
-                type="button"
-                aria-label={`Remove ${item.label}`}
-                className="text-aomi-accent bg-aomi-accent/10 inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs"
-                onClick={() => removeApp(item.key)}
-                onKeyDown={(event) => {
-                  if (event.key === "Backspace" || event.key === "Delete") {
-                    event.preventDefault();
-                    removeApp(item.key);
-                  }
-                }}
-              >
-                {item.label}
-                <span aria-hidden="true">×</span>
-              </button>
-            ))}
-        </div>
-      )}
-      <div className="relative">
-        {!hasText ? (
-          <span className="text-aomi-muted pointer-events-none absolute left-4 top-1.5 text-[13px]">
-            {placeholder}
+      <div className={`${className} flex flex-wrap items-baseline gap-x-1`}>
+        {hintsEnabled && mentions.some((item) => item.kind === "app") && (
+          <span className="contents" aria-label="Selected apps">
+            {mentions
+              .filter((item) => item.kind === "app")
+              .map((item) => {
+                const Icon =
+                  items.find((candidate) => candidate.key === item.key)?.Icon ??
+                  AppWindowIcon;
+                return (
+                  <button
+                    key={item.key}
+                    type="button"
+                    aria-label={`Remove ${item.label}`}
+                    className="text-aomi-accent relative top-px mx-0.5 inline-flex items-center gap-1 whitespace-nowrap align-baseline font-medium"
+                    onClick={() => removeApp(item.key)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Backspace" || event.key === "Delete") {
+                        event.preventDefault();
+                        removeApp(item.key);
+                      }
+                    }}
+                  >
+                    <Icon aria-hidden="true" className="size-3.5 shrink-0" />
+                    {item.label}
+                  </button>
+                );
+              })}
           </span>
-        ) : null}
-        <div
-          ref={editorRef}
-          role="textbox"
-          aria-label="Message input"
-          aria-multiline="true"
-          aria-autocomplete="list"
-          aria-expanded={query !== null}
-          aria-controls={query !== null ? pickerId : undefined}
-          aria-activedescendant={
-            query !== null && highlighted >= 0
-              ? `${pickerId}-option-${highlighted}`
-              : undefined
-          }
-          contentEditable={!isDisabled}
-          suppressContentEditableWarning
-          onInput={syncEditor}
-          onKeyDown={handleKeyDown}
-          className={`${className} min-h-[30px]`}
-        />
-        {hintsEnabled && query !== null ? (
-          <CapabilityPicker
-            pickerId={pickerId}
-            pickerRef={pickerRef}
-            visibleGroups={visibleGroups}
-            highlighted={highlighted}
-            onHighlight={setHighlighted}
-            onSelect={selectItem}
+        )}
+        <div className="relative min-w-[80px] flex-1">
+          {!hasText ? (
+            <span className="text-aomi-muted pointer-events-none absolute left-0 top-0">
+              {placeholder}
+            </span>
+          ) : null}
+          <div
+            ref={editorRef}
+            role="textbox"
+            aria-label="Message input"
+            aria-multiline="true"
+            aria-autocomplete="list"
+            aria-expanded={query !== null}
+            aria-controls={query !== null ? pickerId : undefined}
+            aria-activedescendant={
+              query !== null && highlighted >= 0
+                ? `${pickerId}-option-${highlighted}`
+                : undefined
+            }
+            contentEditable={!isDisabled}
+            suppressContentEditableWarning
+            onInput={syncEditor}
+            onKeyDown={handleKeyDown}
+            className="min-h-[30px] w-full outline-none"
           />
-        ) : null}
+          {hintsEnabled && query !== null ? (
+            <CapabilityPicker
+              pickerId={pickerId}
+              pickerRef={pickerRef}
+              visibleGroups={visibleGroups}
+              highlighted={highlighted}
+              onHighlight={setHighlighted}
+              onSelect={selectItem}
+            />
+          ) : null}
+        </div>
       </div>
       {mentionIconPortals.map(({ target, Icon }) =>
         createPortal(<Icon className="size-3.5" />, target),

--- a/apps/shadcn-registry/src/components/assistant-ui/capability-composer/provider.test.tsx
+++ b/apps/shadcn-registry/src/components/assistant-ui/capability-composer/provider.test.tsx
@@ -88,6 +88,18 @@ function Composer() {
       >
         Choose Cambrian
       </button>
+      <button
+        onClick={() =>
+          composer.addMention({
+            kind: "skill",
+            id: "across",
+            key: "skill:across",
+            label: "Across",
+          })
+        }
+      >
+        Choose Across
+      </button>
       <button onClick={() => composer.removeApp("app:cambrian")}>
         Remove app
       </button>
@@ -262,6 +274,10 @@ it.each(["chip", "input"])(
     });
     const chip = screen.getByRole("button", { name: "Remove Cambrian" });
     expect(chip).toBeVisible();
+    expect(chip.textContent).toBe("Cambrian");
+    expect(chip.querySelector("svg")).not.toBeNull();
+    expect(chip.className).not.toMatch(/rounded|bg-/);
+
     await act(async () => {
       fireEvent.keyDown(
         target === "chip"
@@ -278,3 +294,24 @@ it.each(["chip", "input"])(
     );
   },
 );
+
+it("clears submitted skill mentions while retaining apps without skill avoidance guidance", async () => {
+  fixture.text = "✦ Across hello";
+  const view = render(<Harness />);
+  await act(async () => {
+    fireEvent.click(screen.getByText("Choose Cambrian"));
+    fireEvent.click(screen.getByText("Choose Across"));
+  });
+  expect(screen.getByTestId("selections").textContent).toBe("Cambrian,Across");
+  await act(async () => {
+    fireEvent.click(screen.getByText("Send button"));
+  });
+  fixture.text = "";
+  await act(async () => {
+    view.rerender(<Harness />);
+  });
+  expect(screen.getByTestId("selections").textContent).toBe("Cambrian");
+  expect(fixture.runConfig.custom.aomiCapabilityHints).not.toHaveProperty(
+    "removedApps",
+  );
+});

--- a/apps/shadcn-registry/src/components/assistant-ui/capability-message-text.test.tsx
+++ b/apps/shadcn-registry/src/components/assistant-ui/capability-message-text.test.tsx
@@ -28,3 +28,38 @@ describe("splitCapabilityText", () => {
     ]);
   });
 });
+
+it("shows selected apps alongside inline skills without duplicating existing app mentions", () => {
+  const app = {
+    kind: "app" as const,
+    id: "application:2937773",
+    label: "Cambrian",
+    token: "▦ Cambrian",
+    Icon: AppWindowIcon,
+  };
+  const skill = {
+    kind: "skill" as const,
+    id: "across",
+    label: "Across",
+    token: "✦ Across",
+    Icon: AppWindowIcon,
+  };
+  const segments = splitCapabilityText(
+    "✦ Across now what can you do?",
+    [app, skill],
+    [app, skill],
+  );
+  expect(
+    segments
+      .filter((s) => s.type === "capability")
+      .map((s) => s.type === "capability" && s.capability.label),
+  ).toEqual(["Cambrian", "Across"]);
+  expect(
+    splitCapabilityText("▦ Cambrian hello", [app], [app]).filter(
+      (s) => s.type === "capability",
+    ),
+  ).toHaveLength(1);
+  expect(splitCapabilityText("hello", [app], [])).toEqual([
+    { type: "text", text: "hello" },
+  ]);
+});

--- a/apps/shadcn-registry/src/components/assistant-ui/capability-message-text.tsx
+++ b/apps/shadcn-registry/src/components/assistant-ui/capability-message-text.tsx
@@ -54,7 +54,17 @@ function escapeRegExp(value: string): string {
 export function splitCapabilityText(
   text: string,
   capabilities: readonly RenderedCapability[],
+  selected: readonly CapabilityHint[] = [],
 ): CapabilityTextSegment[] {
+  const missingApps = capabilities.filter(
+    (capability) =>
+      capability.kind === "app" &&
+      selected.some(
+        (hint) => hint.kind === "app" && hint.id === capability.id,
+      ) &&
+      !text.includes(capability.token),
+  );
+  text = [...missingApps.map((app) => app.token), text].join(" ");
   const byToken = new Map(
     capabilities.map((capability) => [capability.token, capability]),
   );
@@ -180,8 +190,8 @@ export const CapabilityMessageText: TextMessagePartComponent = ({ text }) => {
     });
   }, [hints, networkPreferences, skills, state.appDescriptors]);
   const segments = useMemo(
-    () => splitCapabilityText(text, capabilities),
-    [capabilities, text],
+    () => splitCapabilityText(text, capabilities, hints),
+    [capabilities, hints, text],
   );
 
   return (


### PR DESCRIPTION
App selections previously appeared as separate pills and were missing from sent message bubbles. Render them beside the composer text with the same icon and blue-text styling as skill mentions, and include selected apps in sent messages without duplicating existing mentions.

Apps stay selected after sending and retain the existing one-turn removal guidance. Skills remain draft-scoped: sending clears them, and removal does not add avoidance guidance. Bump widget-lib to 2.0.46 and update GOAL.md.

Validation:
- [x] 13 focused composer, message rendering, and capability payload tests
- [x] Registry TypeScript and scoped ESLint
- [x] Registry/widget build and package creation
- [x] Diff whitespace check
- [ ] Live browser visual verification

Follow-up to #587. This PR does not change backend app execution or guest budgeting. No deployment performed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/588"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791631318&installation_model_id=12362&pr_number=588&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F588&signature=65e9bedc25b0d9da8fc7b5f314557593abf631f22916062b951fe0f2ece0a3d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->