### PR TITLE
fix(telegram): preserve Privy identity tokens in webviews

### DIFF
--- a/apps/telegram/src/hooks/use-canonical-account.ts
+++ b/apps/telegram/src/hooks/use-canonical-account.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   getIdentityToken,
   useCreateWallet,
+  useIdentityToken,
   usePrivy,
   type User,
 } from "@privy-io/react-auth";
@@ -40,6 +41,23 @@ function withTimeout<T>(operation: Promise<T>, errorCode: string): Promise<T> {
   });
 }
 
+/** Privy keeps the identity token in memory *and* in `localStorage`, but only
+ *  exposes the in-memory copy through a hook — while `getIdentityToken()`, the
+ *  callable one, reads `localStorage`. Mirroring the hook's value here lets the
+ *  exchange reach the in-memory copy at call time without the session provider
+ *  having to list the token as a dependency: the token rotates, and rebuilding
+ *  the provider on each rotation disposes an exchange that is already in
+ *  flight. Module scope is safe because Privy permits exactly one provider per
+ *  app — it throws on a second one. */
+let inMemoryIdentityToken: string | null = null;
+
+function useMirroredIdentityToken(): void {
+  const { identityToken } = useIdentityToken();
+  useEffect(() => {
+    inMemoryIdentityToken = identityToken;
+  }, [identityToken]);
+}
+
 function telegramPrivyAdapter(input: {
   launch: LaunchContext;
   privySubject: string;
@@ -49,11 +67,42 @@ function telegramPrivyAdapter(input: {
     getFingerprint: () =>
       `telegram:${input.launch.proof?.telegramUserId}:privy:${input.privySubject}:session:${input.launch.sessionId}`,
     exchange: async ({ baseUrl, fetch: fetchImpl }) => {
-      // Fetched per exchange rather than captured: identity tokens are short
-      // lived, and a session provider can outlive the render that built it.
-      const identityToken = (await getIdentityToken())?.trim();
-      if (!identityToken || !input.launch.proof || !input.launch.sessionId) {
-        throw new Error("telegram_privy_credential_unavailable");
+      // Both sources are read per exchange rather than captured: identity
+      // tokens are short lived, and a session provider can outlive the render
+      // that built it.
+      //
+      // Two sources, because neither alone survives a Telegram webview.
+      // `getIdentityToken()` refreshes the token against Privy's API, but then
+      // reads it back out of `localStorage`, which Telegram's in-app webview
+      // can partition or drop — and on Telegram Web the Mini App is an iframe,
+      // so that storage is third-party. `useIdentityToken()` reads the
+      // in-memory store Privy writes on every `storeIdentityToken`, with no
+      // storage involved. Refresh first, so the in-memory value is the fresh
+      // one by the time it is read.
+      const refreshed = await getIdentityToken().then(
+        (token) => ({ failure: null, token }),
+        (cause: unknown) => ({
+          failure: cause instanceof Error ? cause.message : "unknown",
+          token: null,
+        }),
+      );
+      const identityToken = (refreshed.token ?? inMemoryIdentityToken)?.trim();
+      if (!input.launch.proof) {
+        throw new Error("telegram_privy_launch_proof_unavailable");
+      }
+      if (!input.launch.sessionId) {
+        throw new Error("telegram_privy_session_unavailable");
+      }
+      if (!identityToken) {
+        // Split from the launch-context failures above so staging says which
+        // one it hit. Both sources empty after a *successful* refresh means
+        // Privy's API returned no `identity_token` at all — it clears the token
+        // in that case — which is an app-level setting, not a webview problem.
+        throw new Error(
+          refreshed.failure
+            ? `telegram_privy_identity_token_refresh_failed_${refreshed.failure}`
+            : "telegram_privy_identity_token_unavailable",
+        );
       }
       const response = await fetchImpl(
         new URL("/api/auth/widget/telegram/exchange", baseUrl),
@@ -169,6 +218,10 @@ export function useCanonicalAccount(
   // of Privy's local state cannot dispose an in-flight request.
   const { address: embeddedWalletAddress, error: walletError } =
     useEmbeddedWallet(authenticated && customAuth.readyForExchange);
+  // Held in a ref, not a dependency: the token rotates, and rebuilding the
+  // provider on each rotation would dispose an exchange that is already in
+  // flight. The adapter reads the current value when it actually runs.
+  useMirroredIdentityToken();
   const [state, setState] = useState<Omit<CanonicalAccountState, "provider">>({
     error: null,
     status: "disconnected",

--- a/apps/telegram/test/integration-contract.test.mjs
+++ b/apps/telegram/test/integration-contract.test.mjs
@@ -219,6 +219,33 @@ test("the account exchange does not wait on Privy's connected-wallet list", asyn
   assert.match(permission, /useWallets/);
 });
 
+test("the identity token is read from memory as well as storage", async () => {
+  const canonicalAccount = await read("src/hooks/use-canonical-account.ts");
+
+  // `getIdentityToken()` refreshes against Privy's API but reads the result
+  // back out of localStorage, which a Telegram webview can partition or drop —
+  // on Telegram Web the Mini App is an iframe, so that storage is third-party.
+  // Privy also keeps the token in memory, reachable only through the hook, so
+  // both sources are consulted before the exchange is declared impossible.
+  assert.match(canonicalAccount, /useIdentityToken/);
+  assert.match(canonicalAccount, /refreshed\.token \?\? inMemoryIdentityToken/);
+
+  // The three causes that once shared `telegram_privy_credential_unavailable`
+  // must stay distinguishable, or staging cannot say which one it hit.
+  assert.match(canonicalAccount, /telegram_privy_launch_proof_unavailable/);
+  assert.match(canonicalAccount, /telegram_privy_session_unavailable/);
+  assert.match(canonicalAccount, /telegram_privy_identity_token_unavailable/);
+  assert.match(
+    canonicalAccount,
+    /telegram_privy_identity_token_refresh_failed_/,
+  );
+  assert.doesNotMatch(
+    canonicalAccount,
+    /telegram_privy_credential_unavailable/,
+    "the single collapsed credential error must not come back",
+  );
+});
+
 test("Linking is not shown while the embedded-wallet prerequisite is unresolved", async () => {
   const canonicalAccount = await read("src/hooks/use-canonical-account.ts");
 


### PR DESCRIPTION
## Summary
- preserve Privy identity tokens from the in-memory SDK store when Telegram WebView storage is unavailable
- split credential, launch, session, and identity-token failures into actionable diagnostics
- keep the canonical account exchange independent from Privy connected-wallet iframe readiness

## Validation
- pnpm --filter telegram test
- pnpm --filter telegram typecheck
- pnpm --filter telegram build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791733968&installation_model_id=12362&pr_number=602&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F602&signature=cd41a87f2141db45b3ac2f90ccc8461e7cde992409215190a5270e873b04cced"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->