### PR TITLE
fix(telegram): rely on Privy seamless login

### DIFF
--- a/apps/telegram/src/app/page.tsx
+++ b/apps/telegram/src/app/page.tsx
@@ -1,37 +1,16 @@
 "use client";
 
-import { useEffect, useRef } from "react";
-import { useLoginWithTelegram, usePrivy } from "@privy-io/react-auth";
-
 import { useCanonicalAccount } from "@/hooks/use-canonical-account";
 import { usePermissionControl } from "@/hooks/use-permission-control";
 import { useTelegramLaunch } from "@/hooks/use-telegram-launch";
 
 export default function Home() {
-  const { authenticated, ready } = usePrivy();
-  const { login } = useLoginWithTelegram();
-  const opened = useRef(false);
   const launch = useTelegramLaunch();
   const account = useCanonicalAccount(launch.context);
   const permission = usePermissionControl({
     launch: launch.context,
     provider: account.provider,
   });
-
-  useEffect(() => {
-    if (
-      launch.status !== "ready" ||
-      !ready ||
-      authenticated ||
-      opened.current
-    ) {
-      return;
-    }
-    // Telegram already proved who this is via `initData`, so the login is
-    // headless — there is no provider modal for the user to work through.
-    opened.current = true;
-    void login();
-  }, [authenticated, launch.status, login, ready]);
 
   let message = "Signing you in…";
   if (launch.status === "loading") message = "Opening your wallet…";
@@ -60,16 +39,6 @@ export default function Home() {
           <p>
             {permission.target.mode} for {permission.target.wallet}
           </p>
-        )}
-        {launch.status !== "error" && account.status !== "ready" && (
-          <button
-            className="para-button"
-            type="button"
-            disabled={!ready}
-            onClick={() => void login()}
-          >
-            {authenticated ? "Retry" : "Continue"}
-          </button>
         )}
         {permission.status === "ready" && (
           <button

--- a/apps/telegram/test/integration-contract.test.mjs
+++ b/apps/telegram/test/integration-contract.test.mjs
@@ -24,6 +24,15 @@ test("Privy login resolves the canonical Aomi account", async () => {
   assert.match(canonicalAccount, /\/v1\/account/);
 });
 
+test("Telegram Mini Apps rely on Privy's seamless OAuth login", async () => {
+  const page = await read("src/app/page.tsx");
+
+  // Privy completes Telegram Mini App login as the provider initializes.
+  // Calling the experimental headless hook in parallel can leave the page in
+  // its initial signing state when that second auth flow rejects.
+  assert.doesNotMatch(page, /useLoginWithTelegram|void login\(\)/);
+});
+
 test("Telegram launches are verified before a production wallet flow", async () => {
   const [client, route, verifier] = await Promise.all([
     read("src/lib/telegram.ts"),


### PR DESCRIPTION
Remove the experimental explicit Telegram login call from the Mini App. Privy handles Telegram Mini App OAuth seamlessly at provider initialization; the second auth flow could reject silently and leave the user on Signing you in…. Includes a regression contract.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791668449&installation_model_id=12362&pr_number=594&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F594&signature=743ea3139964dc47d16f9ab3892a123c8d5c979d81386a04f2b887a7414dd335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->