### PR TITLE
fix(account): let the Privy widget exchange see the wallets its token attests

### DIFF
--- a/apps/portal/src/server/widget-auth/exchange.ts
+++ b/apps/portal/src/server/widget-auth/exchange.ts
@@ -81,6 +81,17 @@ export async function requireAttestedProviderWallets(
     identity.walletAttestations,
   );
   if (!wallets.length) {
+    // Three different failures used to arrive as one 422, which is exactly the
+    // distinction `resolveAttestedProviderWallets` exists to preserve: a
+    // provider whose REST credentials are missing, a provider API that failed,
+    // and a provider that genuinely attests no wallet are not the same
+    // incident. Only the last is the user's problem.
+    if (resolution.status === "unconfigured") {
+      throw new WidgetAuthError("provider_wallet_api_unconfigured", 500);
+    }
+    if (resolution.status === "unavailable") {
+      throw new WidgetAuthError("provider_wallet_api_unavailable", 503);
+    }
     throw new WidgetAuthError("provider_hosted_wallet_missing", 422);
   }
   return wallets;

--- a/packages/account/src/providers/account-credentials.ts
+++ b/packages/account/src/providers/account-credentials.ts
@@ -6,6 +6,7 @@ import type {
 import { paraIssuerEnvironmentForJwksUrl, verifyParaJwt } from "./para";
 import { verifyPrivyToken } from "./privy";
 import {
+  privyTokenWalletAttestations,
   validWalletAddress,
   type AttestedWallet,
   type AttestedWalletProvider,
@@ -226,36 +227,6 @@ export function paraTokenWalletAttestations(
   return wallets;
 }
 
-export function privyTokenWalletAttestations(
-  rows: readonly unknown[] | undefined,
-): AttestedWallet[] {
-  const wallets: AttestedWallet[] = [];
-  const seen = new Set<string>();
-  for (const row of rows ?? []) {
-    if (!row || typeof row !== "object") continue;
-    const record = row as Record<string, unknown>;
-    if (record.type !== "wallet" || !isPrivyEmbeddedWallet(record)) continue;
-    const family = privyTokenWalletFamily(
-      record.chain_type ?? record.chainType,
-    );
-    const address = stringValue(record.address);
-    if (!family || !address || !validWalletAddress(family, address)) continue;
-    const providerWalletId =
-      stringValue(record.id) ?? stringValue(record.wallet_id) ?? address;
-    const key = `${family}:${family === "evm" ? address.toLowerCase() : address}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    wallets.push({
-      provider: "privy",
-      providerWalletId,
-      family,
-      address,
-      chainScope: null,
-    });
-  }
-  return wallets;
-}
-
 function paraTokenWalletFamily(
   value: unknown,
 ): AttestedWallet["family"] | null {
@@ -271,34 +242,7 @@ function paraTokenWalletFamily(
   }
 }
 
-function privyTokenWalletFamily(
-  value: unknown,
-): AttestedWallet["family"] | null {
-  const normalized = String(value ?? "").toLowerCase();
-  if (normalized === "ethereum" || normalized === "evm") return "evm";
-  if (normalized === "solana" || normalized === "svm") return "svm";
-  return null;
-}
 
-function isPrivyEmbeddedWallet(row: Record<string, unknown>): boolean {
-  const markers = [
-    row.wallet_client_type,
-    row.walletClientType,
-    row.wallet_client,
-    row.walletClient,
-    row.connector_type,
-    row.connectorType,
-  ]
-    .map((value) => String(value ?? "").toLowerCase())
-    .filter(Boolean);
-  return markers.some(
-    (marker) =>
-      marker === "privy" ||
-      marker === "embedded" ||
-      marker === "smart_wallet" ||
-      marker === "smart-wallet",
-  );
-}
 
 function stringValue(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0

--- a/packages/account/src/providers/privy.ts
+++ b/packages/account/src/providers/privy.ts
@@ -2,7 +2,11 @@ import { importSPKI, jwtVerify } from "jose";
 import { z } from "zod";
 import type { VerifiedPrivyToken, WalletFamily } from "../types";
 import type { WidgetProviderDescriptor } from "./descriptor";
-import { validWalletAddress, type AttestedWallet } from "./wallet-attestation";
+import {
+  privyTokenWalletAttestations,
+  validWalletAddress,
+  type AttestedWallet,
+} from "./wallet-attestation";
 import { readAccountAuthEnv } from "../better-auth/env";
 
 type PrivyClaims = {
@@ -60,9 +64,20 @@ export const privyWidgetDescriptor: WidgetProviderDescriptor = {
       email: token.email
         ? { value: token.email, verified: Boolean(token.emailVerified) }
         : undefined,
-      // Provider login authenticates the human only. The common EIP-712
-      // binding flow is the sole ownership proof for browser/Para/Privy.
-      walletAttestations: [],
+      // Privy's `GET /v1/wallets` is authoritative where it has the data, but
+      // it does not return every wallet created through the client SDK — which
+      // is every Telegram Mini App user. Discarding the token's own attestation
+      // therefore left the widget exchange with a single source that can answer
+      // "no wallets" for a user who plainly has one, and a
+      // `provider_hosted_wallet_missing` 422 was the only thing anyone saw.
+      //
+      // These rows are not a client claim: they come from a JWT signed by
+      // Privy, under the same audience as the `sub` bound here, and only
+      // Privy-custodied embedded wallets survive the filter — a merely
+      // connected external wallet cannot back hosted signing and is dropped.
+      // This is what the native credential path has always done, and what
+      // Para's widget descriptor already contributes.
+      walletAttestations: privyTokenWalletAttestations(token.linkedAccounts),
       metadata: {
         sessionId: token.sessionId,
         displayLabel: token.displayLabel,

--- a/packages/account/src/providers/wallet-attestation.ts
+++ b/packages/account/src/providers/wallet-attestation.ts
@@ -53,3 +53,87 @@ export function validWalletAddress(
       : SVM_ADDRESS_RE.test(address))
   );
 }
+
+/**
+ * Embedded wallets a *verified* Privy token attests, read from its
+ * `linked_accounts` claim.
+ *
+ * Privy's `GET /v1/wallets` is the authoritative source where it has the data,
+ * but it does not return every wallet a user created through the client SDK —
+ * which is every Telegram Mini App user. So this is the same supplementary
+ * source Para's descriptor already contributes, and the reason
+ * `requireAttestedProviderWallets` merges two sources rather than trusting one.
+ *
+ * It is not a client claim: the rows come out of a JWT signed by Privy, under
+ * the same audience as the `sub` the canonical account is bound to. The
+ * boundary that matters is {@link isPrivyEmbeddedWallet} — only Privy-custodied
+ * embedded wallets pass. An external wallet merely connected to the session is
+ * not Privy-custodied and can never back hosted signing, so it is dropped.
+ *
+ * Lives here rather than beside its callers because both `privy.ts` (widget
+ * exchange) and `account-credentials.ts` (native credential) need it, and
+ * `account-credentials.ts` already imports from `privy.ts`.
+ */
+export function privyTokenWalletAttestations(
+  rows: readonly unknown[] | undefined,
+): AttestedWallet[] {
+  const wallets: AttestedWallet[] = [];
+  const seen = new Set<string>();
+  for (const row of rows ?? []) {
+    if (!row || typeof row !== "object") continue;
+    const record = row as Record<string, unknown>;
+    if (record.type !== "wallet" || !isPrivyEmbeddedWallet(record)) continue;
+    const family = privyTokenWalletFamily(
+      record.chain_type ?? record.chainType,
+    );
+    const address = stringValue(record.address);
+    if (!family || !address || !validWalletAddress(family, address)) continue;
+    const providerWalletId =
+      stringValue(record.id) ?? stringValue(record.wallet_id) ?? address;
+    const key = `${family}:${family === "evm" ? address.toLowerCase() : address}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    wallets.push({
+      provider: "privy",
+      providerWalletId,
+      family,
+      address,
+      chainScope: null,
+    });
+  }
+  return wallets;
+}
+
+function privyTokenWalletFamily(value: unknown): WalletFamily | null {
+  const normalized = String(value ?? "").toLowerCase();
+  if (normalized === "ethereum" || normalized === "evm") return "evm";
+  if (normalized === "solana" || normalized === "svm") return "svm";
+  return null;
+}
+
+function isPrivyEmbeddedWallet(row: Record<string, unknown>): boolean {
+  const markers = [
+    row.wallet_client_type,
+    row.walletClientType,
+    row.wallet_client,
+    row.walletClient,
+    row.connector_type,
+    row.connectorType,
+  ]
+    .map((value) => String(value ?? "").toLowerCase())
+    .filter(Boolean);
+  return markers.some(
+    (marker) =>
+      marker === "privy" ||
+      marker === "privy-v2" ||
+      marker === "embedded" ||
+      marker === "smart_wallet" ||
+      marker === "smart-wallet",
+  );
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}

--- a/packages/account/test/account-credentials.test.ts
+++ b/packages/account/test/account-credentials.test.ts
@@ -5,9 +5,9 @@ import {
   createDefaultProviderCredentialVerifiers,
   paraTokenWalletAttestations,
   providerSessionUserSeed,
-  privyTokenWalletAttestations,
   verifyProviderCredential,
 } from "../src/providers/account-credentials";
+import { privyTokenWalletAttestations } from "../src/providers/wallet-attestation";
 import { readAccountAuthEnv } from "../src/better-auth/env";
 import type { AccountAuthEnv } from "../src/better-auth/env";
 

--- a/packages/account/test/privy-widget-wallets.test.ts
+++ b/packages/account/test/privy-widget-wallets.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from "vitest";
+import { exportSPKI, generateKeyPair, SignJWT } from "jose";
+import { privyWidgetDescriptor } from "../src/providers/privy";
+
+/**
+ * The Telegram Mini App exchange reached `provider_hosted_wallet_missing` for
+ * users who plainly had an embedded wallet. Privy's `GET /v1/wallets` does not
+ * return every wallet created through the client SDK — which is every Mini App
+ * user — and the widget descriptor was discarding the second source: the
+ * wallets the identity token itself attests.
+ */
+describe("privy widget descriptor wallet attestations", () => {
+  async function verify(linkedAccounts: unknown[]) {
+    const { privateKey, publicKey } = await generateKeyPair("ES256");
+    const spki = await exportSPKI(publicKey);
+    vi.stubEnv("PRIVY_APP_ID", "app-under-test");
+    vi.stubEnv("PRIVY_IDENTITY_JWT_VERIFICATION_KEY", spki);
+    const now = Math.floor(Date.now() / 1000);
+    const token = await new SignJWT({
+      sub: "did:privy:abc",
+      linked_accounts: linkedAccounts,
+    })
+      .setProtectedHeader({ alg: "ES256" })
+      .setIssuer("privy.io")
+      .setAudience("app-under-test")
+      .setIssuedAt(now)
+      .setExpirationTime(now + 300)
+      .sign(privateKey);
+    return privyWidgetDescriptor.verifyWidgetCredential({
+      environment: "PROD",
+      providerToken: token,
+    });
+  }
+
+  it("surfaces the embedded wallet the identity token attests", async () => {
+    const identity = await verify([
+      {
+        type: "wallet",
+        chain_type: "ethereum",
+        wallet_client_type: "privy",
+        address: "0x1111111111111111111111111111111111111111",
+        id: "wallet-1",
+      },
+    ]);
+    expect(identity.walletAttestations).toEqual([
+      {
+        provider: "privy",
+        providerWalletId: "wallet-1",
+        family: "evm",
+        address: "0x1111111111111111111111111111111111111111",
+        chainScope: null,
+      },
+    ]);
+  });
+
+  it("drops a merely connected external wallet", async () => {
+    // Not Privy-custodied, so it can never back hosted signing. This is the
+    // boundary that keeps the token attestation from becoming a client claim.
+    const identity = await verify([
+      {
+        type: "wallet",
+        chain_type: "ethereum",
+        wallet_client_type: "metamask",
+        connector_type: "injected",
+        address: "0x2222222222222222222222222222222222222222",
+      },
+    ]);
+    expect(identity.walletAttestations).toEqual([]);
+  });
+});


### PR DESCRIPTION
Next link in the Telegram Mini App chain (after #600, #601). With identity tokens now enabled on the Privy app, the exchange gets further and fails at `telegram_privy_exchange_failed_422_provider_hosted_wallet_missing`.

Worth noting what that error already proves: the identity token **was** issued and the portal **verified its signature**. The verification-key concern from the last round was a false alarm — those two JWKS keys are rotation, not access-vs-identity.

## The bug

The client had already found an embedded wallet on `user.linkedAccounts` — it won't even build the session provider otherwise. So the server disagreeing meant the server was asking the wrong question.

`requireAttestedProviderWallets` merges two sources, and its own docstring says a provider list endpoint "does not return wallets a user created through the client SDK, which is every Telegram Mini App user", so an empty answer there proves nothing:

| path | contributes token attestation? |
|---|---|
| Para widget descriptor | ✅ |
| Privy native credential | ✅ |
| **Privy widget descriptor** | ❌ `walletAttestations: []` |

That left Privy's `GET /v1/wallets` as the only source — an endpoint that does not enumerate client-SDK embedded wallets. Hence a 422 for a user who has one.

## Changes

- Privy widget descriptor now contributes `privyTokenWalletAttestations(token.linkedAccounts)`, matching Para's descriptor and the native path.
- `privyTokenWalletAttestations` moves to `wallet-attestation.ts` — `account-credentials.ts` already imports from `privy.ts`, so importing back would have been circular.
- Split the collapsed 422: `unconfigured` → 500 `provider_wallet_api_unconfigured`, `unavailable` → 503 `provider_wallet_api_unavailable`, genuine empty stays 422. That is exactly the distinction `resolveAttestedProviderWallets` exists to preserve, and it was being thrown away at the last step.

## Security

These rows are not a client claim — they come from a JWT signed by Privy under the same audience as the `sub` the account binds to, and only Privy-custodied embedded wallets pass `isPrivyEmbeddedWallet`. A merely connected external wallet cannot back hosted signing and is dropped; there is a test pinning that boundary.

## Testing

117 account tests + 19 portal widget-auth tests pass; type-check and lint clean. The new regression test was verified to **fail** against the old `walletAttestations: []` before being kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/aomi-labs/codesmith/aomi/pr/603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791735240&installation_model_id=12362&pr_number=603&repository=aomi-labs%2Faomi&return_to=https%3A%2F%2Fgithub.com%2Faomi-labs%2Faomi%2Fpull%2F603&signature=1c577bb86883bbebbbc2fa875d21ed57266bcd755790aca3d6c347cb9f8bcf1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->