### PR TITLE
fix(telegram): stop every failure from reading as "Linking your Aomi account…"

### DIFF
--- a/apps/telegram/src/app/page.tsx
+++ b/apps/telegram/src/app/page.tsx
@@ -27,61 +27,54 @@ export default function Home() {
     provider: account.provider,
   });
 
-  // One waterfall, latest stage wins: each layer only speaks once the one
-  // below it has something to say.
-  let message = "Checking your Telegram account…";
+  // Errors first, and the deepest stage that failed wins: an error is the one
+  // thing the person can act on, so no later progress message may paint over
+  // it. Progress messages then run in stage order.
+  let message: string;
   let tone: Tone = "pending";
-  if (launch.status === "loading") message = "Opening your wallet…";
-  if (launch.status === "error") {
-    message = "Open this page from Telegram.";
+  if (permission.status === "error") {
+    message = permission.error ?? "Permission was not updated.";
     tone = "error";
-  }
-  if (telegramAuth.phase === "choose") {
-    message = "Choose how to access your wallet.";
-    tone = "ready";
-  }
-  if (telegramAuth.phase === "email") {
-    message = "Use the email linked to your existing wallet.";
-  }
-  if (telegramAuth.phase === "confirm") {
-    message = "Confirm that this Telegram account can access your existing wallet.";
-    tone = "ready";
-  }
-  if (telegramAuth.phase === "authenticating") {
-    message = "Signing you in…";
-  }
-  if (telegramAuth.phase === "error") {
-    message = telegramAuth.error
-      ? `Could not verify your wallet (${telegramAuth.error}).`
-      : "Could not verify your wallet.";
-    tone = "error";
-  }
-  if (account.status === "loading") message = "Linking your Aomi account…";
-  if (account.status === "error") {
+  } else if (account.status === "error") {
     message = account.error
       ? `Could not link your account (${account.error}).`
       : "Could not link your account.";
     tone = "error";
-  }
-  if (account.status === "ready" && !permission.target) {
-    message = "Your wallet is linked.";
-    tone = "ready";
-  }
-  if (permission.status === "ready") {
-    message = "Review the permission below, then sign it.";
-    tone = "ready";
-  }
-  if (permission.status === "signing") {
-    message = "Waiting for your signature…";
-    tone = "pending";
-  }
-  if (permission.status === "done") {
+  } else if (telegramAuth.phase === "error") {
+    message = telegramAuth.error
+      ? `Could not verify your wallet (${telegramAuth.error}).`
+      : "Could not verify your wallet.";
+    tone = "error";
+  } else if (launch.status === "error") {
+    message = "Open this page from Telegram.";
+    tone = "error";
+  } else if (permission.status === "done") {
     message = "Permission updated. Return to Telegram.";
     tone = "ready";
-  }
-  if (permission.status === "error") {
-    message = permission.error ?? "Permission was not updated.";
-    tone = "error";
+  } else if (permission.status === "signing") {
+    message = "Waiting for your signature…";
+  } else if (permission.status === "ready") {
+    message = "Review the permission below, then sign it.";
+    tone = "ready";
+  } else if (account.status === "ready") {
+    message = "Your wallet is linked.";
+    tone = "ready";
+  } else if (account.status === "loading") {
+    message = "Linking your Aomi account…";
+  } else if (telegramAuth.phase === "choose") {
+    message = "Choose how to access your wallet.";
+    tone = "ready";
+  } else if (telegramAuth.phase === "email") {
+    message = "Use the email linked to your existing wallet.";
+  } else if (telegramAuth.phase === "confirm") {
+    message = "Confirm that this Telegram account can access your existing wallet.";
+    tone = "ready";
+  } else if (telegramAuth.phase === "authenticating") {
+    message = "Signing you in…";
+  } else if (launch.status === "loading") {
+    message = "Opening your wallet…";
+  } else {
+    message = "Checking your Telegram account…";
   }
 
   return (

--- a/apps/telegram/src/hooks/use-canonical-account.ts
+++ b/apps/telegram/src/hooks/use-canonical-account.ts
@@ -190,13 +190,26 @@ export function useCanonicalAccount(
   const resolve = useCallback(
     async (accessToken: string | null | undefined) => {
       if (!accessToken) throw new Error("widget_session_unavailable");
+      // Bounded like the exchange above it. This call reaches the backend
+      // through the BFF, and the backend's DB pool is deliberately tiny
+      // (2 connections per host), so a saturated pool must surface as a named
+      // failure rather than a spinner nobody can interpret.
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 15_000);
       const response = await fetch(`${aomiBffUrl}/v1/account`, {
         credentials: "omit",
+        signal: controller.signal,
         headers: {
           Accept: "application/json",
           Authorization: `Bearer ${accessToken}`,
         },
-      });
+      })
+        .catch((cause: unknown) => {
+          throw controller.signal.aborted
+            ? new Error("canonical_account_timeout")
+            : cause;
+        })
+        .finally(() => clearTimeout(timer));
       if (!response.ok) {
         throw new Error(`canonical_account_failed_${response.status}`);
       }
@@ -248,7 +261,14 @@ export function useCanonicalAccount(
     };
   }
   if (authenticated && !provider) {
-    return { error: null, provider: null, status: "loading", userId: null };
+    // Only claim to be linking when the prerequisites are actually met and the
+    // provider is a render away. Reporting `loading` for every provider-less
+    // authenticated state made this the terminal message for *any* upstream
+    // failure — the custom-auth error, the one the person needs to read, was
+    // painted over with "Linking your Aomi account…" and never came back.
+    return customAuth.readyForExchange
+      ? { error: null, provider: null, status: "loading", userId: null }
+      : { error: null, provider: null, status: "disconnected", userId: null };
   }
   return provider
     ? { ...state, provider }

--- a/apps/telegram/src/hooks/use-telegram-custom-auth.ts
+++ b/apps/telegram/src/hooks/use-telegram-custom-auth.ts
@@ -108,10 +108,14 @@ export function useTelegramCustomAuth(
   // flaps `done` -> `loading` -> `done` and tears down the account session
   // provider built on top of it. A Privy session whose Custom JWT subject is
   // this Telegram user is proof enough, and it survives those re-renders.
+  // `linkState.status === "done"` counts too: Privy has confirmed the link for
+  // the Custom JWT this hook just handed it, and `user.linkedAccounts` can lag
+  // that confirmation by a render or two. Without it the watchdog below can
+  // expire inside that window and fail a link that actually succeeded.
   const sessionMatchesTelegram =
     authenticated &&
     customSubject !== null &&
-    privyCustomSubject === customSubject;
+    (privyCustomSubject === customSubject || linkState.status === "done");
   const sessionRef = useRef<{
     authenticated: boolean;
     privyCustomSubject: string | null;

--- a/apps/telegram/test/integration-contract.test.mjs
+++ b/apps/telegram/test/integration-contract.test.mjs
@@ -170,3 +170,26 @@ test("Privy's own components own login and account management", async () => {
   assert.match(providers, /appearance/);
   assert.match(providers, /colorScheme === "light"/);
 });
+
+test("a failure is never painted over by a progress message", async () => {
+  const [page, canonicalAccount] = await Promise.all([
+    read("src/app/page.tsx"),
+    read("src/hooks/use-canonical-account.ts"),
+  ]);
+
+  // Errors are evaluated before any progress message, so the code the person
+  // needs to read survives to the screen.
+  const errorBranch = page.indexOf('telegramAuth.phase === "error"');
+  const loadingBranch = page.indexOf('account.status === "loading"');
+  assert.ok(errorBranch > 0 && loadingBranch > 0);
+  assert.ok(
+    errorBranch < loadingBranch,
+    "the auth error branch must precede the account loading branch",
+  );
+  // "Authenticated but no provider" is a wait on prerequisites, not a link in
+  // progress; claiming otherwise made this the terminal state for every
+  // upstream failure.
+  assert.match(canonicalAccount, /customAuth\.readyForExchange\s*\?/);
+  // The canonical-account lookup is bounded like the exchange above it.
+  assert.match(canonicalAccount, /canonical_account_timeout/);
+});

--- a/specs/STATE.md
+++ b/specs/STATE.md
@@ -2,6 +2,51 @@
 
 ## Last Updated
 
+2026-09-11 (later) — "LINKING YOUR AOMI ACCOUNT…" WAS THE TERMINAL STATE FOR
+  EVERY UPSTREAM FAILURE (branch `fix/telegram-stuck-linking`, on top of
+  merged #598). Reported again after #598 shipped, and the live bundle on
+  mini-app-staging.aomi.dev was confirmed to carry the new code, so this is a
+  second, independent defect:
+  - `useCanonicalAccount` returned `status: "loading"` for *any*
+    `authenticated && !provider` state. `provider` is null whenever the
+    prerequisites are unmet — including right after the custom-auth flow
+    errors — so the page's message waterfall overwrote the real error with
+    "Linking your Aomi account…" and nothing ever cleared it. Every failure in
+    the link flow looked like the same hang, which is why the underlying cause
+    was never visible. It now reports `loading` only when
+    `customAuth.readyForExchange` is true (provider genuinely a render away)
+    and `disconnected` otherwise, so the auth layer keeps its own message.
+  - `page.tsx` evaluated messages as an override chain where later stages won.
+    Rewritten as explicit precedence: errors first, deepest failing stage wins,
+    then progress messages in stage order. An error can no longer be painted
+    over.
+  - `resolve`'s `GET /v1/account` was unbounded while the exchange around it
+    had a 15s timeout. The backend's DB pool is deliberately 2 connections per
+    host (`infra/database-pool-budgets.json`) and staging logs ~20 saturation
+    events a day, so that call now aborts at 15s as `canonical_account_timeout`.
+  - `sessionMatchesTelegram` also accepts `linkState.status === "done"`:
+    `user.linkedAccounts` lags Privy's own link confirmation by a render or
+    two, and the 15s watchdog could expire inside that window and fail a link
+    that had succeeded.
+  Verified: telegram typecheck, eslint, 11 contract tests (1 new), `build`.
+
+2026-09-11 — `send 1 wei` HAS A NAMED CAUSE, READ OFF STAGING: the app is
+  broken, not the wallet flow. Application 2937805 is `hoodit` from
+  `aomi-labs/community-apps`, release tag
+  `apps-142751037-rbd47b5191b-hoodit-705e3bd9946e`. The tarball downloads
+  fine and then fails manifest validation: built with aomi-sdk 4.0.0 while the
+  backend requires 5.0.0. After 3 consecutive failures the fetcher parks it for
+  a 21600s cooldown, so the source is never installed and `find_app_path`
+  raises "application-scoped app source `application-2937805` is not
+  installed" — the thread has no app, hence no reply. Fix is the one the error
+  states: rebuild hoodit against `aomi-sdk = "=5.0.0"`, redeploy, activate
+  again. `requires_action_approval` is the NEXT wall, not this one: it only
+  applies once an Action exists. Also seen on staging-1: dozens of
+  `aomi-oneshot-staging GitHub App is not installed for
+  aomi-labs/partner-*.finance` reconcile failures, and `DB pool saturated`
+  ~20x/24h with `waiting` 1-5 — the pool size is by design
+  (`backend_max_connections_per_host: 2`), not a misconfiguration.
+
 2026-09-11 — THE MINI APP'S 15s AUTH TIMEOUT WAS DISPOSING LIVE SESSIONS, AND
   PRIVY WAS LOGGING THE USER OUT ON EVERY LAUNCH (branch
   `feat/telegram-permission-provider-stability`, on top of PR #598's


### PR DESCRIPTION
Follow-up to #598. The "stuck at Linking your Aomi account…" report came back *after* #598 shipped, and the live bundle on mini-app-staging.aomi.dev was confirmed to carry the new code — so this is a second, independent defect.

## Every failure looked like the same hang

`useCanonicalAccount` returned `status: "loading"` for *any* `authenticated && !provider` state. `provider` is null whenever the prerequisites are unmet — including immediately after the custom-auth flow errors — and `page.tsx` let a later stage's message override an earlier one. So the real error was overwritten with "Linking your Aomi account…", and nothing ever cleared it.

That is why the cause underneath was never visible: the link flow has several ways to fail and all of them rendered as one indefinite spinner.

- `useCanonicalAccount` now reports `loading` only when `readyForExchange` is true and the provider is genuinely a render away, `disconnected` otherwise, so the auth layer keeps its own message.
- `page.tsx` is rewritten from an override chain into explicit precedence: errors first, deepest failing stage wins, then progress messages in stage order.

## Supporting fixes

- `GET /v1/account` was unbounded while the exchange around it had a 15s timeout. The backend's DB pool is deliberately 2 connections per host (`infra/database-pool-budgets.json`) and staging logs ~20 saturation events per 24h, so that call now aborts as `canonical_account_timeout` rather than spinning forever.
- `sessionMatchesTelegram` accepts `linkState.status === "done"` as proof. `user.linkedAccounts` lags Privy's own link confirmation by a render or two, and the 15s watchdog could expire inside that window and fail a link that had actually succeeded.

## Validation

`pnpm --filter telegram check` — typecheck, eslint, 11 contract tests (1 new), `next build`.

## Unrelated, and already diagnosed

`send 1 wei` not replying is the app, not the wallet flow. Read off staging-1: application 2937805 is `hoodit` from `aomi-labs/community-apps`, tag `apps-142751037-rbd47b5191b-hoodit-705e3bd9946e`. The tarball downloads and then fails manifest validation — built with aomi-sdk 4.0.0, backend requires 5.0.0 — and after 3 failures the fetcher parks it for a 6h cooldown, so the source is never installed. Fix is the one the error states: rebuild hoodit against `aomi-sdk = "=5.0.0"`, redeploy, activate again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791729694&installation_model_id=12362&pr_number=599&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F599&signature=ce6cd6ff0e7a4b9c7610295d7ca713c8d189317d24879ea41e5cf861bc854255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->