### PR TITLE
fix: provision Para wallet before Telegram exchange

### DIFF
--- a/apps/telegram/src/hooks/use-canonical-account.ts
+++ b/apps/telegram/src/hooks/use-canonical-account.ts
@@ -26,6 +26,42 @@ type TelegramExchangeResponse = {
   expires_at?: unknown;
 };
 
+type ParaWalletClient = {
+  createWalletPerType: (input: { types: ["EVM"] }) => Promise<unknown>;
+  getWalletsByType: (type: "EVM") => unknown[];
+};
+
+type WalletProvisionState =
+  | { status: "disconnected" | "provisioning" | "ready" }
+  | { error: string; status: "error" };
+
+// React can restart an effect while a connected Para client is still creating
+// its first wallet. Share that work so the account never gets two EVM wallets.
+const evmWalletProvisioning = new WeakMap<
+  ParaWalletClient,
+  Promise<void>
+>();
+
+async function ensureEvmWallet(client: ParaWalletClient): Promise<void> {
+  if (client.getWalletsByType("EVM").length > 0) return;
+
+  let provisioning = evmWalletProvisioning.get(client);
+  if (!provisioning) {
+    provisioning = client
+      .createWalletPerType({ types: ["EVM"] })
+      .then(() => {
+        if (client.getWalletsByType("EVM").length === 0) {
+          throw new Error("para_embedded_wallet_unavailable");
+        }
+      })
+      .finally(() => {
+        evmWalletProvisioning.delete(client);
+      });
+    evmWalletProvisioning.set(client, provisioning);
+  }
+  await provisioning;
+}
+
 function telegramParaAdapter(input: {
   getCredential: () => Promise<{
     keyId?: string;
@@ -95,14 +131,54 @@ export function useCanonicalAccount(
   const account = useAccount();
   const paraClient = useClient();
   const paraSubject = account.embedded.userId ?? paraClient?.userId ?? null;
+  const [walletProvision, setWalletProvision] = useState<WalletProvisionState>({
+    status: "disconnected",
+  });
   const [state, setState] = useState<Omit<CanonicalAccountState, "provider">>({
     error: null,
     status: "disconnected",
     userId: null,
   });
 
+  useEffect(() => {
+    if (!account.embedded.isConnected || !paraClient) {
+      queueMicrotask(() => setWalletProvision({ status: "disconnected" }));
+      return;
+    }
+
+    let active = true;
+    queueMicrotask(() => {
+      if (active) setWalletProvision({ status: "provisioning" });
+    });
+    void ensureEvmWallet(paraClient)
+      .then(() => {
+        if (active) setWalletProvision({ status: "ready" });
+      })
+      .catch((error: unknown) => {
+        if (!active) return;
+        setWalletProvision({
+          error:
+            error instanceof Error
+              ? error.message
+              : "para_embedded_wallet_provision_failed",
+          status: "error",
+        });
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [account.embedded.isConnected, paraClient]);
+
   const provider = useMemo(() => {
-    if (!account.embedded.isConnected || !paraClient || !launch) return null;
+    if (
+      !account.embedded.isConnected ||
+      !paraClient ||
+      !launch ||
+      walletProvision.status !== "ready"
+    ) {
+      return null;
+    }
     const getCredential = async () => {
       const credential = await paraClient.issueJwt({});
       const providerToken = credential.token.trim();
@@ -127,7 +203,13 @@ export function useCanonicalAccount(
             getSubject: () => paraSubject,
           });
     return createAccountSessionProvider({ baseUrl: aomiBffUrl, adapter });
-  }, [account.embedded.isConnected, launch, paraClient, paraSubject]);
+  }, [
+    account.embedded.isConnected,
+    launch,
+    paraClient,
+    paraSubject,
+    walletProvision.status,
+  ]);
 
   useEffect(() => {
     if (!provider) return;
@@ -174,6 +256,21 @@ export function useCanonicalAccount(
     };
   }, [provider]);
 
+  if (walletProvision.status === "error") {
+    return {
+      error: walletProvision.error,
+      provider: null,
+      status: "error",
+      userId: null,
+    };
+  }
+  if (
+    account.embedded.isConnected &&
+    paraClient &&
+    walletProvision.status === "provisioning"
+  ) {
+    return { error: null, provider: null, status: "loading", userId: null };
+  }
   return provider
     ? { ...state, provider }
     : { error: null, provider: null, status: "disconnected", userId: null };

--- a/apps/telegram/test/integration-contract.test.mjs
+++ b/apps/telegram/test/integration-contract.test.mjs
@@ -14,6 +14,8 @@ test("Para login resolves the canonical Aomi account", async () => {
 
   assert.match(providers, /oAuthMethods: \["GOOGLE", "TELEGRAM"\]/);
   assert.match(canonicalAccount, /createProviderCredentialAdapter/);
+  assert.match(canonicalAccount, /createWalletPerType\(\{ types: \["EVM"\] \}\)/);
+  assert.match(canonicalAccount, /evmWalletProvisioning/);
   assert.match(canonicalAccount, /paraClient\.issueJwt/);
   assert.match(canonicalAccount, /createAccountSessionProvider/);
   assert.match(canonicalAccount, /\/api\/auth\/widget\/telegram\/exchange/);


### PR DESCRIPTION
## Summary
- provision an EVM Para embedded wallet before the Telegram credential exchange
- share in-flight provisioning work to avoid duplicate wallets after React effect restarts
- cover the hosted-wallet precondition in the Telegram contract test

## Verification
- pnpm --filter telegram typecheck
- pnpm --filter telegram lint
- pnpm --filter telegram test
- pnpm --filter telegram build

Staging deployment: https://mini-app-staging.aomi.dev

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/591"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791643603&installation_model_id=12362&pr_number=591&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F591&signature=92c6646c660b9501ad354db96317bb328fa403d07b0e9e452d054e2d65315611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->