### PR TITLE
fix(composer): mount the per-user app keys dialog in the new composer row

### DIFF
--- a/apps/shadcn-registry/src/components/assistant-ui/thread.tsx
+++ b/apps/shadcn-registry/src/components/assistant-ui/thread.tsx
@@ -54,6 +54,7 @@ import { useComposerControl } from "@/components/aomi-frame";
 import { AomiMark } from "@/components/aomi-mark";
 import { ActivitySidebar } from "@/components/activity-sidebar/activity-sidebar";
 import { ModelSelect } from "@/components/control-bar/model-select";
+import { AppSecretsDialog } from "@/components/control-bar/app-secrets-dialog";
 import { ModeSelect } from "@/components/control-bar/mode-select";
 import { AppSelect } from "@/components/control-bar/app-select";
 import { ApiKeyInput } from "@/components/control-bar/api-key-input";
@@ -391,6 +392,7 @@ const ComposerAction: FC = () => {
   const hideApiKey = controlBarProps.hideApiKey ?? false;
   const hideWallet = controlBarProps.hideWallet ?? true;
   const hideNetwork = controlBarProps.hideNetwork ?? false;
+  const hideAppSecrets = controlBarProps.hideAppSecrets ?? false;
   const { hostError } = useCapabilityComposer();
 
   return (
@@ -402,6 +404,9 @@ const ComposerAction: FC = () => {
           <CapabilityPickerButton />
           {!hideModel && <ModelSelect />}
           <ExecutionControl />
+          {/* Renders only when the directly targeted app declares secret
+              slots: the signed-in user's own keys for account-bound venues. */}
+          {!hideAppSecrets && <AppSecretsDialog />}
           {!hideWallet && <ConnectButton />}
           {!hideApiKey && <ApiKeyInput />}
         </div>


### PR DESCRIPTION
## Why

#584 added `AppSecretsDialog` to `ControlBar`. #587 then gave the composer its own action row (capability picker, model, execution mode) and stopped rendering `ControlBar` there, so the key button never appears on chat-staging.

## What

- `thread.tsx` `ComposerAction`: render `<AppSecretsDialog />` right after the execution control. It still renders only when the directly targeted app (`getCurrentThreadApp` / `getCurrentThreadApplicationId`, which direct routing keeps updated) carries an `applicationId` and declares secret slots.
- Honors `controlBarProps.hideAppSecrets`.

## Depends on

aomi-labs/product-mono#1066: official apps only advertise their secret slots in `/api/thread/apps` after that lands. Until then the dialog has nothing to render for them.

## Tests

- `pnpm run typecheck`, eslint, prettier clean.
- Registry component suite: 29 files, 250 tests pass (includes `app-secrets-dialog.test.tsx`). No existing harness renders the full composer row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791632108&installation_model_id=12362&pr_number=589&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F589&signature=f8b97ffd46fe33f695e8471345e231ddd2343daaf0bb5bc13e0a3831503b161a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->