### PR TITLE
fix(para): trust Para's signed wallet attestation for widget exchanges

### DIFF
--- a/apps/portal/src/app/api/auth/widget/telegram/exchange/route.test.ts
+++ b/apps/portal/src/app/api/auth/widget/telegram/exchange/route.test.ts
@@ -14,6 +14,20 @@ vi.mock("@aomi-labs/account/account", () => ({
   claimTelegramSessionOwner: mocks.claimOwner,
   linkVerifiedProviderIdentityForUser: mocks.linkIdentity,
   resolveAttestedProviderWallets: mocks.resolveWallets,
+  // Same dedupe-by-address rule as the real helper; the module is mocked
+  // wholesale to keep the Postgres pool out of this suite.
+  mergeProviderWalletAttestations: (
+    primary: { family: string; address: string }[],
+    fallback: { family: string; address: string }[],
+  ) => {
+    const seen = new Set<string>();
+    return [...primary, ...fallback].filter((wallet) => {
+      const key = `${wallet.family}:${wallet.address.toLowerCase()}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  },
   IdentityConflictError: class IdentityConflictError extends Error {},
 }));
 
@@ -80,6 +94,13 @@ const EVM_WALLET = {
   providerWalletId: "para-evm",
   family: "evm",
   address: "0x1111111111111111111111111111111111111111",
+  chainScope: null,
+};
+const TOKEN_WALLET = {
+  provider: "para",
+  providerWalletId: "para-token-evm",
+  family: "evm",
+  address: "0x3333333333333333333333333333333333333333",
   chainScope: null,
 };
 const SVM_WALLET = {
@@ -203,10 +224,7 @@ describe("Telegram Para exchange", () => {
     expect(mocks.claimOwner).not.toHaveBeenCalled();
     expect(mocks.issueSession).not.toHaveBeenCalled();
   });
-  it("links the wallets Para's server API attests, not the ones the JWT claims", async () => {
-    // The Para session JWT is a client-held token: a forged `wallets` claim
-    // must never reach the canonical link. Only the server-side API answer,
-    // fetched with `PARA_API_SECRET_KEY`, may become a `public_keys` row.
+  it("merges the provider API answer with the token's signed attestation", async () => {
     mocks.verifyCredential.mockResolvedValue({
       descriptor: { id: "para", policy: { subjectIsEnvironmentGlobal: true } },
       identity: {
@@ -216,15 +234,7 @@ describe("Telegram Para exchange", () => {
         subject: "para-user",
         email: { value: "user@example.com", verified: true },
         loginIdentifier: { type: "telegram", value: "1234567890" },
-        walletAttestations: [
-          {
-            provider: "para",
-            providerWalletId: "forged",
-            family: "evm",
-            address: "0x9999999999999999999999999999999999999999",
-            chainScope: null,
-          },
-        ],
+        walletAttestations: [TOKEN_WALLET],
       },
     });
 
@@ -240,12 +250,13 @@ describe("Telegram Para exchange", () => {
     expect(mocks.linkIdentity).toHaveBeenCalledWith(
       expect.objectContaining({
         userId: "canonical-user",
-        wallets: [EVM_WALLET, SVM_WALLET],
+        wallets: [EVM_WALLET, SVM_WALLET, TOKEN_WALLET],
       }),
     );
   });
 
-  it("refuses the exchange when Para attests no embedded wallet", async () => {
+  it("refuses the exchange when neither source knows of an embedded wallet", async () => {
+    // The default credential mock carries no token attestation either.
     mocks.resolveWallets.mockResolvedValue({ status: "attested", wallets: [] });
 
     const response = await POST(exchange());
@@ -258,33 +269,36 @@ describe("Telegram Para exchange", () => {
     expect(mocks.issueSession).not.toHaveBeenCalled();
   });
 
-  it("refuses the exchange when the Para API is unavailable", async () => {
-    mocks.resolveWallets.mockResolvedValue({
-      status: "unavailable",
-      error: new Error("para down"),
+  it("links on the token attestation alone when the Para API cannot answer", async () => {
+    // Para's wallet list is indexed by pregen login handle and returns nothing
+    // for an SDK-created wallet, so neither an empty answer nor an outage may
+    // veto the token's own signed attestation.
+    mocks.verifyCredential.mockResolvedValue({
+      descriptor: { id: "para", policy: { subjectIsEnvironmentGlobal: true } },
+      identity: {
+        provider: "para",
+        issuerEnvironment: "beta",
+        tenantId: "para",
+        subject: "para-user",
+        walletAttestations: [TOKEN_WALLET],
+      },
     });
 
-    const response = await POST(exchange());
+    for (const resolution of [
+      { status: "unavailable", error: new Error("para down") },
+      { status: "unconfigured" },
+      { status: "attested", wallets: [] },
+    ]) {
+      mocks.linkIdentity.mockClear();
+      mocks.resolveWallets.mockResolvedValue(resolution);
 
-    expect(response.status).toBe(503);
-    await expect(response.json()).resolves.toEqual({
-      error: "provider_wallets_unavailable",
-    });
-    expect(mocks.linkIdentity).not.toHaveBeenCalled();
-    expect(mocks.issueSession).not.toHaveBeenCalled();
-  });
+      const response = await POST(exchange());
 
-  it("refuses the exchange when no Para server secret is configured", async () => {
-    mocks.resolveWallets.mockResolvedValue({ status: "unconfigured" });
-
-    const response = await POST(exchange());
-
-    expect(response.status).toBe(503);
-    await expect(response.json()).resolves.toEqual({
-      error: "provider_wallets_unconfigured",
-    });
-    expect(mocks.linkIdentity).not.toHaveBeenCalled();
-    expect(mocks.issueSession).not.toHaveBeenCalled();
+      expect(response.status).toBe(200);
+      expect(mocks.linkIdentity).toHaveBeenCalledWith(
+        expect.objectContaining({ wallets: [TOKEN_WALLET] }),
+      );
+    }
   });
 
   it("fails closed when a wallet already belongs to another canonical user", async () => {

--- a/apps/portal/src/server/widget-auth/exchange.test.ts
+++ b/apps/portal/src/server/widget-auth/exchange.test.ts
@@ -1,30 +1,55 @@
 // @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WidgetAuthError } from "@aomi-labs/account/widget-auth";
-import type { VerifiedProviderIdentity } from "@aomi-labs/account/providers";
+import type {
+  AttestedWallet,
+  VerifiedProviderIdentity,
+} from "@aomi-labs/account/providers";
 
 import { requireAttestedProviderWallets } from "./exchange";
 
-// This suite drives the real chain — descriptor identity → attester registry →
+// This suite drives the real chain — verified identity → attester registry →
 // Para's REST wallet list — with only `fetch` and the environment stubbed, so
-// it fails if any seam between them is miswired. The route tests above it mock
-// the lookup itself and cover the failure-code mapping.
+// it fails if any seam between them is miswired. The route tests mock the
+// lookup itself and cover how each outcome maps onto a response.
 
 const PARA_WALLETS_URL = "https://para.test/v1/wallets";
-const EVM = "0x1111111111111111111111111111111111111111";
-const SOL = "53GfEkka7UYR9KsM6ePWSNfbW678grShT41uZMjXAvoL";
+const REST_EVM = "0x1111111111111111111111111111111111111111";
+const TOKEN_EVM = "0x2222222222222222222222222222222222222222";
+const TOKEN_SOL = "53GfEkka7UYR9KsM6ePWSNfbW678grShT41uZMjXAvoL";
 
-const identity: VerifiedProviderIdentity = {
-  provider: "para",
-  issuerEnvironment: "para:beta",
-  tenantId: "para-project",
-  subject: "d5358219-38d3-4650-91a8-e338131d1c5e",
-  expiresAt: 1_900_000_300,
-  email: { value: "alice@example.com", verified: true },
-  loginIdentifier: { type: "email", value: "alice@example.com" },
-  walletAttestations: [],
-  metadata: {},
-};
+const tokenWallets: AttestedWallet[] = [
+  {
+    provider: "para",
+    providerWalletId: "token-evm",
+    family: "evm",
+    address: TOKEN_EVM,
+    chainScope: null,
+  },
+  {
+    provider: "para",
+    providerWalletId: "token-svm",
+    family: "svm",
+    address: TOKEN_SOL,
+    chainScope: null,
+  },
+];
+
+function identity(
+  walletAttestations: AttestedWallet[] = [],
+): VerifiedProviderIdentity {
+  return {
+    provider: "para",
+    issuerEnvironment: "para:beta",
+    tenantId: "para-project",
+    subject: "d5358219-38d3-4650-91a8-e338131d1c5e",
+    expiresAt: 1_900_000_300,
+    email: { value: "alice@example.com", verified: true },
+    loginIdentifier: { type: "email", value: "alice@example.com" },
+    walletAttestations,
+    metadata: {},
+  };
+}
 
 function stubParaWallets(
   handler: (url: URL, init?: RequestInit) => Response,
@@ -34,6 +59,21 @@ function stubParaWallets(
   );
   vi.stubGlobal("fetch", fetchMock);
   return fetchMock;
+}
+
+function restWalletsResponse(): Response {
+  return Response.json({
+    data: [
+      {
+        id: "para-evm",
+        address: REST_EVM,
+        type: "EVM",
+        scheme: "DKLS",
+        status: "ready",
+      },
+    ],
+    pagination: { cursor: null, hasMore: false },
+  });
 }
 
 describe("requireAttestedProviderWallets", () => {
@@ -47,110 +87,81 @@ describe("requireAttestedProviderWallets", () => {
     vi.unstubAllGlobals();
   });
 
-  it("attests the EVM and Solana embedded wallets Para holds for the login handle", async () => {
+  it("merges the provider API answer with the token's signed attestation", async () => {
     const fetchMock = stubParaWallets((url) => {
       expect(url.origin + url.pathname).toBe(PARA_WALLETS_URL);
       expect(url.searchParams.get("userIdentifier")).toBe("alice@example.com");
       expect(url.searchParams.get("userIdentifierType")).toBe("EMAIL");
-      return Response.json({
-        data: [
-          {
-            id: "para-evm",
-            address: EVM,
-            type: "EVM",
-            scheme: "DKLS",
-            status: "ready",
-          },
-          {
-            id: "para-svm",
-            address: SOL,
-            type: "SOLANA",
-            scheme: "ED25519",
-            status: "ready",
-          },
-        ],
-        pagination: { cursor: null, hasMore: false },
-      });
+      return restWalletsResponse();
     });
 
-    await expect(requireAttestedProviderWallets(identity)).resolves.toEqual([
-      {
-        provider: "para",
-        providerWalletId: "para-evm",
-        family: "evm",
-        address: EVM,
-        chainScope: null,
-      },
-      {
-        provider: "para",
-        providerWalletId: "para-svm",
-        family: "svm",
-        address: SOL,
-        chainScope: null,
-      },
+    const wallets = await requireAttestedProviderWallets(
+      identity(tokenWallets),
+    );
+
+    // API rows first, then anything only the token knows about.
+    expect(wallets.map((wallet) => wallet.providerWalletId)).toEqual([
+      "para-evm",
+      "token-evm",
+      "token-svm",
     ]);
     expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
       headers: { "X-API-Key": "sk_para_staging" },
     });
   });
 
-  it("reports a Para account with no embedded wallet instead of linking nothing", async () => {
+  // Para's `GET /v1/wallets` is indexed by pregen login handle and returns
+  // nothing for a wallet the user created through the client SDK — which is
+  // every Mini App user. An empty answer there proves nothing, so it must not
+  // veto the token's own signed attestation.
+  it("still links when the provider API knows nothing about the user", async () => {
+    stubParaWallets(() =>
+      Response.json({ data: [], pagination: { cursor: null, hasMore: false } }),
+    );
+
+    await expect(
+      requireAttestedProviderWallets(identity(tokenWallets)),
+    ).resolves.toEqual(tokenWallets);
+  });
+
+  it("still links when the provider API is down or unconfigured", async () => {
+    stubParaWallets(() => new Response("nope", { status: 500 }));
+    await expect(
+      requireAttestedProviderWallets(identity(tokenWallets)),
+    ).resolves.toEqual(tokenWallets);
+
+    vi.stubEnv("PARA_API_SECRET_KEY", "");
+    const fetchMock = stubParaWallets(() => Response.json({ data: [] }));
+    await expect(
+      requireAttestedProviderWallets(identity(tokenWallets)),
+    ).resolves.toEqual(tokenWallets);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fails when neither source knows of an embedded wallet", async () => {
     stubParaWallets(() =>
       Response.json({
-        // An imported/external wallet is not Para-custodied: it cannot back
-        // hosted signing, so an answer containing only those is "no wallet".
+        // Not Para-custodied, so it can never back hosted signing.
         data: [
-          { id: "para-ext", address: EVM, type: "EVM", scheme: "EXTERNAL" },
+          {
+            id: "para-ext",
+            address: REST_EVM,
+            type: "EVM",
+            scheme: "EXTERNAL",
+          },
         ],
         pagination: { cursor: null, hasMore: false },
       }),
     );
 
-    await expect(
-      requireAttestedProviderWallets(identity),
-    ).rejects.toMatchObject({
-      code: "provider_hosted_wallet_missing",
-      status: 422,
-    });
-  });
-
-  it("fails closed, without falling back to token claims, when Para is down", async () => {
-    stubParaWallets(() => new Response("nope", { status: 500 }));
-
-    await expect(
-      requireAttestedProviderWallets({
-        ...identity,
-        // A forged wallet claim inside the session JWT must not rescue a failed
-        // server-side attestation.
-        walletAttestations: [
-          {
-            provider: "para",
-            providerWalletId: "forged",
-            family: "evm",
-            address: EVM,
-            chainScope: null,
-          },
-        ],
-      }),
-    ).rejects.toMatchObject({
-      code: "provider_wallets_unavailable",
-      status: 503,
-    });
-  });
-
-  it("fails closed when the deployment has no Para server secret", async () => {
-    vi.stubEnv("PARA_API_SECRET_KEY", "");
-    const fetchMock = stubParaWallets(() => Response.json({ data: [] }));
-
-    const error = await requireAttestedProviderWallets(identity).catch(
+    const error = await requireAttestedProviderWallets(identity()).catch(
       (thrown: unknown) => thrown,
     );
 
     expect(error).toBeInstanceOf(WidgetAuthError);
     expect(error).toMatchObject({
-      code: "provider_wallets_unconfigured",
-      status: 503,
+      code: "provider_hosted_wallet_missing",
+      status: 422,
     });
-    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/portal/src/server/widget-auth/exchange.ts
+++ b/apps/portal/src/server/widget-auth/exchange.ts
@@ -1,4 +1,7 @@
-import { resolveAttestedProviderWallets } from "@aomi-labs/account/account";
+import {
+  mergeProviderWalletAttestations,
+  resolveAttestedProviderWallets,
+} from "@aomi-labs/account/account";
 import {
   getWidgetProvider,
   widgetCredentialWireSchema,
@@ -40,25 +43,29 @@ export async function verifyWidgetProviderCredential(body: unknown): Promise<{
 }
 
 /**
- * Resolve the wallets a provider's own server-side API attests for a verified
+ * Resolve every wallet this provider attests it custodies for a verified
  * subject, for flows that cannot function without a hosted wallet.
  *
- * A widget credential proves who the human is, nothing more: every widget
- * descriptor deliberately returns `walletAttestations: []` because the wallet
- * arrays inside a provider session token are client-supplied claims. So the
- * only way a provider-custodied wallet may become a canonical `public_keys`
- * row is this call, made with the server's own provider API secret.
+ * Two sources, merged, neither of them a client claim:
  *
- * Each failure keeps its own code so a caller (and the Mini App reading the
- * response) can tell them apart, and none of them fall back to the token's
- * wallet claims:
- * - `provider_wallets_unconfigured` (503) — no server API secret for this
- *   provider in this environment; nothing was asked and nothing is known.
- * - `provider_wallets_unavailable` (503) — the provider API call failed;
- *   transient, and retrying the exchange is the fix.
- * - `provider_hosted_wallet_missing` (422) — the provider answered, and this
- *   user owns no embedded/MPC wallet. External/imported wallets are filtered
- *   out upstream, so they never satisfy this.
+ * 1. The provider's own server-side wallet API, queried with our API secret.
+ *    Authoritative where it has the data — but Para's `GET /v1/wallets` is
+ *    indexed by pregen login handle and simply does not return wallets a user
+ *    created through the client SDK, which is every Telegram Mini App user. So
+ *    an empty or unavailable answer here proves nothing and must not fail the
+ *    exchange on its own.
+ * 2. The provider token's own signed wallet attestation. For Para that is
+ *    `data.wallets`, signed by the same key, under the same audience, as the
+ *    `sub` we bind the canonical account to. External/connected wallets are
+ *    stripped upstream and never appear here.
+ *
+ * This mirrors what the native credential path has always done
+ * (`prepareVerifiedCredential` merges the same two sources); the widget path
+ * was the outlier in discarding the token attestation.
+ *
+ * Only an empty merged set is a failure: `provider_hosted_wallet_missing`
+ * (422) means neither source knows of an embedded wallet for this user, so
+ * there is nothing that could sign.
  */
 export async function requireAttestedProviderWallets(
   identity: VerifiedProviderIdentity,
@@ -69,14 +76,12 @@ export async function requireAttestedProviderWallets(
     email: identity.email?.value,
     loginIdentifier: identity.loginIdentifier,
   });
-  if (resolution.status === "unconfigured") {
-    throw new WidgetAuthError("provider_wallets_unconfigured", 503);
-  }
-  if (resolution.status === "unavailable") {
-    throw new WidgetAuthError("provider_wallets_unavailable", 503);
-  }
-  if (!resolution.wallets.length) {
+  const wallets = mergeProviderWalletAttestations(
+    resolution.status === "attested" ? resolution.wallets : [],
+    identity.walletAttestations,
+  );
+  if (!wallets.length) {
     throw new WidgetAuthError("provider_hosted_wallet_missing", 422);
   }
-  return resolution.wallets;
+  return wallets;
 }

--- a/packages/account/src/account.ts
+++ b/packages/account/src/account.ts
@@ -14,6 +14,7 @@ export {
   getOrCreateAomiUserForBetterAuthSession,
   linkAnonymousCanonicalAccount,
   linkProviderIdentity,
+  mergeProviderWalletAttestations,
   renameAuthIdentity,
   renameWallet,
   resolveAttestedProviderWallets,

--- a/packages/account/src/providers/para.ts
+++ b/packages/account/src/providers/para.ts
@@ -191,13 +191,24 @@ export async function verifyParaWidgetCredential(input: {
   const nestedVerified = nested?.emailVerified ?? nested?.email_verified;
   const emailVerified =
     payload.email_verified === true || nestedVerified === true;
-  // Validate the wallet-claim shape (reject malformed tokens) but do NOT
-  // surface these as trusted attestations: the wallet arrays embedded in the
-  // Para session JWT are self-asserted claims whose trust level is "none".
-  // Only wallets fetched from Para's authenticated API
-  // (`listParaWalletsForUser`) are trusted for linking, so the widget path
-  // returns no attestations here.
-  walletClaims(nested?.wallets ?? payload.wallets, "wallets");
+  // `data.wallets` is Para's own signed statement of the embedded wallets it
+  // custodies for this subject. It carries exactly the trust of the `sub` we
+  // bind the canonical account to: same RS256 signature, same JWKS, same
+  // audience pinned to our API key — a client can choose which token to
+  // present but cannot alter a field in it. Treating `sub` as authoritative
+  // while calling this array unverifiable would be incoherent.
+  //
+  // Para's REST wallet list cannot replace it: `GET /v1/wallets` is indexed by
+  // pregen login handle and does not return wallets a user created through the
+  // client SDK, so it is a supplementary source (see
+  // `requireAttestedProviderWallets`), not the proof.
+  //
+  // `connectedWallets` stays discarded, and that is the boundary that matters:
+  // those are external wallets attached to the session, not Para-custodied, so
+  // they can never back hosted signing.
+  const walletAttestations = paraTokenWalletAttestations(
+    walletClaims(nested?.wallets ?? payload.wallets, "wallets"),
+  );
   walletClaims(
     nested?.connectedWallets ??
       nested?.connected_wallets ??
@@ -214,7 +225,7 @@ export async function verifyParaWidgetCredential(input: {
     expiresAt,
     email: email ? { value: email, verified: emailVerified } : undefined,
     loginIdentifier: paraLoginIdentifier(nested),
-    walletAttestations: [],
+    walletAttestations,
     metadata: {
       audience,
       expiresAt,
@@ -233,6 +244,31 @@ function paraLoginIdentifier(
   const type = stringClaim(nested?.authType);
   const value = stringClaim(nested?.identifier);
   return type && value ? { type, value } : undefined;
+}
+
+/** Convert Para's signed `data.wallets` entries into attested wallets. Only
+ *  wallets on a family we can key a `public_keys` row for, with a wallet id and
+ *  a well-formed address, survive; the entries carry no `scheme` because
+ *  membership in this array is itself the custody signal. */
+function paraTokenWalletAttestations(
+  claims: readonly unknown[],
+): AttestedWallet[] {
+  const wallets: AttestedWallet[] = [];
+  for (const claim of claims) {
+    const row = claim as { id?: unknown; type?: unknown; address?: unknown };
+    const family = paraWalletFamily(stringClaim(row.type));
+    const providerWalletId = stringClaim(row.id);
+    if (!family || !providerWalletId) continue;
+    if (!validWalletAddress(family, row.address)) continue;
+    wallets.push({
+      provider: "para",
+      providerWalletId,
+      family,
+      address: row.address,
+      chainScope: null,
+    });
+  }
+  return wallets;
 }
 
 export type ParaUserIdentifierType =

--- a/packages/account/test/para.test.ts
+++ b/packages/account/test/para.test.ts
@@ -12,6 +12,9 @@ import {
 } from "../src/providers/para";
 import { getWidgetProvider } from "../src/providers";
 
+const EVM = "0x1111111111111111111111111111111111111111";
+const SOL = "53GfEkka7UYR9KsM6ePWSNfbW678grShT41uZMjXAvoL";
+
 afterEach(() => {
   vi.unstubAllGlobals();
 });
@@ -246,5 +249,91 @@ describe("Para login identifiers", () => {
     // and no identifier type that would name it.
     expect(paraUserIdentifierType("externalWallet")).toBeNull();
     expect(paraUserIdentifierType(undefined)).toBeNull();
+  });
+});
+
+describe("Para token wallet attestations", () => {
+  let jwksSeq = 0;
+
+  async function verifyToken(data: Record<string, unknown>) {
+    const { privateKey, publicKey } = await generateKeyPair("RS256");
+    const jwk = await exportJWK(publicKey);
+    // A fresh JWKS URL per token: the verifier caches remote key sets by URL,
+    // so reusing one would verify the second token against the first key.
+    const jwksUrl = `https://para.example/.well-known/wallet-jwks-${jwksSeq++}.json`;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({ keys: [{ ...jwk, kid: "w-kid", alg: "RS256" }] }),
+      ),
+    );
+    const now = 1_900_000_000;
+    const token = await new SignJWT({ data })
+      .setProtectedHeader({ alg: "RS256", kid: "w-kid" })
+      .setSubject("para-user-wallets")
+      .setAudience("para-project")
+      .setIssuedAt(now)
+      .setExpirationTime(now + 300)
+      .sign(privateKey);
+    return verifyParaWidgetCredential({
+      environment: "BETA",
+      providerToken: token,
+      jwksUrls: { BETA: jwksUrl, PROD: jwksUrl },
+      now: new Date(now * 1000),
+    });
+  }
+
+  it("attests the embedded wallets Para signed into the token", async () => {
+    // Para's REST wallet list is indexed by pregen login handle and cannot see
+    // an SDK-created wallet, so this signed array is the only proof available
+    // for a Mini App user. It carries the same signature as the `sub` the
+    // canonical account is bound to.
+    const identity = await verifyToken({
+      wallets: [
+        { id: "w-evm", type: "EVM", address: EVM },
+        { id: "w-svm", type: "SOLANA", address: SOL },
+      ],
+    });
+
+    expect(identity.walletAttestations).toEqual([
+      {
+        provider: "para",
+        providerWalletId: "w-evm",
+        family: "evm",
+        address: EVM,
+        chainScope: null,
+      },
+      {
+        provider: "para",
+        providerWalletId: "w-svm",
+        family: "svm",
+        address: SOL,
+        chainScope: null,
+      },
+    ]);
+  });
+
+  it("never attests a connected external wallet", async () => {
+    // `connectedWallets` are wallets attached to the session, not custodied by
+    // Para. They can never back hosted signing, so they stay out of the graph
+    // even though they ride in the same signed token.
+    const identity = await verifyToken({
+      connectedWallets: [{ id: "w-external", type: "EVM", address: EVM }],
+    });
+
+    expect(identity.walletAttestations).toEqual([]);
+  });
+
+  it("drops malformed entries instead of trusting the shape", async () => {
+    const identity = await verifyToken({
+      wallets: [
+        { id: "w-no-address", type: "EVM" },
+        { id: "w-bad-address", type: "EVM", address: "0xnothex" },
+        { id: "w-unsupported", type: "COSMOS", address: EVM },
+        { type: "EVM", address: EVM },
+      ],
+    });
+
+    expect(identity.walletAttestations).toEqual([]);
   });
 });

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -2,6 +2,52 @@
 
 ## Last Updated
 
+2026-09-10 — PARA'S REST WALLET LIST CANNOT ATTEST AN SDK-CREATED WALLET
+  (branch `fix/para-token-wallet-attestation`). Follow-up to the two entries
+  below: with the server-side attestation wired in (#590) and the Mini App
+  provisioning an EVM wallet before the exchange (#591), staging still returned
+  422 `provider_hosted_wallet_missing`. An unfiltered
+  `GET /v1/wallets?limit=20` against the staging Para partner scope settled it:
+  15 rows, `hasMore: false`, newest created 2026-05-19 — the wallet the Mini App
+  had created minutes earlier was NOT there, and every row was a pregen/REST
+  test wallet (`a@b.com`, `user@example.com`, `+4912333333`). The public REST
+  list is indexed by pregen login handle; wallets a user creates through the
+  client SDK live in the user-management API the SDK itself calls
+  (`client.getWallets(userId)`), which a partner API key cannot reach. So no
+  `userIdentifierType` mapping and no row filter could ever have fixed this —
+  the data is not in that endpoint. (Also: zero SOLANA wallets exist in the
+  partner scope at all.)
+  The proof therefore comes from Para's signed token, and this is a deliberate
+  reversal of the premise the work started from:
+  - `verifyParaWidgetCredential` now converts `data.wallets` into
+    `AttestedWallet[]` instead of returning `[]`. That array carries exactly
+    the trust of the `sub` the canonical account is bound to — same RS256
+    signature, same JWKS, same `aud` pinned to our API key id. Treating `sub`
+    as authoritative while calling the sibling field unverifiable was
+    incoherent. `connectedWallets` stays discarded: those are session-attached
+    external wallets, not Para-custodied, and can never back hosted signing.
+    That is the boundary that actually matters.
+  - `requireAttestedProviderWallets` now MERGES the REST answer with the token
+    attestation (REST first) and only 422s when both are empty. Consequence:
+    `provider_wallets_unconfigured` / `provider_wallets_unavailable` no longer
+    fail the exchange — an endpoint that structurally cannot see the wallet
+    proves nothing by being empty or down. This mirrors the native path's
+    long-standing `prepareVerifiedCredential` merge; the widget path was the
+    outlier.
+  Unchanged: cross-account wallet conflict still fails closed (409), wallets
+  still land in `public_keys` through the same single transaction, and the
+  scheme/status/type filters still gate the REST source.
+  Deployment topology learned the hard way, now correct and verified by
+  grepping the live bundles:
+  - `tg-mini-app` → mini-app.aomi.dev → `NEXT_PUBLIC_AOMI_BFF_URL=https://chat.aomi.dev`
+  - `tg-mini-app-staging` → mini-app-staging.aomi.dev → `=https://chat-staging.aomi.dev`
+    (root dir `.`, build `pnpm --filter telegram build`, CLI-deployed)
+  The Vercel CLI marks env vars SENSITIVE by default when added
+  non-interactively, and a sensitive `NEXT_PUBLIC_*` never reaches the client
+  bundle — it reads back as `""`. Always pass `--no-sensitive` for public vars.
+  STILL NOT VERIFIED: the live `Auto × Telegram × AA × Hosted` cell. This change
+  has to reach chat-staging (portal main) before the next run.
+
 2026-09-10 — TELEGRAM × PARA HOSTED WALLETS NEVER REACHED `public_keys`
   (working tree, uncommitted). The Mini App said "Para is linked" while the bot
   still reported `Authority: not linked`: `/api/auth/widget/telegram/exchange`


### PR DESCRIPTION
## Why

With server-side attestation wired in (#590) and the Mini App provisioning an EVM wallet before the exchange (#591), staging still returned `422 provider_hosted_wallet_missing`.

An unfiltered listing of the staging Para partner scope settled it:

```
GET /v1/wallets?limit=20  →  15 rows, hasMore: false, newest createdAt 2026-05-19
```

The wallet the Mini App had created minutes earlier **was not in it**, and every row was a pregen/REST test wallet (`a@b.com`, `user@example.com`, `+4912333333`). Para's public REST list is indexed by pregen login handle; wallets a user creates through the client SDK live in the user-management API the SDK itself calls (`client.getWallets(userId)`), which a partner API key cannot reach.

So no `userIdentifierType` mapping and no row filter could have fixed this — the data is not in that endpoint.

## What changed

- `verifyParaWidgetCredential` converts `data.wallets` into `AttestedWallet[]` instead of returning `[]`. That array carries exactly the trust of the `sub` the canonical account is bound to: same RS256 signature, same JWKS, same `aud` pinned to our API key id. A client can choose which token to present but cannot alter a field in it.
- `connectedWallets` stays discarded. Those are external wallets attached to the session, not Para-custodied, and can never back hosted signing — that is the boundary that actually matters.
- `requireAttestedProviderWallets` merges the REST answer with the token attestation (REST first) and only fails when both are empty, mirroring what the native credential path's `prepareVerifiedCredential` has always done.

## Security posture

**Loosened:** `provider_wallets_unconfigured` / `provider_wallets_unavailable` no longer fail the exchange. An endpoint that structurally cannot see the wallet proves nothing by being empty or down.

**Unchanged:** cross-account wallet conflict still fails closed (409), wallets still reach `public_keys` through the same single transaction, and the scheme/status/type filters still gate the REST source.

## Tests

- `packages/account/test/para.test.ts` — signed `data.wallets` become attestations; `connectedWallets` never do; malformed entries are dropped.
- `apps/portal/src/server/widget-auth/exchange.test.ts` — real identity → attester → REST chain with only `fetch`/env stubbed; covers merge, empty API, API down, no secret, and both-empty.
- Root suite 1463 passed, portal 570 passed, both typechecks and eslint clean.

## Still not verified

The live `Auto × Telegram × AA × Hosted` cell. This has to reach chat-staging (portal `main`) before the next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791646496&installation_model_id=12362&pr_number=592&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F592&signature=8fb82a7c3eb45baba31091d2cffbd9e2cff714907ceddd23b7e3d1b949c2dc0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->