### PR TITLE
fix(telegram): stop staging TG mini-app from re-hanging on "Linking your Aomi account…"

### DIFF
--- a/apps/telegram/src/hooks/use-canonical-account.ts
+++ b/apps/telegram/src/hooks/use-canonical-account.ts
@@ -133,6 +133,19 @@ function useEmbeddedWallet(authenticated: boolean) {
     });
   }, [authenticated, createWallet, creating, error, ready, wallet]);
 
+  // `useWallets` normally becomes ready before this hook needs to create a
+  // wallet. If Privy's list never hydrates, however, the create effect above
+  // cannot start. Surface that distinct upstream failure instead of leaving
+  // the account layer to call it an in-progress link forever.
+  useEffect(() => {
+    if (!authenticated || ready || wallet || error) return;
+    const timeout = setTimeout(
+      () => setError("privy_embedded_wallet_list_timeout"),
+      15_000,
+    );
+    return () => clearTimeout(timeout);
+  }, [authenticated, error, ready, wallet]);
+
   return { error: wallet ? null : error, wallet };
 }
 
@@ -261,14 +274,10 @@ export function useCanonicalAccount(
     };
   }
   if (authenticated && !provider) {
-    // Only claim to be linking when the prerequisites are actually met and the
-    // provider is a render away. Reporting `loading` for every provider-less
-    // authenticated state made this the terminal message for *any* upstream
-    // failure — the custom-auth error, the one the person needs to read, was
-    // painted over with "Linking your Aomi account…" and never came back.
-    return customAuth.readyForExchange
-      ? { error: null, provider: null, status: "loading", userId: null }
-      : { error: null, provider: null, status: "disconnected", userId: null };
+    // `useMemo` has already evaluated every provider prerequisite this render.
+    // Without a provider there is no exchange underway, so this must not claim
+    // to be linking. The wallet hook above bounds the only expected wait.
+    return { error: null, provider: null, status: "disconnected", userId: null };
   }
   return provider
     ? { ...state, provider }

--- a/apps/telegram/test/integration-contract.test.mjs
+++ b/apps/telegram/test/integration-contract.test.mjs
@@ -186,10 +186,28 @@ test("a failure is never painted over by a progress message", async () => {
     errorBranch < loadingBranch,
     "the auth error branch must precede the account loading branch",
   );
-  // "Authenticated but no provider" is a wait on prerequisites, not a link in
-  // progress; claiming otherwise made this the terminal state for every
-  // upstream failure.
-  assert.match(canonicalAccount, /customAuth\.readyForExchange\s*\?/);
+  // "Authenticated but no provider" means the exchange has not begun, so it
+  // cannot be presented as linking. A stuck Privy wallet list gets its own
+  // bounded, user-visible failure instead.
+  assert.match(canonicalAccount, /privy_embedded_wallet_list_timeout/);
   // The canonical-account lookup is bounded like the exchange above it.
   assert.match(canonicalAccount, /canonical_account_timeout/);
+});
+
+test("Linking is not shown while the embedded-wallet prerequisite is unresolved", async () => {
+  const canonicalAccount = await read("src/hooks/use-canonical-account.ts");
+
+  // A successful Custom-JWT link can precede Privy's wallet-list hydration.
+  // That is a prerequisite wait, not an account exchange in progress. If this
+  // guard only checks readyForExchange, a stuck SDK list leaves the Mini App on
+  // “Linking your Aomi account…” forever with no timeout or error path.
+  const noProviderFallback = canonicalAccount.slice(
+    canonicalAccount.indexOf("if (authenticated && !provider)"),
+    canonicalAccount.indexOf("return provider", canonicalAccount.indexOf("if (authenticated && !provider)")),
+  );
+  assert.doesNotMatch(
+    noProviderFallback,
+    /status: "loading"/,
+    "only a constructed provider may enter the Linking state",
+  );
 });


### PR DESCRIPTION
## Summary
Codex's fix for the stuck "open wallet" flow on staging re-introduced the stuck "Linking your Aomi account…" screen. Root cause: `useCanonicalAccount` still rendered `loading` for *any* provider-less authenticated state that satisfied `readyForExchange`, so any upstream failure (including a stalled Privy wallet list) got painted over with the same generic linking message forever.

## Fix
- `use-canonical-account.ts`: only report `status: "loading"` once an account exchange has actually started; a provider-less authenticated state now correctly reports `disconnected` instead of masking failures as "linking".
- Added a 15s bound on Privy's embedded wallet list: if `useWallets` never becomes ready, surface a named error (`privy_embedded_wallet_list_timeout`) instead of hanging silently.
- Updated `integration-contract.test.mjs` to cover the new behavior.

## Testing
- `test`, `typecheck`, `lint` all pass
- production build passes
- **Not yet deployed to staging**

## Files
- [use-canonical-account.ts](apps/telegram/src/hooks/use-canonical-account.ts)
- [integration-contract.test.mjs](apps/telegram/test/integration-contract.test.mjs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791731839&installation_model_id=12362&pr_number=600&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F600&signature=d86c80ecd476e805689fa42262c1f6e348236e2754a1f62a500f5a8cec61719a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->