### PR TITLE
Fix Telegram Para hosted wallet linking

### DIFF
--- a/apps/portal/src/app/api/auth/widget/telegram/exchange/route.test.ts
+++ b/apps/portal/src/app/api/auth/widget/telegram/exchange/route.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   claimOwner: vi.fn(),
   issueSession: vi.fn(),
   linkIdentity: vi.fn(),
+  resolveWallets: vi.fn(),
   verifyCredential: vi.fn(),
   verifyTelegram: vi.fn(),
 }));
@@ -12,6 +13,8 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@aomi-labs/account/account", () => ({
   claimTelegramSessionOwner: mocks.claimOwner,
   linkVerifiedProviderIdentityForUser: mocks.linkIdentity,
+  resolveAttestedProviderWallets: mocks.resolveWallets,
+  IdentityConflictError: class IdentityConflictError extends Error {},
 }));
 
 vi.mock("@aomi-labs/account/telegram", () => ({
@@ -28,9 +31,16 @@ vi.mock("@aomi-labs/account/widget-auth", async (importOriginal) => {
   };
 });
 
-vi.mock("@portal/server/widget-auth/exchange", () => ({
-  verifyWidgetProviderCredential: mocks.verifyCredential,
-}));
+// The route runs the real `requireAttestedProviderWallets`, so the mapping from
+// a provider-API answer to a route failure code is under test; only the
+// credential verification and the provider lookup underneath it are mocked.
+vi.mock("@portal/server/widget-auth/exchange", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@portal/server/widget-auth/exchange")
+    >();
+  return { ...actual, verifyWidgetProviderCredential: mocks.verifyCredential };
+});
 
 vi.mock("@portal/server/widget-auth/rate-limit", () => ({
   widgetAuthRateLimit: () => null,
@@ -50,17 +60,45 @@ vi.mock("@portal/server/bff/failures", () => ({
 import { POST } from "./route";
 
 function request(body: unknown): Request {
-  return new Request("https://portal.aomi.dev/api/auth/widget/telegram/exchange", {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      origin: "https://telegram-mini.aomi.dev",
+  return new Request(
+    "https://portal.aomi.dev/api/auth/widget/telegram/exchange",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        origin: "https://telegram-mini.aomi.dev",
+      },
+      body: JSON.stringify(body),
     },
-    body: JSON.stringify(body),
-  });
+  );
 }
 
 const DM_THREAD_ID = "0b9c1f2e-4d3a-4c5b-8e7f-1a2b3c4d5e6f";
+
+const EVM_WALLET = {
+  provider: "para",
+  providerWalletId: "para-evm",
+  family: "evm",
+  address: "0x1111111111111111111111111111111111111111",
+  chainScope: null,
+};
+const SVM_WALLET = {
+  provider: "para",
+  providerWalletId: "para-svm",
+  family: "svm",
+  address: "53GfEkka7UYR9KsM6ePWSNfbW678grShT41uZMjXAvoL",
+  chainScope: null,
+};
+
+function exchange(overrides: Record<string, unknown> = {}): Request {
+  return request({
+    bot_id: "123",
+    init_data: "signed-init-data",
+    session_id: DM_THREAD_ID,
+    credential: { provider: "para", provider_token: "credential" },
+    ...overrides,
+  });
+}
 
 describe("Telegram Para exchange", () => {
   beforeEach(() => {
@@ -82,6 +120,10 @@ describe("Telegram Para exchange", () => {
         subject: "para-user",
         walletAttestations: [],
       },
+    });
+    mocks.resolveWallets.mockResolvedValue({
+      status: "attested",
+      wallets: [EVM_WALLET, SVM_WALLET],
     });
     mocks.linkIdentity.mockResolvedValue({
       status: "linked",
@@ -160,5 +202,121 @@ describe("Telegram Para exchange", () => {
     });
     expect(mocks.claimOwner).not.toHaveBeenCalled();
     expect(mocks.issueSession).not.toHaveBeenCalled();
+  });
+  it("links the wallets Para's server API attests, not the ones the JWT claims", async () => {
+    // The Para session JWT is a client-held token: a forged `wallets` claim
+    // must never reach the canonical link. Only the server-side API answer,
+    // fetched with `PARA_API_SECRET_KEY`, may become a `public_keys` row.
+    mocks.verifyCredential.mockResolvedValue({
+      descriptor: { id: "para", policy: { subjectIsEnvironmentGlobal: true } },
+      identity: {
+        provider: "para",
+        issuerEnvironment: "beta",
+        tenantId: "para",
+        subject: "para-user",
+        email: { value: "user@example.com", verified: true },
+        loginIdentifier: { type: "telegram", value: "1234567890" },
+        walletAttestations: [
+          {
+            provider: "para",
+            providerWalletId: "forged",
+            family: "evm",
+            address: "0x9999999999999999999999999999999999999999",
+            chainScope: null,
+          },
+        ],
+      },
+    });
+
+    const response = await POST(exchange());
+
+    expect(response.status).toBe(200);
+    expect(mocks.resolveWallets).toHaveBeenCalledWith({
+      provider: "para",
+      subject: "para-user",
+      email: "user@example.com",
+      loginIdentifier: { type: "telegram", value: "1234567890" },
+    });
+    expect(mocks.linkIdentity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "canonical-user",
+        wallets: [EVM_WALLET, SVM_WALLET],
+      }),
+    );
+  });
+
+  it("refuses the exchange when Para attests no embedded wallet", async () => {
+    mocks.resolveWallets.mockResolvedValue({ status: "attested", wallets: [] });
+
+    const response = await POST(exchange());
+
+    expect(response.status).toBe(422);
+    await expect(response.json()).resolves.toEqual({
+      error: "provider_hosted_wallet_missing",
+    });
+    expect(mocks.linkIdentity).not.toHaveBeenCalled();
+    expect(mocks.issueSession).not.toHaveBeenCalled();
+  });
+
+  it("refuses the exchange when the Para API is unavailable", async () => {
+    mocks.resolveWallets.mockResolvedValue({
+      status: "unavailable",
+      error: new Error("para down"),
+    });
+
+    const response = await POST(exchange());
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: "provider_wallets_unavailable",
+    });
+    expect(mocks.linkIdentity).not.toHaveBeenCalled();
+    expect(mocks.issueSession).not.toHaveBeenCalled();
+  });
+
+  it("refuses the exchange when no Para server secret is configured", async () => {
+    mocks.resolveWallets.mockResolvedValue({ status: "unconfigured" });
+
+    const response = await POST(exchange());
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: "provider_wallets_unconfigured",
+    });
+    expect(mocks.linkIdentity).not.toHaveBeenCalled();
+    expect(mocks.issueSession).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when a wallet already belongs to another canonical user", async () => {
+    mocks.linkIdentity.mockResolvedValue({
+      status: "conflict",
+      reason: "already_linked_to_another_account",
+      signalType: "wallet",
+    });
+
+    const response = await POST(exchange());
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      status: "conflict",
+      reason: "already_linked_to_another_account",
+      signalType: "wallet",
+      error: "already_linked_to_another_account",
+    });
+    expect(mocks.issueSession).not.toHaveBeenCalled();
+  });
+
+  it("tops up a missing wallet on a retry with the identity already linked", async () => {
+    // The identity link is idempotent, so a user who linked Para before this
+    // route synced wallets gets the wallet on the next Open Para — no manual
+    // unlink, no new Telegram session.
+    await POST(exchange());
+    const response = await POST(exchange());
+
+    expect(response.status).toBe(200);
+    expect(mocks.linkIdentity).toHaveBeenCalledTimes(2);
+    for (const call of mocks.linkIdentity.mock.calls) {
+      expect(call[0]).toMatchObject({ wallets: [EVM_WALLET, SVM_WALLET] });
+    }
   });
 });

--- a/apps/portal/src/app/api/auth/widget/telegram/exchange/route.ts
+++ b/apps/portal/src/app/api/auth/widget/telegram/exchange/route.ts
@@ -8,7 +8,10 @@ import {
   requireWidgetOrigin,
   WidgetAuthError,
 } from "@aomi-labs/account/widget-auth";
-import { verifyWidgetProviderCredential } from "@portal/server/widget-auth/exchange";
+import {
+  requireAttestedProviderWallets,
+  verifyWidgetProviderCredential,
+} from "@portal/server/widget-auth/exchange";
 import { widgetAuthRateLimit } from "@portal/server/widget-auth/rate-limit";
 import {
   widgetPreflight,
@@ -31,7 +34,8 @@ type TelegramParaExchange = {
   session_id?: unknown;
 };
 
-const DM_THREAD_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const DM_THREAD_ID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 function requiredString(value: unknown, maxLength: number): string | null {
   if (typeof value !== "string") return null;
@@ -89,10 +93,18 @@ export const POST = widgetRoute(async (request: Request) => {
   if (descriptor.id !== "para" || identity.provider !== "para") {
     throw new WidgetAuthError("provider_not_enabled", 400);
   }
+  // A Para session JWT proves the human, never a wallet. Ask Para's own API,
+  // with the server-held secret, which embedded wallets it custodies for this
+  // verified subject, and hand them to the canonical link so identity, the
+  // cross-account wallet conflict check and the `public_keys` rows are all
+  // decided in one transaction. Fetching before the link keeps a provider
+  // outage from leaving a linked identity with no signer behind it.
+  const wallets = await requireAttestedProviderWallets(identity);
   const resolution = await linkVerifiedProviderIdentityForUser({
     userId,
     identity,
     policy: descriptor.policy,
+    wallets,
   });
   if (resolution.status === "conflict") {
     return Response.json(

--- a/apps/portal/src/server/widget-auth/exchange.test.ts
+++ b/apps/portal/src/server/widget-auth/exchange.test.ts
@@ -1,0 +1,156 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WidgetAuthError } from "@aomi-labs/account/widget-auth";
+import type { VerifiedProviderIdentity } from "@aomi-labs/account/providers";
+
+import { requireAttestedProviderWallets } from "./exchange";
+
+// This suite drives the real chain — descriptor identity → attester registry →
+// Para's REST wallet list — with only `fetch` and the environment stubbed, so
+// it fails if any seam between them is miswired. The route tests above it mock
+// the lookup itself and cover the failure-code mapping.
+
+const PARA_WALLETS_URL = "https://para.test/v1/wallets";
+const EVM = "0x1111111111111111111111111111111111111111";
+const SOL = "53GfEkka7UYR9KsM6ePWSNfbW678grShT41uZMjXAvoL";
+
+const identity: VerifiedProviderIdentity = {
+  provider: "para",
+  issuerEnvironment: "para:beta",
+  tenantId: "para-project",
+  subject: "d5358219-38d3-4650-91a8-e338131d1c5e",
+  expiresAt: 1_900_000_300,
+  email: { value: "alice@example.com", verified: true },
+  loginIdentifier: { type: "email", value: "alice@example.com" },
+  walletAttestations: [],
+  metadata: {},
+};
+
+function stubParaWallets(
+  handler: (url: URL, init?: RequestInit) => Response,
+): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn(async (input: URL | string, init?: RequestInit) =>
+    handler(new URL(String(input)), init),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+describe("requireAttestedProviderWallets", () => {
+  beforeEach(() => {
+    vi.stubEnv("PARA_API_SECRET_KEY", "sk_para_staging");
+    vi.stubEnv("PARA_API_BASE_URL", PARA_WALLETS_URL);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("attests the EVM and Solana embedded wallets Para holds for the login handle", async () => {
+    const fetchMock = stubParaWallets((url) => {
+      expect(url.origin + url.pathname).toBe(PARA_WALLETS_URL);
+      expect(url.searchParams.get("userIdentifier")).toBe("alice@example.com");
+      expect(url.searchParams.get("userIdentifierType")).toBe("EMAIL");
+      return Response.json({
+        data: [
+          {
+            id: "para-evm",
+            address: EVM,
+            type: "EVM",
+            scheme: "DKLS",
+            status: "ready",
+          },
+          {
+            id: "para-svm",
+            address: SOL,
+            type: "SOLANA",
+            scheme: "ED25519",
+            status: "ready",
+          },
+        ],
+        pagination: { cursor: null, hasMore: false },
+      });
+    });
+
+    await expect(requireAttestedProviderWallets(identity)).resolves.toEqual([
+      {
+        provider: "para",
+        providerWalletId: "para-evm",
+        family: "evm",
+        address: EVM,
+        chainScope: null,
+      },
+      {
+        provider: "para",
+        providerWalletId: "para-svm",
+        family: "svm",
+        address: SOL,
+        chainScope: null,
+      },
+    ]);
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
+      headers: { "X-API-Key": "sk_para_staging" },
+    });
+  });
+
+  it("reports a Para account with no embedded wallet instead of linking nothing", async () => {
+    stubParaWallets(() =>
+      Response.json({
+        // An imported/external wallet is not Para-custodied: it cannot back
+        // hosted signing, so an answer containing only those is "no wallet".
+        data: [
+          { id: "para-ext", address: EVM, type: "EVM", scheme: "EXTERNAL" },
+        ],
+        pagination: { cursor: null, hasMore: false },
+      }),
+    );
+
+    await expect(
+      requireAttestedProviderWallets(identity),
+    ).rejects.toMatchObject({
+      code: "provider_hosted_wallet_missing",
+      status: 422,
+    });
+  });
+
+  it("fails closed, without falling back to token claims, when Para is down", async () => {
+    stubParaWallets(() => new Response("nope", { status: 500 }));
+
+    await expect(
+      requireAttestedProviderWallets({
+        ...identity,
+        // A forged wallet claim inside the session JWT must not rescue a failed
+        // server-side attestation.
+        walletAttestations: [
+          {
+            provider: "para",
+            providerWalletId: "forged",
+            family: "evm",
+            address: EVM,
+            chainScope: null,
+          },
+        ],
+      }),
+    ).rejects.toMatchObject({
+      code: "provider_wallets_unavailable",
+      status: 503,
+    });
+  });
+
+  it("fails closed when the deployment has no Para server secret", async () => {
+    vi.stubEnv("PARA_API_SECRET_KEY", "");
+    const fetchMock = stubParaWallets(() => Response.json({ data: [] }));
+
+    const error = await requireAttestedProviderWallets(identity).catch(
+      (thrown: unknown) => thrown,
+    );
+
+    expect(error).toBeInstanceOf(WidgetAuthError);
+    expect(error).toMatchObject({
+      code: "provider_wallets_unconfigured",
+      status: 503,
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/portal/src/server/widget-auth/exchange.ts
+++ b/apps/portal/src/server/widget-auth/exchange.ts
@@ -1,6 +1,8 @@
+import { resolveAttestedProviderWallets } from "@aomi-labs/account/account";
 import {
   getWidgetProvider,
   widgetCredentialWireSchema,
+  type AttestedWallet,
   type VerifiedProviderIdentity,
   type WidgetProviderDescriptor,
 } from "@aomi-labs/account/providers";
@@ -35,4 +37,46 @@ export async function verifyWidgetProviderCredential(body: unknown): Promise<{
     keyId: credential.data.key_id,
   });
   return { descriptor, identity };
+}
+
+/**
+ * Resolve the wallets a provider's own server-side API attests for a verified
+ * subject, for flows that cannot function without a hosted wallet.
+ *
+ * A widget credential proves who the human is, nothing more: every widget
+ * descriptor deliberately returns `walletAttestations: []` because the wallet
+ * arrays inside a provider session token are client-supplied claims. So the
+ * only way a provider-custodied wallet may become a canonical `public_keys`
+ * row is this call, made with the server's own provider API secret.
+ *
+ * Each failure keeps its own code so a caller (and the Mini App reading the
+ * response) can tell them apart, and none of them fall back to the token's
+ * wallet claims:
+ * - `provider_wallets_unconfigured` (503) — no server API secret for this
+ *   provider in this environment; nothing was asked and nothing is known.
+ * - `provider_wallets_unavailable` (503) — the provider API call failed;
+ *   transient, and retrying the exchange is the fix.
+ * - `provider_hosted_wallet_missing` (422) — the provider answered, and this
+ *   user owns no embedded/MPC wallet. External/imported wallets are filtered
+ *   out upstream, so they never satisfy this.
+ */
+export async function requireAttestedProviderWallets(
+  identity: VerifiedProviderIdentity,
+): Promise<AttestedWallet[]> {
+  const resolution = await resolveAttestedProviderWallets({
+    provider: identity.provider,
+    subject: identity.subject,
+    email: identity.email?.value,
+    loginIdentifier: identity.loginIdentifier,
+  });
+  if (resolution.status === "unconfigured") {
+    throw new WidgetAuthError("provider_wallets_unconfigured", 503);
+  }
+  if (resolution.status === "unavailable") {
+    throw new WidgetAuthError("provider_wallets_unavailable", 503);
+  }
+  if (!resolution.wallets.length) {
+    throw new WidgetAuthError("provider_hosted_wallet_missing", 422);
+  }
+  return resolution.wallets;
 }

--- a/apps/telegram/src/app/page.tsx
+++ b/apps/telegram/src/app/page.tsx
@@ -28,7 +28,11 @@ export default function Home() {
   if (launch.status === "loading") message = "Opening Para…";
   if (launch.status === "error") message = "Open this page from Telegram.";
   if (account.status === "loading") message = "Linking your Aomi account…";
-  if (account.status === "error") message = "Could not link your account.";
+  if (account.status === "error") {
+    message = account.error
+      ? `Could not link your account (${account.error}).`
+      : "Could not link your account.";
+  }
   if (account.status === "ready" && !permission.target) {
     message = "Para is linked.";
   }

--- a/apps/telegram/src/hooks/use-canonical-account.ts
+++ b/apps/telegram/src/hooks/use-canonical-account.ts
@@ -22,6 +22,7 @@ type CanonicalAccountState = {
 
 type TelegramExchangeResponse = {
   access_token?: unknown;
+  error?: unknown;
   expires_at?: unknown;
 };
 
@@ -70,7 +71,15 @@ function telegramParaAdapter(input: {
         typeof body?.access_token !== "string" ||
         typeof body.expires_at !== "number"
       ) {
-        throw new Error(`telegram_para_exchange_failed_${response.status}`);
+        // Keep the route's own failure code: a hosted-wallet exchange can fail
+        // for reasons the status alone cannot name (Para attests no embedded
+        // wallet, the Para API is down, no server secret is configured), and
+        // the person staring at the Mini App needs to see which one it was.
+        throw new Error(
+          typeof body?.error === "string" && body.error
+            ? `telegram_para_exchange_failed_${response.status}_${body.error}`
+            : `telegram_para_exchange_failed_${response.status}`,
+        );
       }
       return {
         accessToken: body.access_token,

--- a/packages/account/src/account.ts
+++ b/packages/account/src/account.ts
@@ -16,6 +16,7 @@ export {
   linkProviderIdentity,
   renameAuthIdentity,
   renameWallet,
+  resolveAttestedProviderWallets,
   resolveSignal,
   syncProviderAttestedWallets,
   syncProviderWallets,
@@ -26,6 +27,7 @@ export {
   unlinkWallet,
   updateAccountProfile,
   upsertVerifiedWallet,
+  type AttestedProviderWallets,
   type DeactivateAomiAccountResult,
 } from "./service/account-service";
 
@@ -69,6 +71,7 @@ export {
 export type {
   AttestedWallet,
   AttestedWalletProvider,
+  ProviderLoginIdentifier,
   WalletAttestationLogger,
   WalletAttester,
   WalletAttesterRegistry,

--- a/packages/account/src/providers/default-wallet-attesters.ts
+++ b/packages/account/src/providers/default-wallet-attesters.ts
@@ -1,7 +1,14 @@
 import { readAccountAuthEnv, type AccountAuthEnv } from "../better-auth/env";
-import { listParaWalletsForUser } from "./para";
+import {
+  listParaWalletsForUser,
+  paraUserIdentifierType,
+  type ParaUserIdentifierType,
+} from "./para";
 import { listPrivyWalletsForUser } from "./privy";
-import type { WalletAttesterRegistry } from "./wallet-attestation";
+import type {
+  ProviderLoginIdentifier,
+  WalletAttesterRegistry,
+} from "./wallet-attestation";
 
 export function createDefaultWalletAttesters(
   env: AccountAuthEnv = readAccountAuthEnv(),
@@ -21,13 +28,47 @@ export function createDefaultWalletAttesters(
 
   const paraApiKey = env.paraApiKey;
   if (paraApiKey) {
-    attesters.para = ({ subject }) =>
-      listParaWalletsForUser({
-        apiKey: paraApiKey,
-        userIdentifier: subject,
-        userIdentifierType: "CUSTOM_ID",
-      });
+    attesters.para = async ({ subject, email, loginIdentifier }) => {
+      const lookup = paraWalletLookup({ subject, email, loginIdentifier });
+      // No lookup key means Para cannot be asked about this user at all (an
+      // `externalWallet` login, say). Answering `null` keeps that apart from
+      // "Para says this user has no embedded wallet" so a caller that requires
+      // a hosted wallet fails closed instead of inferring an empty set.
+      if (!lookup) return null;
+      return listParaWalletsForUser({ apiKey: paraApiKey, ...lookup });
+    };
   }
 
   return attesters;
+}
+
+/**
+ * Pick the `userIdentifier` / `userIdentifierType` pair Para's wallet API is
+ * keyed by. That API is partner-scoped and indexed by the user's login handle;
+ * its `userIdentifierType` enum has no member naming a Para user id, so the
+ * session token's `sub` cannot be used as a lookup key. The verified login
+ * identifier is the right key, a verified email is the fallback for a token
+ * that omits it, and `CUSTOM_ID` on the subject stays last for partners that
+ * pregenerate wallets under their own ids.
+ */
+function paraWalletLookup(input: {
+  subject: string;
+  email?: string | null;
+  loginIdentifier?: ProviderLoginIdentifier | null;
+}): {
+  userIdentifier: string;
+  userIdentifierType: ParaUserIdentifierType;
+} | null {
+  const identifierType = paraUserIdentifierType(input.loginIdentifier?.type);
+  if (identifierType && input.loginIdentifier?.value) {
+    return {
+      userIdentifier: input.loginIdentifier.value,
+      userIdentifierType: identifierType,
+    };
+  }
+  if (input.loginIdentifier) return null;
+  if (input.email) {
+    return { userIdentifier: input.email, userIdentifierType: "EMAIL" };
+  }
+  return { userIdentifier: input.subject, userIdentifierType: "CUSTOM_ID" };
 }

--- a/packages/account/src/providers/descriptor.ts
+++ b/packages/account/src/providers/descriptor.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
-import type { AttestedWallet } from "./wallet-attestation";
+import type {
+  AttestedWallet,
+  ProviderLoginIdentifier,
+} from "./wallet-attestation";
 
 export type VerifiedProviderIdentity = {
   provider: string;
@@ -8,6 +11,9 @@ export type VerifiedProviderIdentity = {
   subject: string;
   expiresAt: number;
   email?: { value: string; verified: boolean };
+  /** The provider-native login handle this token attests, when the provider
+   *  publishes one. Wallet attestation is keyed by it. */
+  loginIdentifier?: ProviderLoginIdentifier;
   walletAttestations: AttestedWallet[];
   metadata: Record<string, unknown>;
 };

--- a/packages/account/src/providers/index.ts
+++ b/packages/account/src/providers/index.ts
@@ -54,9 +54,11 @@ export {
 export {
   createParaWidgetDescriptor,
   listParaWalletsForUser,
+  paraUserIdentifierType,
   paraWidgetDescriptor,
   verifyParaJwt,
   verifyParaWidgetCredential,
+  type ParaUserIdentifierType,
 } from "./para";
 
 export { privyWidgetDescriptor } from "./privy";
@@ -65,6 +67,7 @@ export {
   validWalletAddress,
   type AttestedWallet,
   type AttestedWalletProvider,
+  type ProviderLoginIdentifier,
   type WalletAttestationLogger,
   type WalletAttester,
   type WalletAttesterRegistry,

--- a/packages/account/src/providers/para.ts
+++ b/packages/account/src/providers/para.ts
@@ -5,7 +5,11 @@ import type {
   VerifiedProviderIdentity,
   WidgetProviderDescriptor,
 } from "./descriptor";
-import { validWalletAddress, type AttestedWallet } from "./wallet-attestation";
+import {
+  validWalletAddress,
+  type AttestedWallet,
+  type ProviderLoginIdentifier,
+} from "./wallet-attestation";
 
 type ParaClaims = {
   sub?: string;
@@ -209,6 +213,7 @@ export async function verifyParaWidgetCredential(input: {
     subject,
     expiresAt,
     email: email ? { value: email, verified: emailVerified } : undefined,
+    loginIdentifier: paraLoginIdentifier(nested),
     walletAttestations: [],
     metadata: {
       audience,
@@ -218,13 +223,63 @@ export async function verifyParaWidgetCredential(input: {
   };
 }
 
+/** The login handle Para verified for this session (`data.authType` +
+ *  `data.identifier`). Para's wallet API is partner-scoped and keyed by this
+ *  pair — the JWT `sub` is a Para user id and no `userIdentifierType` names
+ *  it — so this is what makes a server-side wallet attestation possible. */
+function paraLoginIdentifier(
+  nested: Record<string, unknown> | undefined,
+): ProviderLoginIdentifier | undefined {
+  const type = stringClaim(nested?.authType);
+  const value = stringClaim(nested?.identifier);
+  return type && value ? { type, value } : undefined;
+}
+
+export type ParaUserIdentifierType =
+  | "EMAIL"
+  | "PHONE"
+  | "CUSTOM_ID"
+  | "GUEST_ID"
+  | "DISCORD"
+  | "TWITTER"
+  | "TELEGRAM"
+  | "FARCASTER";
+
+/** Map a Para `authType` onto the `userIdentifierType` its REST wallet API
+ *  accepts. Unmapped types — `externalWallet` above all — have no REST
+ *  equivalent: an external wallet is not Para-custodied, so there is nothing
+ *  to attest and callers must fail closed rather than guess an identifier. */
+export function paraUserIdentifierType(
+  authType: string | undefined | null,
+): ParaUserIdentifierType | null {
+  switch (authType?.trim().toLowerCase()) {
+    case "email":
+      return "EMAIL";
+    case "phone":
+      return "PHONE";
+    case "telegram":
+      return "TELEGRAM";
+    case "farcaster":
+      return "FARCASTER";
+    case "discord":
+      return "DISCORD";
+    case "twitter":
+    case "x":
+      return "TWITTER";
+    case "guest":
+      return "GUEST_ID";
+    default:
+      return null;
+  }
+}
+
 /** Fetch every wallet Para attests is owned by the user identified by
  * `userIdentifier` / `userIdentifierType`. Filters to embedded/MPC wallets
  * Para custody-shares; external imports must still go through SIWE/SIWS. */
 export async function listParaWalletsForUser(input: {
   apiKey: string;
   userIdentifier: string;
-  userIdentifierType?: "CUSTOM_ID" | "EMAIL" | "PHONE";
+  userIdentifierType?: ParaUserIdentifierType;
 }): Promise<AttestedWallet[]> {
   const headers: Record<string, string> = {
     "X-API-Key": input.apiKey,
@@ -273,6 +328,7 @@ interface ParaWalletRow {
   address?: string;
   type?: string;
   scheme?: string;
+  status?: string;
 }
 
 function normalizeParaWalletRow(row: ParaWalletRow): AttestedWallet | null {
@@ -281,6 +337,10 @@ function normalizeParaWalletRow(row: ParaWalletRow): AttestedWallet | null {
   if (!row.id || typeof row.id !== "string") return null;
   if (!validWalletAddress(family, row.address)) return null;
   if (!isEmbeddedScheme(row.scheme)) return null;
+  // Para returns an address before key generation finishes and says to read
+  // `status`, not the presence of `address`. Linking a `creating` wallet would
+  // put a not-yet-signable key in `public_keys`.
+  if (row.status && row.status.toLowerCase() !== "ready") return null;
 
   return {
     provider: "para",
@@ -304,11 +364,21 @@ function paraWalletFamily(type: string | undefined): WalletFamily | null {
 }
 
 /** MPC / embedded custody schemes Para uses for non-extractable embedded
- * wallets. Anything else (or missing) is treated as non-custodied. */
+ * wallets. `DKLS` and `CGGMP` cover EVM and Cosmos, `ED25519` covers Solana and
+ * Stellar — Para's documented `scheme` enum is exactly these three, and every
+ * one of them is a Para-held key share. `FROST` and any other `*MPC*` name stay
+ * accepted for forward compatibility. Anything else — or a missing scheme — is
+ * treated as non-custodied and never becomes a `public_keys` row. */
 function isEmbeddedScheme(scheme: string | undefined): boolean {
   if (!scheme) return false;
   const upper = scheme.toUpperCase();
-  return upper === "DKLS" || upper === "FROST" || upper.includes("MPC");
+  return (
+    upper === "DKLS" ||
+    upper === "CGGMP" ||
+    upper === "ED25519" ||
+    upper === "FROST" ||
+    upper.includes("MPC")
+  );
 }
 
 function getJwks(url: string): ReturnType<typeof createRemoteJWKSet> {

--- a/packages/account/src/providers/wallet-attestation.ts
+++ b/packages/account/src/providers/wallet-attestation.ts
@@ -2,10 +2,22 @@ import type { WalletFamily } from "../types";
 
 export type AttestedWalletProvider = "privy" | "para" | (string & {});
 
+/** The login handle a provider verified for this session, verbatim: Para's
+ *  `data.authType` / `data.identifier`. It is what a provider's own wallet API
+ *  is keyed by — those APIs are partner-scoped and look wallets up by the
+ *  user's login handle, not by the session token's subject — so an attester
+ *  that has one can ask a question the subject alone cannot express. */
+export type ProviderLoginIdentifier = {
+  /** Provider-native identifier type, e.g. Para `email` / `telegram`. */
+  type: string;
+  value: string;
+};
+
 export type WalletAttester = (input: {
   /** Verified provider-token subject. */
   subject: string;
   email?: string | null;
+  loginIdentifier?: ProviderLoginIdentifier | null;
 }) => Promise<AttestedWallet[] | null>;
 
 export type WalletAttesterRegistry = Record<string, WalletAttester | undefined>;

--- a/packages/account/src/service/account-service.ts
+++ b/packages/account/src/service/account-service.ts
@@ -36,6 +36,7 @@ import { createDefaultWalletAttesters } from "../providers/default-wallet-attest
 import {
   type AttestedWallet,
   type AttestedWalletProvider,
+  type ProviderLoginIdentifier,
   type WalletAttestationLogger,
   type WalletAttesterRegistry,
 } from "../providers/wallet-attestation";
@@ -768,42 +769,77 @@ export async function syncProviderWallets(input: {
   return input.attested.length > 0 ? { status: "linked" } : { status: "noop" };
 }
 
-/** Fetch attested embedded wallets for a verified provider subject using the
- *  server-side provider API. Returns `null` when the provider's REST
- *  credentials aren't configured (graceful degradation: callers fall back to
- *  identity-only behavior) or when the fetch fails (so the caller can skip
- *  the sync without revoking live rows). */
-export async function fetchAttestedProviderWallets(input: {
+/** Outcome of a server-side attested-wallet lookup. The three cases are kept
+ *  apart because they mean different things to a caller that requires a hosted
+ *  wallet: `attested` is the provider's answer (an empty list is an answer —
+ *  this user owns no embedded wallet), while `unconfigured` and `unavailable`
+ *  mean no answer was obtained at all and nothing may be inferred from them. */
+export type AttestedProviderWallets =
+  | { status: "attested"; wallets: AttestedWallet[] }
+  | { status: "unconfigured" }
+  | { status: "unavailable"; error: unknown };
+
+/** Ask the provider's server-side API which embedded wallets it attests for a
+ *  verified subject. This is the only trusted source of provider wallet
+ *  ownership: wallet arrays inside a provider session token are self-asserted
+ *  client claims and never reach this path. */
+export async function resolveAttestedProviderWallets(input: {
   provider: AttestedWalletProvider;
   /** Verified token subject: `did:privy:…` for Privy, Para user id for Para. */
   subject: string;
   email?: string | null;
+  /** The provider-native login handle the token attests, when it carries one.
+   *  Para's wallet API is keyed by it rather than by the subject. */
+  loginIdentifier?: ProviderLoginIdentifier | null;
   attesters?: WalletAttesterRegistry;
   logger?: WalletAttestationLogger;
-}): Promise<AttestedWallet[] | null> {
+}): Promise<AttestedProviderWallets> {
   const attester = (input.attesters ?? createDefaultWalletAttesters())[
     input.provider
   ];
-  if (!attester) return null;
+  if (!attester) return { status: "unconfigured" };
   try {
     const wallets = await attester({
       subject: input.subject,
       email: input.email,
+      loginIdentifier: input.loginIdentifier,
     });
-    return (
-      wallets?.map((wallet) => ({
+    if (!wallets) return { status: "unavailable", error: null };
+    return {
+      status: "attested",
+      wallets: wallets.map((wallet) => ({
         ...wallet,
         provider: input.provider,
-      })) ?? null
-    );
+      })),
+    };
   } catch (error) {
     observeAccountInternalFailure({ kind: "provider_wallets", error });
     input.logger?.warn(
       `syncProviderWallets: failed to list ${input.provider} wallets for ${input.subject}`,
       error,
     );
-    return null;
+    return { status: "unavailable", error };
   }
+}
+
+/** Fetch attested embedded wallets for a verified provider subject using the
+ *  server-side provider API. Returns `null` when the provider's REST
+ *  credentials aren't configured (graceful degradation: callers fall back to
+ *  identity-only behavior) or when the fetch fails (so the caller can skip
+ *  the sync without revoking live rows). Callers that must not confuse those
+ *  two with "the provider attests no wallet" use
+ *  {@link resolveAttestedProviderWallets} instead. */
+export async function fetchAttestedProviderWallets(input: {
+  provider: AttestedWalletProvider;
+  /** Verified token subject: `did:privy:…` for Privy, Para user id for Para. */
+  subject: string;
+  email?: string | null;
+  loginIdentifier?: ProviderLoginIdentifier | null;
+  attesters?: WalletAttesterRegistry;
+  logger?: WalletAttestationLogger;
+}): Promise<AttestedWallet[] | null> {
+  const resolution = await resolveAttestedProviderWallets(input);
+  return resolution.status === "attested" ? resolution.wallets : null;
 }
 
 /** Best-effort embedded-wallet sync after a successful provider identity link.

--- a/packages/account/test/para.test.ts
+++ b/packages/account/test/para.test.ts
@@ -6,6 +6,7 @@ import nestedFixture from "./fixtures/para-widget-nested.json";
 import topLevelFixture from "./fixtures/para-widget-top-level.json";
 import {
   createParaWidgetDescriptor,
+  paraUserIdentifierType,
   verifyParaJwt,
   verifyParaWidgetCredential,
 } from "../src/providers/para";
@@ -194,5 +195,56 @@ describe("Para widget credentials", () => {
     await expect(verify(malformedWallets, "STAGING")).rejects.toThrow(
       "invalid_provider_environment",
     );
+  });
+});
+
+describe("Para login identifiers", () => {
+  it("surfaces the verified login handle a wallet lookup is keyed by", async () => {
+    // Para's wallet API is partner-scoped and indexed by the login handle, and
+    // its `userIdentifierType` enum has no member for a Para user id — so the
+    // `sub` cannot key a lookup and `data.authType` / `data.identifier` must
+    // survive verification.
+    const { privateKey, publicKey } = await generateKeyPair("RS256");
+    const jwk = await exportJWK(publicKey);
+    const jwksUrl = "https://para.example/.well-known/identifier-jwks.json";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({ keys: [{ ...jwk, kid: "id-kid", alg: "RS256" }] }),
+      ),
+    );
+    const now = 1_900_000_000;
+    const token = await new SignJWT({
+      data: { authType: "telegram", identifier: "1234567890" },
+    })
+      .setProtectedHeader({ alg: "RS256", kid: "id-kid" })
+      .setSubject("para-user-telegram")
+      .setAudience("para-project")
+      .setIssuedAt(now)
+      .setExpirationTime(now + 300)
+      .sign(privateKey);
+
+    const identity = await verifyParaWidgetCredential({
+      environment: "BETA",
+      providerToken: token,
+      jwksUrls: { BETA: jwksUrl, PROD: jwksUrl },
+      now: new Date(now * 1000),
+    });
+
+    expect(identity.loginIdentifier).toEqual({
+      type: "telegram",
+      value: "1234567890",
+    });
+    expect(identity.walletAttestations).toEqual([]);
+  });
+
+  it("maps Para auth types onto the REST identifier enum and refuses the rest", () => {
+    expect(paraUserIdentifierType("email")).toBe("EMAIL");
+    expect(paraUserIdentifierType("Telegram")).toBe("TELEGRAM");
+    expect(paraUserIdentifierType("x")).toBe("TWITTER");
+    // An external wallet is not Para-custodied, so there is nothing to attest
+    // and no identifier type that would name it.
+    expect(paraUserIdentifierType("externalWallet")).toBeNull();
+    expect(paraUserIdentifierType(undefined)).toBeNull();
   });
 });

--- a/packages/account/test/provider-wallets.test.ts
+++ b/packages/account/test/provider-wallets.test.ts
@@ -275,6 +275,76 @@ describe("listParaWalletsForUser", () => {
     ]);
   });
 
+  it("returns the schemes Para actually reports for embedded wallets", async () => {
+    // Para's documented `scheme` enum is DKLS | CGGMP | ED25519. A Solana
+    // embedded wallet comes back as ED25519, so a filter that only knew DKLS
+    // silently dropped every Solana signer.
+    mockFetch([
+      jsonResponse({
+        data: [
+          {
+            id: "p-evm",
+            address: EVM,
+            type: "EVM",
+            scheme: "CGGMP",
+            status: "ready",
+          },
+          {
+            id: "p-sol",
+            address: SOL,
+            type: "SOLANA",
+            scheme: "ED25519",
+            status: "ready",
+          },
+        ],
+        pagination: { cursor: null, hasMore: false },
+      }),
+    ]);
+
+    const result = await listParaWalletsForUser({
+      apiKey: "sk_x",
+      userIdentifier: "alice@example.com",
+      userIdentifierType: "EMAIL",
+    });
+
+    expect(result.map((w) => [w.providerWalletId, w.family])).toEqual([
+      ["p-evm", "evm"],
+      ["p-sol", "svm"],
+    ]);
+  });
+
+  it("skips a wallet whose key generation has not finished", async () => {
+    mockFetch([
+      jsonResponse({
+        data: [
+          {
+            id: "p-creating",
+            address: EVM,
+            type: "EVM",
+            scheme: "DKLS",
+            status: "creating",
+          },
+          {
+            id: "p-ready",
+            address: EVM2,
+            type: "EVM",
+            scheme: "DKLS",
+            status: "ready",
+          },
+        ],
+        pagination: { cursor: null, hasMore: false },
+      }),
+    ]);
+
+    const result = await listParaWalletsForUser({
+      apiKey: "sk_x",
+      userIdentifier: "alice@example.com",
+      userIdentifierType: "EMAIL",
+    });
+
+    expect(result.map((w) => w.providerWalletId)).toEqual(["p-ready"]);
+  });
+
   it("filters out wallets without a recognized embedded/MPC scheme", async () => {
     mockFetch([
       jsonResponse({

--- a/packages/account/test/wallet-attestation.test.ts
+++ b/packages/account/test/wallet-attestation.test.ts
@@ -10,6 +10,7 @@ import {
 import {
   fetchAttestedProviderWallets,
   mergeProviderWalletAttestations,
+  resolveAttestedProviderWallets,
 } from "../src/service/account-service";
 import { setAccountInternalFailureObserver } from "../src/observability";
 
@@ -106,6 +107,71 @@ describe("fetchAttestedProviderWallets", () => {
   });
 });
 
+describe("resolveAttestedProviderWallets", () => {
+  afterEach(() => setAccountInternalFailureObserver(undefined));
+
+  const wallets: AttestedWallet[] = [
+    {
+      provider: "custom",
+      providerWalletId: "w-1",
+      family: "evm",
+      address: EVM,
+      chainScope: null,
+    },
+  ];
+
+  it("reports what the provider attested", async () => {
+    await expect(
+      resolveAttestedProviderWallets({
+        provider: "custom",
+        subject: "provider-user",
+        attesters: { custom: async () => wallets },
+      }),
+    ).resolves.toEqual({ status: "attested", wallets });
+  });
+
+  // "the provider says this user owns no embedded wallet" is an answer, and a
+  // caller that requires a hosted wallet must be able to tell it apart from
+  // "we never got an answer" — the two collapse to `null` in the legacy
+  // `fetchAttestedProviderWallets` contract.
+  it("keeps an empty attestation distinct from no answer", async () => {
+    await expect(
+      resolveAttestedProviderWallets({
+        provider: "custom",
+        subject: "provider-user",
+        attesters: { custom: async () => [] },
+      }),
+    ).resolves.toEqual({ status: "attested", wallets: [] });
+
+    await expect(
+      resolveAttestedProviderWallets({
+        provider: "custom",
+        subject: "provider-user",
+        attesters: {},
+      }),
+    ).resolves.toEqual({ status: "unconfigured" });
+  });
+
+  it("reports a failed provider fetch as unavailable and observes it", async () => {
+    const error = new Error("provider down");
+    const observer = vi.fn();
+    setAccountInternalFailureObserver(observer);
+
+    await expect(
+      resolveAttestedProviderWallets({
+        provider: "custom",
+        subject: "provider-user",
+        attesters: {
+          custom: async () => {
+            throw error;
+          },
+        },
+      }),
+    ).resolves.toEqual({ status: "unavailable", error });
+    expect(observer).toHaveBeenCalledWith({ kind: "provider_wallets", error });
+  });
+});
+
 describe("mergeProviderWalletAttestations", () => {
   it("keeps provider API rows and fills missing token-attested wallets", () => {
     expect(
@@ -166,6 +232,71 @@ describe("mergeProviderWalletAttestations", () => {
         chainScope: null,
       },
     ]);
+  });
+});
+
+describe("the Para attester's lookup key", () => {
+  const paraEnv: AccountAuthEnv = { ...baseEnv, paraApiKey: "para-secret" };
+
+  function stubWalletApi(): ReturnType<typeof vi.fn> {
+    const fetchMock = vi.fn(async () =>
+      Response.json({ data: [], pagination: { cursor: null, hasMore: false } }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("asks Para by the verified login handle, not by the token subject", async () => {
+    // Para's `userIdentifierType` enum names login handles only; querying a
+    // Para user id as a CUSTOM_ID matches nothing, which is how a linked Para
+    // identity ended up with no hosted wallet behind it.
+    const fetchMock = stubWalletApi();
+
+    await createDefaultWalletAttesters(paraEnv).para?.({
+      subject: "d5358219-38d3-4650-91a8-e338131d1c5e",
+      email: "alice@example.com",
+      loginIdentifier: { type: "telegram", value: "1234567890" },
+    });
+
+    const url = new URL(String(fetchMock.mock.calls[0]?.[0]));
+    expect(url.searchParams.get("userIdentifier")).toBe("1234567890");
+    expect(url.searchParams.get("userIdentifierType")).toBe("TELEGRAM");
+  });
+
+  it("falls back to a verified email, then to a CUSTOM_ID subject", async () => {
+    const fetchMock = stubWalletApi();
+    const para = createDefaultWalletAttesters(paraEnv).para;
+
+    await para?.({ subject: "para-user", email: "alice@example.com" });
+    await para?.({ subject: "para-user" });
+
+    const [byEmail, bySubject] = fetchMock.mock.calls.map(
+      (call) => new URL(String(call[0])).searchParams,
+    );
+    expect(byEmail?.get("userIdentifier")).toBe("alice@example.com");
+    expect(byEmail?.get("userIdentifierType")).toBe("EMAIL");
+    expect(bySubject?.get("userIdentifier")).toBe("para-user");
+    expect(bySubject?.get("userIdentifierType")).toBe("CUSTOM_ID");
+  });
+
+  it("answers null — never an empty wallet set — for an unqueryable login", async () => {
+    // An `externalWallet` login has no Para-custodied wallet to attest and no
+    // identifier type that names it. Reporting "no answer" keeps a caller that
+    // requires a hosted wallet from reading this as "the user owns none".
+    const fetchMock = stubWalletApi();
+
+    await expect(
+      createDefaultWalletAttesters(paraEnv).para?.({
+        subject: "para-user",
+        loginIdentifier: {
+          type: "externalWallet",
+          value: "0xaD6b78193b78e23F9aBBB675734f4a2B3559598D",
+        },
+      }),
+    ).resolves.toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });
 

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -2,6 +2,66 @@
 
 ## Last Updated
 
+2026-09-10 — TELEGRAM × PARA HOSTED WALLETS NEVER REACHED `public_keys`
+  (working tree, uncommitted). The Mini App said "Para is linked" while the bot
+  still reported `Authority: not linked`: `/api/auth/widget/telegram/exchange`
+  linked the Para identity and stopped there. Every widget descriptor returns
+  `walletAttestations: []` on purpose (a session JWT's wallet arrays are client
+  claims), and no widget route ever ran the server-side attestation, so no
+  Para-custodied wallet became a canonical row. Fixed at three layers:
+  - `requireAttestedProviderWallets` (`apps/portal/src/server/widget-auth/exchange.ts`)
+    asks Para's own API with `PARA_API_SECRET_KEY` and hands the result to
+    `linkVerifiedProviderIdentityForUser({ wallets })` BEFORE the link, so
+    identity, the cross-account wallet conflict check and `public_keys` all
+    commit in one transaction and a provider outage cannot leave a linked
+    identity with no signer. Failure codes are distinct and never fall back to
+    token claims: `provider_wallets_unconfigured` (503, no server secret),
+    `provider_wallets_unavailable` (503, API failed), `provider_hosted_wallet_missing`
+    (422, Para attests no embedded wallet). `resolveAttestedProviderWallets`
+    (`packages/account/src/service/account-service.ts`) is the new
+    three-state lookup; `fetchAttestedProviderWallets` keeps its null contract
+    on top of it.
+  - THE LOOKUP KEY WAS WRONG, and this is what actually broke staging: Para's
+    `GET /v1/wallets` is partner-scoped and keyed by the LOGIN HANDLE, and its
+    `userIdentifierType` enum (EMAIL/PHONE/CUSTOM_ID/GUEST_ID/DISCORD/TWITTER/
+    TELEGRAM/FARCASTER) has no member naming a Para user id — so the old
+    `CUSTOM_ID`-on-`sub` attester could only ever return nothing (already
+    flagged in WIDGET-AUTH-INTEGRATION-PLAN.md:253). `verifyParaWidgetCredential`
+    now surfaces `loginIdentifier` (`data.authType` + `data.identifier`), which
+    threads through `WalletAttester` to `paraWalletLookup`: login handle first,
+    verified email second, `CUSTOM_ID`-on-subject last. An unmappable handle
+    (`externalWallet`) answers `null` — "no answer", not "no wallets".
+  - THE SCHEME FILTER WAS WRONG TOO: `isEmbeddedScheme` accepted only
+    DKLS/FROST/*MPC*, but Para's documented enum is DKLS | CGGMP | ED25519, so
+    every Solana embedded wallet (ED25519) was being dropped. Now accepts the
+    documented three plus the old tolerances, and skips `status: "creating"`
+    rows (Para returns an address before key generation finishes).
+  Mini App: the exchange's failure code now rides through
+  `use-canonical-account.ts` into the visible message, so a hosted-wallet
+  failure is diagnosable instead of a bare "Could not link your account."
+  Verified: root `vitest run` 1461 tests, portal 571, telegram 6, root
+  typecheck, portal `tsc` (after `rm -rf .next/dev/types` — the checked-out
+  `.next` carried stale route validators that fail typecheck on `main` too),
+  eslint clean. `apps/portal/src/server/widget-auth/exchange.test.ts` drives the
+  real identity → attester → REST chain with only `fetch` + env stubbed.
+  NOT DONE — needs a human: the live staging matrix cell
+  `Auto × Telegram × AA × Hosted` (deploy to chat-staging.aomi.dev, DM
+  `@hoodittest_bot`, `/wallet` → Open Para → Para login → `/wallet` → expect an
+  Authority address → `/permission`). Cannot be driven from here (Telegram
+  account + Para login). Preflight done: `PARA_API_SECRET_KEY` IS set on
+  chat-portal Preview; `PARA_API_BASE_URL` is not, so the beta default host
+  applies, which matches tg-mini-app (no `NEXT_PUBLIC_PARA_ENVIRONMENT` → BETA).
+  Pending decisions/known gaps:
+  - `/api/auth/widget/exchange` and `/v1/account/provider/exchange` (widget
+    principal branch) still link identity WITHOUT attested wallets — same defect,
+    deliberately left alone to keep this change on the Telegram cell.
+    `requireAttestedProviderWallets` is shared and ready for them, but the
+    browser widget would need a decision on whether a Para user with no hosted
+    wallet may still sign in (here it may not).
+  - `paraWalletsUrl()` is deployment-global while credentials carry a BETA/PROD
+    environment; a portal serving both would query the wrong Para host. Fine
+    today (staging is BETA-only), a hazard for the production rollout.
+
 2026-09-09 — TRANSACTION ROUTING SURFACES: FIX + TEST PROGRAM (branch
   `codex/wallet-routing-surfaces`, working tree, uncommitted; pairs with
   product-mono `cecilia/para-evm-envelope`). Review findings resolved:


### PR DESCRIPTION
## Summary
- resolve Telegram Para wallets only through Para’s server-side attestation API before canonical linking
- use the verified Para login identifier for wallet lookup and support Solana ED25519 hosted wallets
- expose explicit hosted-wallet exchange failures in the Telegram Mini App

## Verification
- `pnpm exec vitest run apps/portal/src/app/api/auth/widget/telegram/exchange/route.test.ts packages/account/test/para.test.ts packages/account/test/provider-wallets.test.ts packages/account/test/wallet-attestation.test.ts`
- `pnpm --filter portal exec vitest run src/server/widget-auth/exchange.test.ts`
- `pnpm exec eslint` on changed source files
- `pnpm --filter @aomi-labs/account type-check`
- `pnpm typecheck:portal`
- `pnpm typecheck:telegram`

## Staging acceptance
After deployment: Telegram `/wallet` → `Open Para` → login → `/wallet` must report the Para authority rather than `not linked`; then exercise `/permission` manual and mandate-backed hosted signing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791639719&installation_model_id=12362&pr_number=590&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F590&signature=30ae331b3925751e66f01ba0fce8433939d20e793b8c69f30f7e5e27e23a0df0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->