### PR TITLE
fix(telegram): stop gating the account exchange on Privy's connected-wallet list

### DIFF
--- a/apps/telegram/src/hooks/use-canonical-account.ts
+++ b/apps/telegram/src/hooks/use-canonical-account.ts
@@ -1,12 +1,11 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
-  getEmbeddedConnectedWallet,
   getIdentityToken,
   useCreateWallet,
   usePrivy,
-  useWallets,
+  type User,
 } from "@privy-io/react-auth";
 import {
   createAccountSessionProvider,
@@ -100,53 +99,64 @@ function telegramPrivyAdapter(input: {
   };
 }
 
+/** The embedded EVM wallet recorded on the Privy *user*.
+ *
+ *  This is deliberately not `useWallets()`. That hook answers "is a wallet
+ *  connected in this browser", and its `ready` additionally waits on Privy's
+ *  wallet-proxy iframe, on the external connectors, and — once the account
+ *  already owns an embedded wallet — on that wallet being actively connected.
+ *  Inside Telegram's in-app webview, third-party iframe storage is restricted
+ *  and that connection routinely never lands, so `ready` stays false forever
+ *  on an account whose wallet exists and works.
+ *
+ *  The exchange never touches the wallet object: it sends an identity token,
+ *  and the portal attests the hosted wallet through Privy's server API
+ *  (`requireAttestedProviderWallets`). So existence on the user is the real
+ *  prerequisite, and `linkedAccounts` reports it without any of that
+ *  iframe machinery. */
+function linkedEmbeddedWalletAddress(user: User | null): string | null {
+  const account = user?.linkedAccounts.find(
+    (entry) =>
+      entry.type === "wallet" &&
+      entry.chainType === "ethereum" &&
+      (entry.walletClientType === "privy" ||
+        entry.walletClientType === "privy-v2"),
+  );
+  return account && "address" in account ? account.address : null;
+}
+
 /** Ensure the signed-in user has an embedded EVM wallet before the exchange.
  *  `createOnLogin` covers the normal path; this closes the gap for accounts
  *  that predate that config, and answers "wallet exists" as state the exchange
  *  can wait on rather than a race. */
 function useEmbeddedWallet(authenticated: boolean) {
-  const { wallets, ready } = useWallets();
+  const { user } = usePrivy();
   const { createWallet } = useCreateWallet();
   const [error, setError] = useState<string | null>(null);
-  const wallet = useMemo(
-    () => (ready ? getEmbeddedConnectedWallet(wallets) : null),
-    [ready, wallets],
-  );
-  const [creating, setCreating] = useState(false);
+  const address = useMemo(() => linkedEmbeddedWalletAddress(user), [user]);
+  // One attempt per mount. `createWallet` resolving without a linked wallet
+  // appearing must not re-enter, or each pass races Privy's own "already has an
+  // embedded wallet" rejection and the hook spins instead of settling.
+  const attempted = useRef(false);
 
   useEffect(() => {
-    if (!authenticated || !ready || wallet || creating || error) return;
-    queueMicrotask(() => {
-      setCreating(true);
-      void withTimeout(createWallet(), "privy_embedded_wallet_timeout")
-        .catch((cause: unknown) => {
-          // A concurrent create (or one Privy already ran on login) rejects with
-          // "already has an embedded wallet"; `wallets` will carry it shortly, so
-          // only a genuine failure should surface.
-          setError(
-            cause instanceof Error
-              ? cause.message
-              : "privy_embedded_wallet_unavailable",
-          );
-        })
-        .finally(() => setCreating(false));
-    });
-  }, [authenticated, createWallet, creating, error, ready, wallet]);
-
-  // `useWallets` normally becomes ready before this hook needs to create a
-  // wallet. If Privy's list never hydrates, however, the create effect above
-  // cannot start. Surface that distinct upstream failure instead of leaving
-  // the account layer to call it an in-progress link forever.
-  useEffect(() => {
-    if (!authenticated || ready || wallet || error) return;
-    const timeout = setTimeout(
-      () => setError("privy_embedded_wallet_list_timeout"),
-      15_000,
+    if (!authenticated || address || attempted.current) return;
+    attempted.current = true;
+    void withTimeout(createWallet(), "privy_embedded_wallet_timeout").catch(
+      (cause: unknown) => {
+        // A concurrent create (or one Privy already ran on login) rejects with
+        // "already has an embedded wallet"; `user` will carry it shortly, so
+        // only a genuine failure should survive — see the return below.
+        setError(
+          cause instanceof Error
+            ? cause.message
+            : "privy_embedded_wallet_unavailable",
+        );
+      },
     );
-    return () => clearTimeout(timeout);
-  }, [authenticated, error, ready, wallet]);
+  }, [address, authenticated, createWallet]);
 
-  return { error: wallet ? null : error, wallet };
+  return { address, error: address ? null : error };
 }
 
 export function useCanonicalAccount(
@@ -155,13 +165,10 @@ export function useCanonicalAccount(
 ): CanonicalAccountState {
   const { authenticated, ready: privyReady, user } = usePrivy();
   const privySubject = user?.id ?? null;
-  const { error: walletError, wallet } = useEmbeddedWallet(
-    authenticated && customAuth.readyForExchange,
-  );
-  // Privy can return a fresh wallet object when local SDK state changes. The
-  // session provider only needs a wallet to exist; key it by the stable address
-  // so a harmless object refresh cannot dispose an in-flight request.
-  const embeddedWalletAddress = wallet?.address ?? null;
+  // Already a stable address rather than an SDK object, so a harmless refresh
+  // of Privy's local state cannot dispose an in-flight request.
+  const { address: embeddedWalletAddress, error: walletError } =
+    useEmbeddedWallet(authenticated && customAuth.readyForExchange);
   const [state, setState] = useState<Omit<CanonicalAccountState, "provider">>({
     error: null,
     status: "disconnected",
@@ -276,7 +283,8 @@ export function useCanonicalAccount(
   if (authenticated && !provider) {
     // `useMemo` has already evaluated every provider prerequisite this render.
     // Without a provider there is no exchange underway, so this must not claim
-    // to be linking. The wallet hook above bounds the only expected wait.
+    // to be linking. The only prerequisite that can still be pending here is
+    // wallet creation, which is bounded and reports its own error above.
     return { error: null, provider: null, status: "disconnected", userId: null };
   }
   return provider

--- a/apps/telegram/test/integration-contract.test.mjs
+++ b/apps/telegram/test/integration-contract.test.mjs
@@ -26,7 +26,7 @@ test("Custom Telegram auth resolves the canonical Aomi account", async () => {
   assert.match(canonicalAccount, /getIdentityToken/);
   assert.match(canonicalAccount, /custom_user_id/);
   assert.match(canonicalAccount, /provider: "privy"/);
-  assert.match(canonicalAccount, /getEmbeddedConnectedWallet/);
+  assert.match(canonicalAccount, /linkedEmbeddedWalletAddress/);
   assert.match(canonicalAccount, /privy_embedded_wallet_timeout/);
   assert.match(canonicalAccount, /telegram_privy_exchange_timeout/);
   assert.match(canonicalAccount, /createAccountSessionProvider/);
@@ -186,21 +186,47 @@ test("a failure is never painted over by a progress message", async () => {
     errorBranch < loadingBranch,
     "the auth error branch must precede the account loading branch",
   );
-  // "Authenticated but no provider" means the exchange has not begun, so it
-  // cannot be presented as linking. A stuck Privy wallet list gets its own
-  // bounded, user-visible failure instead.
-  assert.match(canonicalAccount, /privy_embedded_wallet_list_timeout/);
   // The canonical-account lookup is bounded like the exchange above it.
   assert.match(canonicalAccount, /canonical_account_timeout/);
+});
+
+test("the account exchange does not wait on Privy's connected-wallet list", async () => {
+  const canonicalAccount = await read("src/hooks/use-canonical-account.ts");
+
+  // `useWallets().ready` waits on the wallet-proxy iframe, the external
+  // connectors, and — once the account owns an embedded wallet — on that wallet
+  // being actively connected. Telegram's webview restricts third-party iframe
+  // storage, so that connection routinely never lands and `ready` stays false
+  // forever on an account whose wallet exists and works. The exchange only ever
+  // needs the wallet to EXIST: it sends an identity token, and the portal
+  // attests the hosted wallet through Privy's server API. Reading
+  // `linkedAccounts` answers existence with none of that machinery.
+  // Asserted against the import list rather than the file, so the explanation
+  // above may keep naming the hook it is warning about.
+  const privyImport = canonicalAccount.slice(
+    canonicalAccount.indexOf("import {"),
+    canonicalAccount.indexOf('} from "@privy-io/react-auth"'),
+  );
+  assert.doesNotMatch(
+    privyImport,
+    /useWallets/,
+    "the account exchange must not gate on Privy's connected-wallet list",
+  );
+  assert.match(canonicalAccount, /linkedAccounts/);
+  // Signing a permit is the one flow that genuinely needs a *connected* wallet,
+  // so that hook keeps using useWallets.
+  const permission = await read("src/hooks/use-permission-control.ts");
+  assert.match(permission, /useWallets/);
 });
 
 test("Linking is not shown while the embedded-wallet prerequisite is unresolved", async () => {
   const canonicalAccount = await read("src/hooks/use-canonical-account.ts");
 
-  // A successful Custom-JWT link can precede Privy's wallet-list hydration.
-  // That is a prerequisite wait, not an account exchange in progress. If this
-  // guard only checks readyForExchange, a stuck SDK list leaves the Mini App on
-  // “Linking your Aomi account…” forever with no timeout or error path.
+  // A successful Custom-JWT link can precede the embedded wallet appearing on
+  // the Privy user. That is a prerequisite wait, not an account exchange in
+  // progress. If this guard only checks readyForExchange, an unresolved
+  // prerequisite leaves the Mini App on “Linking your Aomi account…” forever
+  // with no timeout or error path.
   const noProviderFallback = canonicalAccount.slice(
     canonicalAccount.indexOf("if (authenticated && !provider)"),
     canonicalAccount.indexOf("return provider", canonicalAccount.indexOf("if (authenticated && !provider)")),


### PR DESCRIPTION
Follow-up to #600. That PR made the stall *visible* (`privy_embedded_wallet_list_timeout` instead of an eternal "Linking your Aomi account…"). Staging then reported that named error — which showed the gate it guarded was the wrong one all along.

## Diagnosis

First, an elimination: the timer only arms when `authenticated && customAuth.readyForExchange` are both true, and `readyForExchange` requires Privy authenticated **and** the Custom-JWT subject matching this Telegram user. **So Privy login fully succeeded.** The stall is entirely downstream of auth — switching to email login would stall identically.

Decoding Privy v3.27.1's actual `ready` computation out of the bundle:

```js
ready = areExternalConnectorsReady && hasResolvedInitialUser
        && walletProxy && (!hasLinkedEmbeddedWallet || embeddedWalletConnected)
```

`useWallets().ready` is **not** "the user has a wallet". It additionally waits on Privy's wallet-proxy **iframe**, on the external connectors, and — once the account already owns an embedded wallet — on that wallet being actively **connected**.

Telegram's in-app webview restricts third-party iframe storage, so for an account that already has a wallet `hasLinkedEmbeddedWallet` is true while `embeddedWalletConnected` never becomes true → `ready` stays false **forever**, on an account whose wallet exists and works fine.

The exchange never needed any of it. `telegramPrivyAdapter.exchange` posts only an identity token and never touches the wallet object; the portal attests the hosted wallet **server-side** through Privy's API (`requireAttestedProviderWallets`, which 422s `provider_hosted_wallet_missing` when there is none). Existence on the Privy user is the real prerequisite, and `user.linkedAccounts` reports it with none of that iframe machinery.

## Changes

- Read the address from `user.linkedAccounts` (matching Privy's own internal filter) instead of `useWallets()`.
- Drop the list timeout along with the gate that needed it.
- `createWallet` stays as the fallback for accounts predating `createOnLogin`, now guarded by a ref — the previous code could re-enter and spin against Privy's own "already has an embedded wallet" rejection.
- `usePermissionControl` deliberately keeps `useWallets`: signing a permit calls `wallet.getEthereumProvider()`, so it genuinely needs a *connected* wallet.

## Testing

`test`, `typecheck`, `lint` and the production build all pass. Not yet deployed to staging.

## Follow-up to watch

This unblocks **linking**. If the iframe really is blocked in Telegram's webview, **permit signing** may still not arm — it needs a live connected wallet, which no server-side attestation can substitute for. That would surface as the permission button staying idle rather than a hang. Worth checking on staging once this is out; if it reproduces, that flow needs its own bounded error and possibly Privy's delegated/headless signing instead of the in-browser provider.

## Files

- [use-canonical-account.ts](apps/telegram/src/hooks/use-canonical-account.ts)
- [integration-contract.test.mjs](apps/telegram/test/integration-contract.test.mjs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791733095&installation_model_id=12362&pr_number=601&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F601&signature=a85d2d33c52b4adead3d64ceb7c3aaff296d2416a7f958e002218ab14cb3948c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->