### PR TITLE
Fix capability picker visibility

### DIFF
--- a/GOAL.md
+++ b/GOAL.md
@@ -1,5 +1,10 @@
 # Current work
 
+**CAPABILITY PICKER VISIBILITY FIX 2026-09-11** — restore the capability
+picker outside the composer's overflow-controlled input row so both `@` and
+the plus button open a visible menu while preserving inline app chips. Widget
+patch version: 2.0.47. Follow-up only; no deployment.
+
 **INLINE APP CHIPS 2026-09-10** — apps match skill icon/text styling in the composer and are visible in submitted messages. Apps persist; skill mentions remain draft-scoped. App deletion retains one-turn guidance. Isolated follow-up; no deployment.
 
 **PERSISTENT APP CHIPS 2026-09-10** — selected app chips remain in the composer

--- a/apps/shadcn-registry/package.json
+++ b/apps/shadcn-registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aomi-labs/widget-lib",
-  "version": "2.0.46",
+  "version": "2.0.47",
   "description": "Shadcn registry for the Aomi widget.",
   "type": "module",
   "main": "./dist/index.js",

--- a/apps/shadcn-registry/src/components/assistant-ui/capability-composer/input.tsx
+++ b/apps/shadcn-registry/src/components/assistant-ui/capability-composer/input.tsx
@@ -462,72 +462,77 @@ export const CapabilityMentionInput: FC<{
 
   return (
     <>
-      <div className={`${className} flex flex-wrap items-baseline gap-x-1`}>
-        {hintsEnabled && mentions.some((item) => item.kind === "app") && (
-          <span className="contents" aria-label="Selected apps">
-            {mentions
-              .filter((item) => item.kind === "app")
-              .map((item) => {
-                const Icon =
-                  items.find((candidate) => candidate.key === item.key)?.Icon ??
-                  AppWindowIcon;
-                return (
-                  <button
-                    key={item.key}
-                    type="button"
-                    aria-label={`Remove ${item.label}`}
-                    className="text-aomi-accent relative top-px mx-0.5 inline-flex items-center gap-1 whitespace-nowrap align-baseline font-medium"
-                    onClick={() => removeApp(item.key)}
-                    onKeyDown={(event) => {
-                      if (event.key === "Backspace" || event.key === "Delete") {
-                        event.preventDefault();
-                        removeApp(item.key);
-                      }
-                    }}
-                  >
-                    <Icon aria-hidden="true" className="size-3.5 shrink-0" />
-                    {item.label}
-                  </button>
-                );
-              })}
-          </span>
-        )}
-        <div className="relative min-w-[80px] flex-1">
-          {!hasText ? (
-            <span className="text-aomi-muted pointer-events-none absolute left-0 top-0">
-              {placeholder}
+      <div className="relative">
+        <div className={`${className} flex flex-wrap items-baseline gap-x-1`}>
+          {hintsEnabled && mentions.some((item) => item.kind === "app") && (
+            <span className="contents" aria-label="Selected apps">
+              {mentions
+                .filter((item) => item.kind === "app")
+                .map((item) => {
+                  const Icon =
+                    items.find((candidate) => candidate.key === item.key)
+                      ?.Icon ?? AppWindowIcon;
+                  return (
+                    <button
+                      key={item.key}
+                      type="button"
+                      aria-label={`Remove ${item.label}`}
+                      className="text-aomi-accent relative top-px mx-0.5 inline-flex items-center gap-1 whitespace-nowrap align-baseline font-medium"
+                      onClick={() => removeApp(item.key)}
+                      onKeyDown={(event) => {
+                        if (
+                          event.key === "Backspace" ||
+                          event.key === "Delete"
+                        ) {
+                          event.preventDefault();
+                          removeApp(item.key);
+                        }
+                      }}
+                    >
+                      <Icon aria-hidden="true" className="size-3.5 shrink-0" />
+                      {item.label}
+                    </button>
+                  );
+                })}
             </span>
-          ) : null}
-          <div
-            ref={editorRef}
-            role="textbox"
-            aria-label="Message input"
-            aria-multiline="true"
-            aria-autocomplete="list"
-            aria-expanded={query !== null}
-            aria-controls={query !== null ? pickerId : undefined}
-            aria-activedescendant={
-              query !== null && highlighted >= 0
-                ? `${pickerId}-option-${highlighted}`
-                : undefined
-            }
-            contentEditable={!isDisabled}
-            suppressContentEditableWarning
-            onInput={syncEditor}
-            onKeyDown={handleKeyDown}
-            className="min-h-[30px] w-full outline-none"
-          />
-          {hintsEnabled && query !== null ? (
-            <CapabilityPicker
-              pickerId={pickerId}
-              pickerRef={pickerRef}
-              visibleGroups={visibleGroups}
-              highlighted={highlighted}
-              onHighlight={setHighlighted}
-              onSelect={selectItem}
+          )}
+          <div className="relative min-w-[80px] flex-1">
+            {!hasText ? (
+              <span className="text-aomi-muted pointer-events-none absolute left-0 top-0">
+                {placeholder}
+              </span>
+            ) : null}
+            <div
+              ref={editorRef}
+              role="textbox"
+              aria-label="Message input"
+              aria-multiline="true"
+              aria-autocomplete="list"
+              aria-expanded={query !== null}
+              aria-controls={query !== null ? pickerId : undefined}
+              aria-activedescendant={
+                query !== null && highlighted >= 0
+                  ? `${pickerId}-option-${highlighted}`
+                  : undefined
+              }
+              contentEditable={!isDisabled}
+              suppressContentEditableWarning
+              onInput={syncEditor}
+              onKeyDown={handleKeyDown}
+              className="min-h-[30px] w-full outline-none"
             />
-          ) : null}
+          </div>
         </div>
+        {hintsEnabled && query !== null ? (
+          <CapabilityPicker
+            pickerId={pickerId}
+            pickerRef={pickerRef}
+            visibleGroups={visibleGroups}
+            highlighted={highlighted}
+            onHighlight={setHighlighted}
+            onSelect={selectItem}
+          />
+        ) : null}
       </div>
       {mentionIconPortals.map(({ target, Icon }) =>
         createPortal(<Icon className="size-3.5" />, target),

--- a/apps/shadcn-registry/src/components/assistant-ui/capability-composer/provider.test.tsx
+++ b/apps/shadcn-registry/src/components/assistant-ui/capability-composer/provider.test.tsx
@@ -103,6 +103,7 @@ function Composer() {
       <button onClick={() => composer.removeApp("app:cambrian")}>
         Remove app
       </button>
+      <button onClick={composer.openCapabilityPicker}>Open picker</button>
       <span data-testid="selections">
         {composer.mentions.map((item) => item.label).join(",")}
       </span>
@@ -136,7 +137,10 @@ function Harness() {
       }}
     >
       <Composer />
-      <CapabilityMentionInput placeholder="Message" className="" />
+      <CapabilityMentionInput
+        placeholder="Message"
+        className="aui-composer-input overflow-x-hidden"
+      />
     </CapabilityComposerProvider>
   );
 }
@@ -314,4 +318,16 @@ it("clears submitted skill mentions while retaining apps without skill avoidance
   expect(fixture.runConfig.custom.aomiCapabilityHints).not.toHaveProperty(
     "removedApps",
   );
+});
+
+it("mounts the picker outside the composer overflow boundary", async () => {
+  render(<Harness />);
+  await act(async () => {
+    fireEvent.click(screen.getByText("Open picker"));
+  });
+
+  const listbox = screen.getByRole("listbox", {
+    name: "Apps, skills, and chains",
+  });
+  expect(listbox.closest(".overflow-x-hidden")).toBeNull();
 });


### PR DESCRIPTION
## Summary

- restore the capability picker outside the composer overflow boundary introduced by db39c75e
- preserve the inline app-chip layout
- add a regression assertion for the clipping boundary
- bump @aomi-labs/widget-lib to 2.0.47

## Verification

- [x] focused capability composer test: 9/9
- [x] full widget suite: 490/490
- [x] scoped ESLint and Prettier
- [x] registry, ESM, DTS, and CSS package builds
- [x] npm package dry run for 2.0.47

No backend, configuration, or deployment changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791706423&installation_model_id=12362&pr_number=596&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F596&signature=22735df3a1632d008f82db5a7856bc12b5bb1459ed35efaee760f23849f5c2a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->