### PR TITLE
fix(telegram): bound wallet linking waits

### DIFF
--- a/apps/portal/src/server/widget-auth/telegram-custom-auth.test.ts
+++ b/apps/portal/src/server/widget-auth/telegram-custom-auth.test.ts
@@ -13,6 +13,7 @@ const privateKeyPem = privateKey.export({ format: "pem", type: "pkcs8" }).toStri
 
 describe("Telegram Custom JWT issuer", () => {
   it("uses a stable bot-independent subject and a short-lived ES256 token", async () => {
+    const issuedAt = new Date("2026-09-11T12:00:00Z");
     const subject = telegramCustomAuthSubject({
       environment: "staging",
       telegramUserId: "12345",
@@ -22,13 +23,13 @@ describe("Telegram Custom JWT issuer", () => {
     const token = await issueTelegramCustomAuthJwt({
       customSubject: subject,
       privateKeyPem,
-      now: new Date("2026-09-11T12:00:00Z"),
+      now: issuedAt,
     });
     const jwk = await telegramCustomAuthJwk({ privateKeyPem });
     const { payload, protectedHeader } = await jwtVerify(
       token,
       await importJWK(jwk, "ES256"),
-      { algorithms: ["ES256"] },
+      { algorithms: ["ES256"], currentDate: issuedAt },
     );
 
     expect(payload).toMatchObject({ sub: subject, iat: 1_789_128_000, exp: 1_789_128_300 });

--- a/apps/telegram/src/hooks/use-canonical-account.ts
+++ b/apps/telegram/src/hooks/use-canonical-account.ts
@@ -31,6 +31,16 @@ type TelegramExchangeResponse = {
   expires_at?: unknown;
 };
 
+function withTimeout<T>(operation: Promise<T>, errorCode: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(errorCode)), 15_000);
+  });
+  return Promise.race([operation, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
 function telegramPrivyAdapter(input: {
   launch: LaunchContext;
   privySubject: string;
@@ -105,10 +115,10 @@ function useEmbeddedWallet(authenticated: boolean) {
   const [creating, setCreating] = useState(false);
 
   useEffect(() => {
-    if (!authenticated || !ready || wallet || creating) return;
+    if (!authenticated || !ready || wallet || creating || error) return;
     queueMicrotask(() => {
       setCreating(true);
-      void createWallet()
+      void withTimeout(createWallet(), "privy_embedded_wallet_timeout")
         .catch((cause: unknown) => {
           // A concurrent create (or one Privy already ran on login) rejects with
           // "already has an embedded wallet"; `wallets` will carry it shortly, so
@@ -121,7 +131,7 @@ function useEmbeddedWallet(authenticated: boolean) {
         })
         .finally(() => setCreating(false));
     });
-  }, [authenticated, createWallet, creating, ready, wallet]);
+  }, [authenticated, createWallet, creating, error, ready, wallet]);
 
   return { error: wallet ? null : error, wallet };
 }
@@ -196,7 +206,7 @@ export function useCanonicalAccount(
     queueMicrotask(() => {
       if (active) setState({ error: null, status: "loading", userId: null });
     });
-    void provider()
+    void withTimeout(provider(), "telegram_privy_exchange_timeout")
       .then(resolve)
       .then((userId) => {
         if (active) setState({ error: null, status: "ready", userId });

--- a/apps/telegram/test/integration-contract.test.mjs
+++ b/apps/telegram/test/integration-contract.test.mjs
@@ -27,6 +27,8 @@ test("Custom Telegram auth resolves the canonical Aomi account", async () => {
   assert.match(canonicalAccount, /custom_user_id/);
   assert.match(canonicalAccount, /provider: "privy"/);
   assert.match(canonicalAccount, /getEmbeddedConnectedWallet/);
+  assert.match(canonicalAccount, /privy_embedded_wallet_timeout/);
+  assert.match(canonicalAccount, /telegram_privy_exchange_timeout/);
   assert.match(canonicalAccount, /createAccountSessionProvider/);
   assert.match(canonicalAccount, /\/api\/auth\/widget\/telegram\/exchange/);
   assert.match(canonicalAccount, /\/v1\/account/);


### PR DESCRIPTION
## Summary
- fail wallet creation after a bounded wait instead of leaving the Mini App loading indefinitely
- bound the downstream account exchange as well
- preserve the concrete diagnostic code for user-visible retry

## Verification
- pnpm --filter telegram lint
- pnpm --filter telegram typecheck
- node --test apps/telegram/test/integration-contract.test.mjs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791721792&installation_model_id=12362&pr_number=597&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F597&signature=d3174c4d238e03592070f666544b2e32202469886957a9d62bec11cb7a09cb33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->